### PR TITLE
Show times of notification messages

### DIFF
--- a/apps/frontend/src/components/notifications/notification.component.tsx
+++ b/apps/frontend/src/components/notifications/notification.component.tsx
@@ -19,6 +19,7 @@ export const ShowNotification: FC<{
   lastReadNotification: string;
 }> = (props) => {
   const { notification } = props;
+  const createdAt = new Date(notification.createdAt).toLocaleString();
   const [newNotification] = useState(
     new Date(notification.createdAt) > new Date(props.lastReadNotification)
   );
@@ -29,6 +30,8 @@ export const ShowNotification: FC<{
         `text-textColor px-[16px] py-[10px] border-b border-tableBorder last:border-b-0 transition-colors ${interClass} overflow-hidden text-ellipsis`,
         newNotification && 'font-bold bg-seventh animate-newMessages'
       )}
+      data-tooltip-id="tooltip"
+      data-tooltip-content={createdAt}
       dangerouslySetInnerHTML={{ __html: replaceLinks(notification.content) }}
     />
   );


### PR DESCRIPTION
Makes the date and time of each notification message available as a tooltip, in the locale and timezone

# What kind of change does this PR introduce?

Minor improvement

# Why was this change needed?

It's hard to see if you're testing a post that keeps on failing whether you've yet got a new notification. And helpful to be able to check the timestamp of when notifications were sent.

Now it can be seen by mousing over:
![image](https://github.com/user-attachments/assets/3cd223ae-a3af-4571-8c54-70b93bc7892d)


# Other information:

I suggested it in https://discordapp.com/channels/1243410146097500202/1291105186068041778
