### PR TITLE
ci: Allow building containers as a manually started job

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -2,6 +2,7 @@
 name: "Build Tag"
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'


### PR DESCRIPTION
This just allows the containers job to be started manually. 