### PR TITLE
Enable multipart uploads for all cloudflare uploads via uppy.

### DIFF
--- a/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
+++ b/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
@@ -26,6 +26,7 @@ export const getUppyUploadPlugin = (provider: string, fetch: any, backendUrl: st
           plugin: AwsS3Multipart,
           options: {
             shouldUseMultipart: (file : any) => true,
+            endpoint: '',
             createMultipartUpload: async (file: any) => {
               const arrayBuffer = await new Response(file.data).arrayBuffer();
               const fileHash = sha256(Buffer.from(arrayBuffer));

--- a/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
+++ b/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
@@ -25,6 +25,9 @@ export const getUppyUploadPlugin = (provider: string, fetch: any, backendUrl: st
         return {
           plugin: AwsS3Multipart,
           options: {
+            shouldUseMultipart(file : any) {
+              return true;
+            },
             createMultipartUpload: async (file: any) => {
               const arrayBuffer = await new Response(file.data).arrayBuffer();
               const fileHash = sha256(Buffer.from(arrayBuffer));

--- a/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
+++ b/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
@@ -25,9 +25,7 @@ export const getUppyUploadPlugin = (provider: string, fetch: any, backendUrl: st
         return {
           plugin: AwsS3Multipart,
           options: {
-            shouldUseMultipart(file : any) {
-              return true;
-            },
+            shouldUseMultipart: (file : any) => true,
             createMultipartUpload: async (file: any) => {
               const arrayBuffer = await new Response(file.data).arrayBuffer();
               const fileHash = sha256(Buffer.from(arrayBuffer));


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

This fixes upload errors with files < 100MB by forcing Uppy to always use multipart. Otherwise it would try to use singlepart and there is no presigning iomplemented for this case.


# Other information:

Was discussed on Discord

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
