### PR TITLE
ci: only run actions when certain paths change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,18 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - apps/*
+      - libraries/*
+
   pull_request:
+    paths:
+      - package.json
+      - apps/*
+      - libraries/*
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,14 +7,14 @@ on:
       - main
     paths:
       - package.json
-      - apps/*
-      - libraries/*
+      - apps/**
+      - libraries/**
 
   pull_request:
     paths:
       - package.json
-      - apps/*
-      - libraries/*
+      - apps/**
+      - libraries/**
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,16 @@ name: "Code Quality  Analysis"
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - apps/*
+      - libraries/*
+
   pull_request:
+    paths:
+      - apps/*
+      - libraries/*
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,13 +6,13 @@ on:
     branches:
       - main
     paths:
-      - apps/*
-      - libraries/*
+      - apps/**
+      - libraries/**
 
   pull_request:
     paths:
-      - apps/*
-      - libraries/*
+      - apps/**
+      - libraries/**
 
 jobs:
   analyze:

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -3,7 +3,18 @@ name: ESLint
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - apps/*
+      - libraries/*
+
   pull_request:
+    paths:
+      - package.json
+      - apps/*
+      - libraries/*
 
 jobs:
   eslint:

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -7,14 +7,14 @@ on:
       - main
     paths:
       - package.json
-      - apps/*
-      - libraries/*
+      - apps/**
+      - libraries/**
 
   pull_request:
     paths:
       - package.json
-      - apps/*
-      - libraries/*
+      - apps/**
+      - libraries/**
 
 jobs:
   eslint:


### PR DESCRIPTION
This will restrict GitHub actions to only run when certain paths change. This is to avoid actions running for silly reasons (eg, docs changing triggers a eslint). 