### PR TITLE
Fix: Updated API keys instructions for social media X integrations (#263)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,8 @@ CLOUDFLARE_REGION="auto"
 
 
 # Social Media API Settings
-X_API_KEY=""
-X_API_SECRET=""
+X_API_KEY="your_actual_32_character_API_key"
+X_API_SECRET="your_actual_32_character_API_secret"
 X_CLIENT=""
 X_SECRET=""
 LINKEDIN_CLIENT_ID=""


### PR DESCRIPTION
This PR updates the .env.example file with the correct API key and secret formats required for social media integrations with X.

Previously, the configuration was leading to errors such as "Credential access key has length 40, should be 32." By updating these keys, the application should now function properly when attempting to upload images to X.

### Instructions to Obtain the X API Key

1. **Go to the Twitter Developer Portal**: Visit [Twitter Developer](https://developer.twitter.com/).
  
2. **Create a New App**:
   - Sign in to your account.
   - Click on “Projects & Apps” in the top menu.
   - Select “Create App” and follow the prompts to create a new app.

3. **Configure Your App**:
   - Under "App Settings," set the **App Permissions** to **Read and Write**.
   - Specify the **Type of App** (Web App, Automated App, or Bot).
   - In the **App Info** section, set the **Callback URI / Redirect URL** to `http://localhost:4200/integrations/social/x`.

4. **Get Your API Keys**:
   - Navigate to the "Keys and Tokens" tab of your app.
   - Click on "Regenerate" inside "Consumer Keys" to obtain your **API Key** and **API Secret**.

5. **Update Your `.env` File**:
   - Open your `.env` file in the project.
   - Set the following variables with the keys you obtained:
     ```
     X_API_KEY="your_32_character_api_key_here"
     X_API_SECRET="your_32_character_api_secret_here"
     ```

This resolves issue #263 .
