### PR TITLE
feature: Responsive launches UI

### DIFF
--- a/apps/frontend/src/app/global.scss
+++ b/apps/frontend/src/app/global.scss
@@ -10,7 +10,6 @@ html {
 }
 .box {
   position: relative;
-  padding: 8px 24px;
 }
 .box span {
   position: relative;

--- a/apps/frontend/src/components/launches/add.edit.model.tsx
+++ b/apps/frontend/src/components/launches/add.edit.model.tsx
@@ -385,14 +385,15 @@ export const AddEditModal: FC<{
           instructions="You are an assistant that help the user to schedule their social media posts, everytime somebody write something, try to use a function call, if not prompt the user that the request is invalid and you are here to assists with social media posts"
         />
       )}
-      <div
-        className={clsx('flex p-[10px] rounded-[4px] bg-primary gap-[20px]')}
+      <div 
+        id="add-edit-modal"
+        className={clsx('flex flex-col md:flex-row p-[10px] rounded-[4px] bg-primary gap-[20px]')}
       >
         <div
           className={clsx(
             'flex flex-col gap-[16px] transition-all duration-700 whitespace-nowrap',
             !expend.expend
-              ? 'flex-1 w-1 animate-overflow'
+              ? 'flex-1 animate-overflow'
               : 'w-0 overflow-hidden'
           )}
         >
@@ -540,10 +541,10 @@ export const AddEditModal: FC<{
             ) : null}
           </div>
           <div className="relative h-[68px] flex flex-col rounded-[4px] border border-customColor6 bg-sixth">
-            <div className="flex flex-1 gap-[10px] relative">
-              <div className="absolute w-full h-full flex gap-[10px] justify-end items-center right-[16px]">
+            <div className="gap-[10px] relative">
+              <div id = "add-edit-post-dialog-buttons" className="flex flex-row flex-wrap w-full h-full gap-[10px] justify-end items-center right-[16px]">
                 <Button
-                  className="bg-transparent text-inputText"
+                  className="rounded-[4px]"
                   onClick={askClose}
                 >
                   Cancel

