### PR TITLE
feat: Host an internal proxy to get around CORs issues

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,17 +14,20 @@ ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN apk add --no-cache \
+	caddy \
 	bash=5.2.21-r0 \
 	supervisor=4.2.5-r4
 
 WORKDIR /app
 
-EXPOSE 4200
 EXPOSE 3000
+EXPOSE 4200
+EXPOSE 5000
 
 COPY var/docker/entrypoint.sh /app/entrypoint.sh
 COPY var/docker/supervisord.conf /etc/supervisord.conf
 COPY var/docker/supervisord /app/supervisord_available_configs/
+COPY var/docker/Caddyfile /app/Caddyfile
 COPY .env.example /config/postiz.env
 
 VOLUME /config

--- a/var/docker/Caddyfile
+++ b/var/docker/Caddyfile
@@ -1,0 +1,9 @@
+:5000/ {
+	handle_path /api/* {
+		reverse_proxy * localhost:3000
+	}
+
+	handle {
+		reverse_proxy * localhost:4200
+	}
+}

--- a/var/docker/entrypoint.sh
+++ b/var/docker/entrypoint.sh
@@ -5,11 +5,16 @@ set -o xtrace
 if [[ "$SKIP_CONFIG_CHECK" != "true" ]]; then
 	echo "Entrypoint: Copying /config/postiz.env into /app/.env"
 
-	if [ ! -f /config/.env ]; then
-		echo "Entrypoint: WARNING: No .env file found in /config/postiz.env"
+	if [ ! -f /config/postiz.env ]; then
+		echo "Entrypoint: WARNING: No postiz.env file found in /config/postiz.env"
 	fi
 
 	cp -vf /config/postiz.env /app/.env
+fi
+
+if [[ "$INTERNAL_PROXY_ENABLED" != "false" ]]; then
+	echo "Entrypoint: Starting internal proxy"
+	cp -vf /app/supervisord_available_configs/caddy.conf /etc/supervisor.d/
 fi
 
 if [[ "$POSTIZ_APPS" -eq "" ]]; then

--- a/var/docker/supervisord/caddy.conf
+++ b/var/docker/supervisord/caddy.conf
@@ -1,0 +1,8 @@
+[program:backend]
+directory=/app
+command=caddy run --config /app/Caddyfile
+autostart=true
+autorestart=false
+redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0


### PR DESCRIPTION
# What kind of change does this PR introduce?

feature

# Why was this change needed?

This will spawn an internal Caddy proxy, to proxy the frontend and backend, which should really help people who are struggling with CORs.

# Other information:

Not been able to test this yet, just gonna kinda commit/test...commit/test this a bit. 
