### PR TITLE
Fixed Quickstart link in README to point to Postiz documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@
 - Resend (email notifications)
 
 ## Quick Start
-To have the project up and running, please follow the [Quick Start Guide](https://docs.gitroom.com/quickstart)
+To have the project up and running, please follow the [Quick Start Guide](https://docs.postiz.com/quickstart)
 
 # License
 


### PR DESCRIPTION
Update documentation: replaced non-working Gitroom link with Postiz link in README to point to valid Quickstart documentation

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update
- **Why was this change needed?** (You can also link to an open issue here)
The original Gitroom link was non-functional and has been replaced with a Postiz link to ensure access to up-to-date and accurate documentation. 
- **Other information**: