### PR TITLE
[AB-0001]: added web ui for redis docker-compose.dev.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ Thumbs.db
 # Vim files
 **/*.swp
 **/*.swo
+
+# Temporary files
+*.orig
+*.~*~
+*.tsbuildinfo
+
+# ignore Secrets folder
+.secrets/

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,7 @@
 services:
   postiz-postgres:
-    image: postgres:14.5
+    # ref: https://hub.docker.com/_/postgres
+    image: postgres:17-alpine # 17.0
     container_name: postiz-postgres
     restart: always
     environment:
@@ -13,8 +14,18 @@ services:
       - 5432:5432
     networks:
       - postiz-network
+  postiz-redis:
+    # ref: https://hub.docker.com/_/redis
+    image: redis:7-alpine # 7.4.0
+    container_name: postiz-redis
+    restart: always
+    ports:
+      - 6379:6379
+    networks:
+      - postiz-network
   postiz-pg-admin:
-    image: dpage/pgadmin4
+    # ref: https://hub.docker.com/r/dpage/pgadmin4/tags
+    image: dpage/pgadmin4:latest
     container_name: postiz-pg-admin
     restart: always
     ports:
@@ -24,14 +35,22 @@ services:
       PGADMIN_DEFAULT_PASSWORD: admin
     networks:
       - postiz-network
-  postiz-redis:
-    image: redis:7.2
-    container_name: postiz-redis
-    restart: always
+  postiz-redisinsight:
+    # ref: https://hub.docker.com/r/redis/redisinsight
+    image: redis/redisinsight:latest
+    container_name: postiz-redisinsight
+    links:
+      - postiz-redis
     ports:
-      - 6379:6379
+      - "5540:5540"
+    volumes:
+      - redisinsight:/data
+    networks:
+      - postiz-network
+    restart: always
 
 volumes:
+  redisinsight:
   postgres-volume:
     external: false
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:backend": "npx nx run backend:serve:development",
     "dev:workers": "npx nx run workers:serve:development",
     "dev:cron": "npx nx run cron:serve:development",
+    "dev:docker": "docker compose -f ./docker-compose.dev.yaml up -d",
     "start:prod": "node dist/apps/backend/main.js",
     "start:prod:frontend": "nx run frontend:serve:production",
     "start:prod:workers": "node dist/apps/workers/main.js",
@@ -193,5 +194,8 @@
     "typescript": "5.5.4",
     "vite": "^5.0.0",
     "vitest": "1.6.0"
+  },
+  "volta": {
+    "node": "20.17.0"
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Improvements:
- added npm script to run the docker-compose for local development. `npm run dev:docker`
- added volta pin to latest node LTS version `20.17.0` (lts/iron)
- added Redis web UI for the developer so that we can check the Redis state in a nice way
- switch docker images to the latest/alpine versions, which have much smaller sizes of docker images (save some space)

# Why was this change needed?

It makes setup for local development easier.
