### PR TITLE
ci: Container for dev had wrong name, and a few other fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,13 @@
 # We want the docker builds to be clean, and as fast as possible. Don't send
 # any half-built stuff in the build context as a pre-caution (also saves copying
 # 180k files in node_modules that isn't used!).
-node_modules
+**/node_modules
 dist
 .nx
 .devcontainer
-.git
-*.md
+**/.git
+**/dist
+**/*.md
+**/LICENSE
+**/npm-debug.log
+**/*.vscode

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -8,7 +8,7 @@ on:
       - '*'
 
 jobs:
-  build-tag:
+  build-containers:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,10 +30,14 @@ jobs:
         run: |
           echo "DATE=$(date +'%s')" >> "$GITHUB_ENV"
 
+      - name: Print post-build debug info
+        run: |
+          docker images
+
       - name: docker tag
         run: |
           docker tag localhost/postiz ghcr.io/gitroomhq/postiz-app:${{ env.DATE }}
           docker push ghcr.io/gitroomhq/postiz-app:${{ env.DATE }}
 
-          docker tag localhost/postiz-devcontainer ghcr.io/gitroomhq/postiz-app:${{ env.DATE }}
+          docker tag localhost/postiz-devcontainer ghcr.io/gitroomhq/postiz-devcontainer:${{ env.DATE }}
           docker push ghcr.io/gitroomhq/postiz-devcontainer:${{ env.DATE }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ Thumbs.db
 
 # Next.js
 .next
+
+# Vim files
+**/*.swp
+**/*.swo

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-# This Dockerfile is used for producing 3 container images. 
+# This Dockerfile is used for producing 3 container images.
 #
 # base - which is thrown away, that contains node and the basic infrastructure. 
 # devcontainer - which is used for development, and contains the source code and the node_modules.

--- a/var/docker/docker-build.sh
+++ b/var/docker/docker-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o xtrace
+
 docker rmi localhost/postiz || true
 docker build --target dist -t localhost/postiz -f Dockerfile.dev .
 docker build --target devcontainer -t localhost/postiz-devcontainer -f Dockerfile.dev .


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

These are the main two changed lines - I had "app" twice. 

```
-          docker tag localhost/postiz-devcontainer ghcr.io/gitroomhq/postiz-app:${{ env.DATE }}
+          docker tag localhost/postiz-devcontainer ghcr.io/gitroomhq/postiz-devcontainer:${{ env.DATE }}
```