### PR TITLE
[FEAT] change dates to the American people #156

### DIFF
--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -27,8 +27,17 @@ import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { groupBy, sortBy } from 'lodash';
 import Image from 'next/image';
 import { extend } from 'dayjs';
+import { isUSCitizen } from './helpers/isuscitizen.utils';
 extend(isSameOrAfter);
 extend(isSameOrBefore);
+
+const convertTimeFormatBasedOnLocality = (time: number) => {
+  if (isUSCitizen()) {
+    return `${time === 12 ? 12 : time%12}:00 ${time >= 12 ? "PM" : "AM"}`
+  } else {
+    return `${time}:00`
+  }
+}
 
 export const days = [
   'Monday',
@@ -91,7 +100,7 @@ export const DayView = () => {
               .startOf('day')
               .add(option[0].time, 'minute')
               .local()
-              .format('HH:mm')}
+              .format(isUSCitizen() ? "hh:mm A": "HH:mm")}
           </div>
           <div
             key={option[0].time}
@@ -140,7 +149,8 @@ export const WeekView = () => {
           {hours.map((hour) => (
             <Fragment key={hour}>
               <div className="p-2 pr-4 bg-secondary text-center items-center justify-center flex">
-                {hour.toString().padStart(2, '0')}:00
+                {/* {hour.toString().padStart(2, '0')}:00 */}
+                {convertTimeFormatBasedOnLocality(hour)}
               </div>
               {days.map((day, indexDay) => (
                 <Fragment key={`${day}-${hour}`}>

--- a/apps/frontend/src/components/launches/filters.tsx
+++ b/apps/frontend/src/components/launches/filters.tsx
@@ -3,6 +3,7 @@ import { useCalendar } from '@gitroom/frontend/components/launches/calendar.cont
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import { useCallback } from 'react';
+import { isUSCitizen } from './helpers/isuscitizen.utils';
 
 export const Filters = () => {
   const week = useCalendar();
@@ -12,30 +13,30 @@ export const Filters = () => {
           .year(week.currentYear)
           .isoWeek(week.currentWeek)
           .day(week.currentDay)
-          .format('DD/MM/YYYY')
+          .format(isUSCitizen() ? 'MM/DD/YYYY' :'DD/MM/YYYY')
       : week.display === 'week'
       ? dayjs()
           .year(week.currentYear)
           .isoWeek(week.currentWeek)
           .startOf('isoWeek')
-          .format('DD/MM/YYYY') +
+          .format(isUSCitizen() ? 'MM/DD/YYYY' :'DD/MM/YYYY') +
         ' - ' +
         dayjs()
           .year(week.currentYear)
           .isoWeek(week.currentWeek)
           .endOf('isoWeek')
-          .format('DD/MM/YYYY')
+          .format(isUSCitizen() ? 'MM/DD/YYYY' :'DD/MM/YYYY')
       : dayjs()
           .year(week.currentYear)
           .month(week.currentMonth)
           .startOf('month')
-          .format('DD/MM/YYYY') +
+          .format(isUSCitizen() ? 'MM/DD/YYYY' :'DD/MM/YYYY') +
         ' - ' +
         dayjs()
           .year(week.currentYear)
           .month(week.currentMonth)
           .endOf('month')
-          .format('DD/MM/YYYY');
+          .format(isUSCitizen() ? 'MM/DD/YYYY' :'DD/MM/YYYY');
 
   const setDay = useCallback(() => {
     week.setFilters({

--- a/apps/frontend/src/components/launches/helpers/date.picker.tsx
+++ b/apps/frontend/src/components/launches/helpers/date.picker.tsx
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { Calendar, TimeInput } from '@mantine/dates';
 import { useClickOutside } from '@mantine/hooks';
 import { Button } from '@gitroom/react/form/button';
+import { isUSCitizen } from './isuscitizen.utils';
 
 export const DatePicker: FC<{
   date: dayjs.Dayjs;
@@ -39,7 +40,7 @@ export const DatePicker: FC<{
       onClick={changeShow}
       ref={ref}
     >
-      <div className="cursor-pointer">{date.format('DD/MM/YYYY HH:mm')}</div>
+      <div className="cursor-pointer">{date.format(isUSCitizen() ? 'MM/DD/YYYY hh:mm A' : 'DD/MM/YYYY HH:mm')}</div>
       <div className="cursor-pointer">
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/apps/frontend/src/components/launches/helpers/isuscitizen.utils.tsx
+++ b/apps/frontend/src/components/launches/helpers/isuscitizen.utils.tsx
@@ -1,0 +1,5 @@
+
+export const isUSCitizen = () => {
+    const userLanguage = navigator.language || navigator.languages[0];
+    return userLanguage.startsWith('en-US')
+}


### PR DESCRIPTION
# What kind of change does this PR introduce?
It finds out the users preferred language and displays the time and date based on that

# Why was this change needed?
The change needed was that the American people weren't able to understand the dates in the original format

Please link to related issues when possible, and explain WHY you changed things, not WHAT you changed.
This solves the issue #156
I added a utility function that checks the current preference the user requires, and change the format of the displayed dates in the dayjs library based on it)

# Other information:
None

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
