### PR TITLE
feat: Config option for secure cookies (default false), and user activation (default false)

### DIFF
--- a/apps/backend/src/api/routes/auth.controller.ts
+++ b/apps/backend/src/api/routes/auth.controller.ts
@@ -32,7 +32,7 @@ export class AuthController {
 
       const activationRequired = !!process.env.ACTIVATION_REQUIRED;
 
-      if (process.envbody.provider === 'LOCAL' && activationRequired) {
+      if (process.env.provider === 'LOCAL' && activationRequired) {
         response.header('activate', 'true');
         response.status(200).json({ activate: true });
         return;

--- a/apps/backend/src/api/routes/auth.controller.ts
+++ b/apps/backend/src/api/routes/auth.controller.ts
@@ -30,7 +30,9 @@ export class AuthController {
         getOrgFromCookie
       );
 
-      if (body.provider === 'LOCAL') {
+      const activationRequired = !!process.env.ACTIVATION_REQUIRED;
+
+      if (process.envbody.provider === 'LOCAL' && activationRequired) {
         response.header('activate', 'true');
         response.status(200).json({ activate: true });
         return;
@@ -38,7 +40,7 @@ export class AuthController {
 
       response.cookie('auth', jwt, {
         domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-        secure: true,
+        secure: !!process.env.COOKIES_MARK_SECURE,
         httpOnly: true,
         sameSite: 'none',
         expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
@@ -47,7 +49,7 @@ export class AuthController {
       if (typeof addedOrg !== 'boolean' && addedOrg?.organizationId) {
         response.cookie('showorg', addedOrg.organizationId, {
           domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-          secure: true,
+          secure: !!process.env.COOKIES_MARK_SECURE
           httpOnly: true,
           sameSite: 'none',
           expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),


### PR DESCRIPTION
# What kind of change does this PR introduce?

feature

# Why was this change needed?

We're seeing quite a lot of people struggle with the initial setup of postiz, so this PR introduces two changes to make it easier for new users getting started. 

## Cookies insecure by default (which means https/secure context isn't required)
The first change is in how cookies are set, which is currently "secure" - meaning the cookie is only set on HTTPS. However, many people don't have HTTPS setup, or don't know now, meaning they get confused when they cannot login. 

WARNING: This default is now less secure, but makes postiz easier to user. 

Existing users and the SaaS version of Postiz should set COOKIES_MARK_SECURE=1 to continue to make cookies secure.

## User activation disabled by default

Most people self-hosting postiz probably will just have 1 user, without RESEND configured, so activation becomes a pain. At the moment the register controller always posts back that activation is required if local auth is being used. With this change, that activation header is not set by default.

WARNING: Existing users that want to continue activating users, and the SaaS version of Postiz should set ACTIVATION_REQUIRED=1 to continue activating users.

# Other information:

I thought about making the inverted options, like DISABLE_USER_ACTIVATION and DISABLE_SECURE_COOKIES, but this means more configuration options needed in the default config - and we're trying to make less options needed by default. 