--- a/apps/frontend/src/components/launches/filters.tsx
+++ b/apps/frontend/src/components/launches/filters.tsx
@@ -145,74 +145,78 @@ export const Filters = () => {
     week.currentDay,
   ]);
   return (
-    <div className="text-textColor flex gap-[8px] items-center select-none">
-      <div onClick={previous} className="cursor-pointer">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 20 20"
-          fill="none"
-        >
-          <path
-            d="M13.1644 15.5866C13.3405 15.7628 13.4395 16.0016 13.4395 16.2507C13.4395 16.4998 13.3405 16.7387 13.1644 16.9148C12.9883 17.0909 12.7494 17.1898 12.5003 17.1898C12.2513 17.1898 12.0124 17.0909 11.8363 16.9148L5.58629 10.6648C5.49889 10.5777 5.42954 10.4742 5.38222 10.3602C5.3349 10.2463 5.31055 10.1241 5.31055 10.0007C5.31055 9.87732 5.3349 9.75515 5.38222 9.64119C5.42954 9.52724 5.49889 9.42375 5.58629 9.33665L11.8363 3.08665C12.0124 2.91053 12.2513 2.81158 12.5003 2.81158C12.7494 2.81158 12.9883 2.91053 13.1644 3.08665C13.3405 3.26277 13.4395 3.50164 13.4395 3.75071C13.4395 3.99978 13.3405 4.23865 13.1644 4.41477L7.57925 9.99993L13.1644 15.5866Z"
-            fill="#E9E9F1"
-          />
-        </svg>
-      </div>
-      <div className="w-[80px] text-center">
-        {week.display === 'day'
-          ? `${dayjs()
-              .month(week.currentMonth)
-              .week(week.currentWeek)
-              .day(week.currentDay)
-              .format('dddd')}`
-          : week.display === 'week'
-          ? `Week ${week.currentWeek}`
-          : `${dayjs().month(week.currentMonth).format('MMMM')}`}
-      </div>
-      <div onClick={next} className="cursor-pointer">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 20 20"
-          fill="none"
-        >
-          <path
-            d="M14.4137 10.6633L8.16374 16.9133C7.98761 17.0894 7.74874 17.1884 7.49967 17.1884C7.2506 17.1884 7.01173 17.0894 6.83561 16.9133C6.65949 16.7372 6.56055 16.4983 6.56055 16.2492C6.56055 16.0002 6.65949 15.7613 6.83561 15.5852L12.4223 10L6.83717 4.41331C6.74997 4.3261 6.68079 4.22257 6.6336 4.10863C6.5864 3.99469 6.56211 3.87257 6.56211 3.74925C6.56211 3.62592 6.5864 3.5038 6.6336 3.38986C6.68079 3.27592 6.74997 3.17239 6.83717 3.08518C6.92438 2.99798 7.02791 2.9288 7.14185 2.88161C7.25579 2.83441 7.37791 2.81012 7.50124 2.81012C7.62456 2.81012 7.74668 2.83441 7.86062 2.88161C7.97456 2.9288 8.07809 2.99798 8.1653 3.08518L14.4153 9.33518C14.5026 9.42238 14.5718 9.52596 14.619 9.63997C14.6662 9.75398 14.6904 9.87618 14.6903 9.99957C14.6901 10.123 14.6656 10.2451 14.6182 10.359C14.5707 10.4729 14.5012 10.5763 14.4137 10.6633Z"
-            fill="#E9E9F1"
-          />
-        </svg>
-      </div>
-      <div className="flex-1">{betweenDates}</div>
-      <div
-        className={clsx(
-          'border border-tableBorder p-[10px] cursor-pointer',
-          week.display === 'day' && 'bg-tableBorder'
-        )}
-        onClick={setDay}
-      >
-        Day
-      </div>
-      <div
-        className={clsx(
-          'border border-tableBorder p-[10px] cursor-pointer',
-          week.display === 'week' && 'bg-tableBorder'
-        )}
-        onClick={setWeek}
-      >
-        Week
-      </div>
-      <div
-        className={clsx(
-          'border border-tableBorder p-[10px] cursor-pointer',
-          week.display === 'month' && 'bg-tableBorder'
-        )}
-        onClick={setMonth}
-      >
-        Month
-      </div>
+    <div className="text-textColor flex flex-col md:flex-row gap-[8px] items-center select-none">
+	  <div className = "flex flex-grow flex-row">
+		<div onClick={previous} className="cursor-pointer">
+		  <svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="20"
+			height="20"
+			viewBox="0 0 20 20"
+			fill="none"
+		  >
+			<path
+			  d="M13.1644 15.5866C13.3405 15.7628 13.4395 16.0016 13.4395 16.2507C13.4395 16.4998 13.3405 16.7387 13.1644 16.9148C12.9883 17.0909 12.7494 17.1898 12.5003 17.1898C12.2513 17.1898 12.0124 17.0909 11.8363 16.9148L5.58629 10.6648C5.49889 10.5777 5.42954 10.4742 5.38222 10.3602C5.3349 10.2463 5.31055 10.1241 5.31055 10.0007C5.31055 9.87732 5.3349 9.75515 5.38222 9.64119C5.42954 9.52724 5.49889 9.42375 5.58629 9.33665L11.8363 3.08665C12.0124 2.91053 12.2513 2.81158 12.5003 2.81158C12.7494 2.81158 12.9883 2.91053 13.1644 3.08665C13.3405 3.26277 13.4395 3.50164 13.4395 3.75071C13.4395 3.99978 13.3405 4.23865 13.1644 4.41477L7.57925 9.99993L13.1644 15.5866Z"
+			  fill="#E9E9F1"
+			/>
+		  </svg>
+		</div>
+		<div className="w-[80px] text-center">
+		  {week.display === 'day'
+			? `${dayjs()
+				.month(week.currentMonth)
+				.week(week.currentWeek)
+				.day(week.currentDay)
+				.format('dddd')}`
+			: week.display === 'week'
+			? `Week ${week.currentWeek}`
+			: `${dayjs().month(week.currentMonth).format('MMMM')}`}
+		</div>
+		<div onClick={next} className="cursor-pointer">
+		  <svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="20"
+			height="20"
+			viewBox="0 0 20 20"
+			fill="none"
+		  >
+			<path
+			  d="M14.4137 10.6633L8.16374 16.9133C7.98761 17.0894 7.74874 17.1884 7.49967 17.1884C7.2506 17.1884 7.01173 17.0894 6.83561 16.9133C6.65949 16.7372 6.56055 16.4983 6.56055 16.2492C6.56055 16.0002 6.65949 15.7613 6.83561 15.5852L12.4223 10L6.83717 4.41331C6.74997 4.3261 6.68079 4.22257 6.6336 4.10863C6.5864 3.99469 6.56211 3.87257 6.56211 3.74925C6.56211 3.62592 6.5864 3.5038 6.6336 3.38986C6.68079 3.27592 6.74997 3.17239 6.83717 3.08518C6.92438 2.99798 7.02791 2.9288 7.14185 2.88161C7.25579 2.83441 7.37791 2.81012 7.50124 2.81012C7.62456 2.81012 7.74668 2.83441 7.86062 2.88161C7.97456 2.9288 8.07809 2.99798 8.1653 3.08518L14.4153 9.33518C14.5026 9.42238 14.5718 9.52596 14.619 9.63997C14.6662 9.75398 14.6904 9.87618 14.6903 9.99957C14.6901 10.123 14.6656 10.2451 14.6182 10.359C14.5707 10.4729 14.5012 10.5763 14.4137 10.6633Z"
+			  fill="#E9E9F1"
+			/>
+		  </svg>
+		</div>
+      	<div className="flex-1">{betweenDates}</div>
+	  </div>
+	  <div className="flex flex-row">
+		<div
+		  className={clsx(
+			'border border-tableBorder p-[10px] cursor-pointer',
+			week.display === 'day' && 'bg-tableBorder'
+		  )}
+		  onClick={setDay}
+		>
+		  Day
+		</div>
+		<div
+		  className={clsx(
+			'border border-tableBorder p-[10px] cursor-pointer',
+			week.display === 'week' && 'bg-tableBorder'
+		  )}
+		  onClick={setWeek}
+		>
+		  Week
+		</div>
+		<div
+		  className={clsx(
+			'border border-tableBorder p-[10px] cursor-pointer',
+			week.display === 'month' && 'bg-tableBorder'
+		  )}
+		  onClick={setMonth}
+		>
+		  Month
+		</div>
+	  </div>
     </div>
   );
 };

