### PR TITLE
doc: Simplify quickstart instructions for end users

### DIFF
--- a/apps/docs/emails.mdx
+++ b/apps/docs/emails.mdx
@@ -3,14 +3,16 @@ title: Email Notifications
 description: How to send notifications to users
 ---
 
-At the moment we are using Resend to send email notifications to users, and might be changed the Novu later.
+Postiz uses Resend to send email notifications to users. Emails are currently 
+required as part of the new-user creation process, which sends an activation 
+email.
 
-Register to [Resend](https://resend.com) connect your domain.
-Copy your API Key.
-Head over to .env file and add the following line.
+* Register to [Resend](https://resend.com), and connect your domain.
+* Copy your API Key from the Resend control panel.
+* Open the .env file and edit the following line.
 
 ```env
-RESEND_API_KEY=""
+RESEND_API_KEY="<your-api-key-here>"
 ```
 
 Feel free to contribute other providers to send email notifications.

--- a/apps/docs/howitworks.mdx
+++ b/apps/docs/howitworks.mdx
@@ -8,13 +8,13 @@ Unlike other NX project, this project has one `.env` file that is shared between
 It makes it easier to develop and deploy the project.<br /><br />
 When deploying to websites like [Railway](https://railway.app) or [Heroku](https://heroku.com), you can use a shared environment variables for all the apps.<br /><br />
 
-**At the moment it has 6 project:**
+**At the moment it has 6 projects:**
 
-- **Backend** - NestJS based system
-- **Workers** - NestJS based workers connected to a Redis Queue.
-- **Cron**    - NestJS scheduler to run cron jobs.
-- **Frontend** - NextJS based control panel.
-- **Docs** - Mintlify based documentation website.
+- [Frontend](#frontend) - Provides the Web user interface, talks to the Backend.
+- [Backend](#backend) - Does all the real work, provides an API for the frontend, and posts work to the redis queue.
+- [Workers](#worker) - Consumes work from the Redis Queue.
+- [Cron](#cron) - Run jobs at scheduled times.
+- [Docs](#docs) - This documentation site!
 
 <img
   src="/images/arch.png"

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -2,6 +2,10 @@
 title: 'Quickstart'
 ---
 
+At the moment it is necessary to build the project locally - some dependencies 
+like redis and postgres can run as docker containers, but there is no docker 
+container for Postiz just yet.
+
 ## Prerequisites
 
 To run the project you need to have multiple things:
@@ -17,25 +21,29 @@ To run the project you need to have multiple things:
 
 A complete guide of how to install NodeJS can be found [here](https://nodejs.org/en/download/).
 
-### PostgreSQL (or any other SQL database)
+### PostgreSQL (or any other SQL database) & Redis
 
-Make sure you have PostgreSQL installed on your machine.<br />
-If you don't, you can install [Docker](https://www.docker.com/products/docker-desktop) and run:
+Make sure you have PostgreSQL installed on your machine.
 
-```bash
+#### Option A) Postgres and Redis as Single containers
+
+You can install [Docker](https://www.docker.com/products/docker-desktop) and run:
+
+```bash Terminal
 docker run -e POSTGRES_USER=root -e POSTGRES_PASSWORD=your_password --name postgres -p 5432:5432 -d postgres
-```
-
-### Redis
-
-Make sure you have Redis installed on your machine.<br />
-If you don't, you can install [Docker](https://www.docker.com/products/docker-desktop) and run:
-
-```bash
 docker run --name redis -p 6379:6379 -d redis
 ```
 
-## Installation
+#### Option B) Postgres and Redis as docker-compose
+
+Download the [docker-compose.yaml file here](https://raw.githubusercontent.com/gitroomhq/postiz-app/main/docker-compose.dev.yaml), 
+or grab it from the repository in the next step.
+
+```bash Terminal
+docker compose -f "docker-compose.dev.yaml" up
+```
+
+## Build Postiz
 
 <Steps>
   <Step title="Clone the repository">
@@ -44,7 +52,7 @@ git clone https://github.com/gitroomhq/gitroom
 ```
   </Step>
 
-  <Step title="Copy environment variables">
+  <Step title="Set environment variables">
 Copy the `.env.example` file to `.env` and fill in the values
 
 ```bash .env
@@ -79,12 +87,6 @@ IS_GENERAL="true" # required for now
 
 ```bash Terminal
 npm install
-```
-  </Step>
-
-  <Step title="Setup postgres & redis via docker compose">
-```bash Terminal
-docker compose -f "docker-compose.dev.yaml" up
 ```
   </Step>
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

This just simplifies some of the quickstart instructions for end users (most people don't care that it's a nextjs app, etc), and need to have it explained that there isn't a docker image (yet). I also pulled the postgres/redis instructions up, as it makes sense to do those either as standalone containers, or, using docker-compose, etc. 

Also cleaned up the email page a bit. 

# Why was this change needed? (You can also link to an open issue here)

Make it easier for end users!