### PR TITLE
bugfix: Component property needs braces

### DIFF
--- a/apps/frontend/src/components/settings/teams.component.tsx
+++ b/apps/frontend/src/components/settings/teams.component.tsx
@@ -210,7 +210,7 @@ export const TeamsComponent = () => {
                   <Button
                     className={`!bg-customColor3 !h-[24px] border border-customColor21 rounded-[4px] text-[12px] ${interClass}`}
                     onClick={remove(p)}
-                    secondary=true
+                    secondary={true}
                   >
                     <div className="flex justify-center items-center gap-[4px]">
                       <div>


### PR DESCRIPTION
Fix syntax break in 21d5b01f4721f9e37e8625f40d93a304b97dbe4a