### PR TITLE
Fixing the marketplace white ticks in white background

### DIFF
--- a/apps/frontend/src/app/colors.scss
+++ b/apps/frontend/src/app/colors.scss
@@ -131,7 +131,7 @@
     --color-custom49: #0a0b14;
     --color-custom50: #262373;
     --color-custom51: #4f46e5;
-    --color-custom52: #eaeef2;
+    --color-custom52: #0a0a0a;
     --color-custom53: #7c7d86;
     --color-custom54: #afb8c1;
   }


### PR DESCRIPTION
# What kind of change does this PR introduce?
In light mode, checkboxes are checked, but the tick mark is not clearly visible. However, it is visible in dark mode.

# Why was this change needed?
https://github.com/gitroomhq/postiz-app/issues/266