### PR TITLE
feat: LinkedIn - move to v2 API calls, drop the advertising API requirement

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -19,7 +19,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   identifier = 'linkedin';
   name = 'LinkedIn';
   isBetweenSteps = false;
-  scopes = ['openid', 'profile', 'w_member_social', 'r_basicprofile'];
+  scopes = ['openid', 'profile', 'w_member_social'];
   refreshWait = true;
 
   async refreshToken(refresh_token: string): Promise<AuthTokenDetails> {
@@ -42,19 +42,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       })
     ).json();
 
-    const { vanityName } = await (
-      await this.fetch('https://api.linkedin.com/v2/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
-
-    const {
-      name,
-      sub: id,
-      picture,
-    } = await (
+    const userinfo = await (
       await this.fetch('https://api.linkedin.com/v2/userinfo', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -63,13 +51,13 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     ).json();
 
     return {
-      id,
+      id: userinfo.sub,
       accessToken,
       refreshToken,
       expiresIn: expires_in,
-      name,
-      picture,
-      username: vanityName,
+      name: userinfo.name,
+      picture: userinfo.picture,
+      username: userinfo.name,
     };
   }
 
@@ -122,11 +110,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
 
     this.checkScopes(this.scopes, scope);
 
-    const {
-      name,
-      sub: id,
-      picture,
-    } = await (
+    const userinfo = await (
       await this.fetch('https://api.linkedin.com/v2/userinfo', {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -134,22 +118,14 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       })
     ).json();
 
-    const { vanityName } = await (
-      await this.fetch('https://api.linkedin.com/v2/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
-
     return {
-      id,
+      id: userinfo.sub,
       accessToken,
       refreshToken,
       expiresIn,
-      name,
-      picture,
-      username: vanityName,
+      name: userinfo.name,
+      picture: userinfo.picture,
+      username: userinfo.name,
     };
   }
 


### PR DESCRIPTION
The LinkedIn Advertising API requirement is challenging, because it requires manual review and approval of the app by LinkedIn. 

The only reason for the LinkedIn Advertising API is to be able to read r_basicprofile - which is typically used to view other people's profiles. Postiz only needs to view the currently logged in user, and accessing /v2/userinfo is a better way of doing this, ad /v2/me is a legacy API call. 

This change removes the calls to /v2/me, and just uses the /v2/userinfo call, which means we can drop the LinkedIn Advertising API requirement - making it much easier for users to add LinkedIn support in postiz (including me!).

I have tested this on my own LinkedIn account, and posting is working just fine.

I see that there is a company() function, but I don't see this actually being used at the moment. 

I originally raised #428 to discuss this, but I think a PR would be easier to discuss. 