### PR TITLE
Updated sweetalert to v11.14.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "sharp": "^0.33.4",
     "simple-statistics": "^7.8.3",
     "stripe": "^15.5.0",
-    "sweetalert2": "^11.6.13",
+    "sweetalert2": "11.14.5",
     "swr": "^2.2.5",
     "tailwind-scrollbar": "^3.1.0",
     "tailwindcss": "3.4.3",


### PR DESCRIPTION
# What kind of change does this PR introduce?

Dependency Update 

# Why was this change needed?

Sweetalert2 was getting flagged by WebStorm. So I thought I'd check it out. Turns out quite the [software](https://www.npmjs.com/package/sweetalert2/v/11.14.5).

Similar stuff has been flagged in OSV and Snyk.

Undesired Behavior
Affecting [sweetalert2](https://security.snyk.io/package/npm/sweetalert2) package, versions >=11.4.9

https://vulners.com/osv/OSV:GHSA-MRR8-V49W-3333


I'd say keep a watch on it. **No need to merge this PR.**
