### PR TITLE
ci: Add cache key to build job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,5 +20,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: |
+            **/package-lock.json
+
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

@jonathan-irvin Current builds on this job are not actually using the cache, I think this may be due to having a cache key not set (like I did with the eslint job), so it makes sense to add it here to at least be the same as the other job. 