--- a/apps/frontend/src/components/launches/general.preview.component.tsx
+++ b/apps/frontend/src/components/launches/general.preview.component.tsx
@@ -19,7 +19,7 @@ export const GeneralPreviewComponent: FC<{maximumCharacters?: number}> = (props)
   });
 
   return (
-    <div className={clsx('w-[555px] px-[16px]')}>
+    <div className={clsx('w-full md:w-[555px] px-[16px]')}>
       <div className="w-full h-full relative flex flex-col">
         {newValues.map((value, index) => (
           <div

--- a/apps/frontend/src/components/launches/launches.component.tsx
+++ b/apps/frontend/src/components/launches/launches.component.tsx
@@ -116,8 +116,8 @@ export const LaunchesComponent = () => {
     <CalendarWeekProvider integrations={sortedIntegrations}>
       <div className="flex flex-1 flex-col">
         <div className="flex flex-1 relative">
-          <div className="outline-none w-full h-full grid grid-cols-[220px_minmax(0,1fr)] gap-[30px] scrollbar scrollbar-thumb-tableBorder scrollbar-track-secondary">
-            <div className="w-[220px] bg-third p-[16px] flex flex-col gap-[24px] min-h-[100%]">
+          <div className="outline-none w-full h-full grid grid-cols[1fr] md:grid-cols-[220px_minmax(0,1fr)] gap-[30px] scrollbar scrollbar-thumb-tableBorder scrollbar-track-secondary">
+            <div className="bg-third p-[16px] flex flex-col gap-[24px] min-h-[100%]">
               <h2 className="text-[20px]">Channels</h2>
               <div className="gap-[16px] flex flex-col">
                 {sortedIntegrations.length === 0 && (

--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -107,7 +107,7 @@ export const Impersonate = () => {
   }, [data]);
 
   return (
-    <div className="px-[23px]">
+    <div className="md:px-[23px]">
       <div className="bg-forth h-[52px] flex justify-center items-center border-input border rounded-[8px]">
         <div className="relative flex flex-col w-[600px]">
           <div className="relative z-[999]">

--- a/apps/frontend/src/components/layout/layout.settings.tsx
+++ b/apps/frontend/src/components/layout/layout.settings.tsx
@@ -77,12 +77,12 @@ export const LayoutSettings = ({ children }: { children: ReactNode }) => {
             {user.tier !== 'FREE' && <Onboarding />}
             <Support />
             <ContinueProvider />
-            <div className="min-h-[100vh] w-full max-w-[1440px] mx-auto bg-primary px-[12px] text-textColor flex flex-col">
+            <div className="min-h-[100vh] w-full max-w-[1440px] mx-auto bg-primary sm:px-6 px-0 text-textColor flex flex-col">
               {user?.admin && <Impersonate />}
-              <div className="px-[23px] flex h-[80px] items-center justify-between z-[200] sticky top-0 bg-primary">
+              <nav className="px-0 md:px-[23px] gap-2 grid grid-rows-[repeat(2,_auto)] grid-cols-2 md:grid-rows-1 md:grid-cols-[repeat(3,_auto)] items-center justify-between z-[200] sticky top-0 bg-primary">
                 <Link
                   href="/"
-                  className="text-2xl flex items-center gap-[10px] text-textColor"
+                  className="text-2xl flex items-center gap-[10px] text-textColor order-1"
                 >
                   <div className="min-w-[55px]">
                     <Image
@@ -132,15 +132,15 @@ export const LayoutSettings = ({ children }: { children: ReactNode }) => {
                 ) : (
                   <div />
                 )}
-                <div className="flex items-center gap-[8px]">
+                <div id = "systray-buttons" className="flex items-center justify-self-end gap-[8px] order-2 md:order-3">
                   <ModeComponent />
                   <SettingsComponent />
                   <NotificationComponent />
                   <OrganizationSelector />
                 </div>
-              </div>
+              </nav>
               <div className="flex-1 flex">
-                <div className="flex-1 rounded-3xl px-[23px] py-[17px] flex flex-col">
+                <div className="flex-1 rounded-3xl px-0 md:px-[23px] py-[17px] flex flex-col">
                   {(user.tier === 'FREE' && isGeneral) && billingEnabled ? (
                     <>
                       <div className="text-center mb-[20px] text-xl">

--- a/apps/frontend/src/components/layout/top.menu.tsx
+++ b/apps/frontend/src/components/layout/top.menu.tsx
@@ -70,8 +70,8 @@ export const TopMenu: FC = () => {
   const menuItems = useMenuItems();
 
   return (
-    <div className="flex flex-col h-full animate-normalFadeDown">
-      <ul className="gap-5 flex flex-1 items-center text-[18px]">
+    <div className="flex flex-col h-full animate-normalFadeDown order-3 md:order-2 col-span-2 md:col-span-1">
+      <ul className="gap-0 md:gap-5 flex flex-1 items-center text-[18px]">
         {menuItems
           .filter((f) => {
             if (f.requireBilling && !billingEnabled) {
@@ -88,7 +88,7 @@ export const TopMenu: FC = () => {
                 prefetch={true}
                 href={item.path}
                 className={clsx(
-                  'flex gap-2 items-center box',
+                  'flex gap-2 items-center box px-[6px] md:px-[24px] py-[8px]',
                   menuItems
                     .filter((f) => {
                       if (f.role) {

--- a/apps/frontend/src/components/notifications/notification.component.tsx
+++ b/apps/frontend/src/components/notifications/notification.component.tsx
@@ -42,7 +42,7 @@ export const NotificationOpenComponent = () => {
   const { data, isLoading } = useSWR('notifications', loadNotifications);
 
   return (
-    <div className="opacity-0 animate-normalFadeDown mt-[10px] absolute w-[420px] min-h-[200px] top-[100%] right-0 bg-third text-textColor rounded-[16px] flex flex-col border border-tableBorder">
+    <div id="notification-popup" className="opacity-0 animate-normalFadeDown mt-[10px] absolute w-[420px] min-h-[200px] top-[100%] right-0 bg-third text-textColor rounded-[16px] flex flex-col border border-tableBorder z-[2]">
       <div className={`p-[16px] border-b border-tableBorder ${interClass} font-bold`}>
         Notifications
       </div>


### PR DESCRIPTION
TODO: Writing description - come back in a few mins

This PR introduces a functional responsive UI for at least the "launches" part of the web interface, which is obviously the most important. I didn't want to go /too/ far, but at least this makes Positz pretty usable on mobile. 

Below are many before/after screenshots. 

# Launches UI 

## BEFORE - **Desktop** - Firefox 

![image](https://github.com/user-attachments/assets/056d41ef-6425-4465-ae55-6989dcaa1f28)

## BEFORE - **iPhone 12 Pro** - Firefox 

Problems;

* The page scrolls sideways
* The header menu scrolls off the page
* The "systray icons" are off the page
* The calendar is too small to be usable or clickable

![image](https://github.com/user-attachments/assets/6d52d51f-69b3-4167-9747-30463f4b15c3)

## AFTER - **Desktop** - Firefox (no visual change, even if the structure of the header is now different in the HTML); 

Just posting this to prove I didn't break compatibility with the current UI. 

![image](https://github.com/user-attachments/assets/88bdcc8b-32a1-4fc1-9000-282d12bfca82)

## AFTER - **iPhone 12 Pro** - Firefox

The header automatically re-organizes to make use of the minimal screen space, and automatically expands to the full-width in the above desktop version. Zero side-scrolling in a screen width of just 390px. :-)

![image](https://github.com/user-attachments/assets/9f5e8bab-4039-46d1-8dd4-35656b6b5110)

## AFTER - **iPhone 12 Pro** - Chrome & Dark Mode

![image](https://github.com/user-attachments/assets/a5fece38-2720-4987-b8a2-feb1f8f43191)


# Posting UI

## BEFORE - **Desktop** - Firefox

Problems;

* Cancel button is hidden

![image](https://github.com/user-attachments/assets/ad408243-2f15-4f57-a605-ed10cbd90cd4)

## AFTER - **Desktop** - Firefox (no visual change, even if the  structure of the HTML is now different)

Just posting this to prove I didn't break compatibility with the current UI.  Fixed the cancel button in light mode. 

![image](https://github.com/user-attachments/assets/3384376d-8a59-492b-90e9-b0e60faadc31)

## BEFORE - **iPhone 12 Pro** - Firefox

Problems;

* The preview displays side by side, making the screen scroll
* The dialog buttons scroll off the left of the page
* The two "panels" overlap

![image](https://github.com/user-attachments/assets/8c0d8cac-3d3b-42e1-b49a-13cd4bb41366)

## AFTER - **iPhone 12 Pro** - Firefox

Note: Certainly not perfect, but it's functional in the "after" version, whereas it's unusable in the current version. The preview is moved to the bottom in small screen widths, making it just scroll vertically. The buttons don't sroll off the page. 

I think this general dialog could do with some overall UI improvements, so I didn't go *too* far with this, but just wanted to make it functional. 

![image](https://github.com/user-attachments/assets/3f20a11a-46c7-40c7-8054-6ed285a04f16)

## After - **iPhone 12 Pro** - Chrome & Dark Mode

![image](https://github.com/user-attachments/assets/6db93e5a-5ea8-493b-be4f-092e635e9f1d)


# Notes

* All the responsive changes were made with idiomatic tailwind CSS to the best of my knowledge (first time using tailwind). 
* Small markup changes were made in a couple of places to give IDs to elements (not used for styling), because it was driving me insane to find where elements were defined in the source. Adding IDs makes them easy to grep for!
* The "div soup" started to annoy me, and I changed one tag name - one div to a <nav /> to start doing symantic HTML. We could make a lot of changes like that going forward to help people to accessibility needs. 


