### PR TITLE
ci: Add latest tag to containers with each build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,11 @@
-# What kind of change does this PR introduce?** 
+# What kind of change does this PR introduce?
 
 eg: Bug fix, feature, docs update, ...
 
-# Why was this change needed?** 
+# Why was this change needed?
 
 Please link to related issues when possible.
 
-**Other information**:
+# Other information:
+
+eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc? 

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -39,5 +39,11 @@ jobs:
           docker tag localhost/postiz ghcr.io/gitroomhq/postiz-app:${{ env.DATE }}
           docker push ghcr.io/gitroomhq/postiz-app:${{ env.DATE }}
 
+          docker tag ghcr.io/gitroomhq/postiz-app:${{ env.DATE }} ghcr.io/gitroomhq/postiz-app:latest
+          docker push ghcr.io/gitroomhq/postiz-app:latest
+
           docker tag localhost/postiz-devcontainer ghcr.io/gitroomhq/postiz-devcontainer:${{ env.DATE }}
           docker push ghcr.io/gitroomhq/postiz-devcontainer:${{ env.DATE }}
+
+          docker tag ghcr.io/gitroomhq/postiz-devcontainer:${{ env.DATE }} ghcr.io/gitroomhq/postiz-devcontainer:latest
+          docker push ghcr.io/gitroomhq/postiz-devcontainer:latest


### PR DESCRIPTION
# What kind of change does this PR introduce? 

CI change

# Why was this change needed?

This will tag new builds of container images with the latest tag, making it easy for container upgrades. 

**Other information:
