### PR TITLE
Increase Discord Message Character Limit for Better Compatibility

### DIFF
--- a/apps/frontend/src/components/launches/providers/discord/discord.provider.tsx
+++ b/apps/frontend/src/components/launches/providers/discord/discord.provider.tsx
@@ -17,5 +17,5 @@ export default withProvider(
   undefined,
   DiscordDto,
   undefined,
-  280
+  1980
 );


### PR DESCRIPTION
Closes #378 

### What kind of change does this PR introduce?

Bug fix regarding the issue where maximum amount of characters is set to 280 before being truncated, despite Discord's character limit is way higher.

### Why was this change needed?

This PR addresses the issue where messages sent to Discord through Postiz were being truncated at 280 characters, despite Discord’s actual character limit being 2000 characters. The change increases the `maxCharacter` limit in Postiz to 1980 to better align with Discord’s limit while keeping a slight buffer to account for any additional metadata Discord may attach, such as special formatting or potential future changes in message structure.

Having a buffer also improves reliability by reducing the risk of unexpected truncation or errors due to reaching the exact character limit in cases of small variations.

### Other information:

This issue was discussed briefly, and it's a small but impactful change, enhancing Postiz's usability for users sending longer messages to Discord. No further plans for modifications at this time.

### Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR). 
