### PR TITLE
feat(analytics): make analytics optional for self-hosted installations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,7 @@ STRIPE_SIGNING_KEY_CONNECT=""
 # Developer Settings
 NX_ADD_PLUGINS=false
 IS_GENERAL="true" # required for now
+
+# Analytics Configuration
+ENABLE_PLAUSIBLE=false  # Set to "true" to enable Plausible analytics
+ENABLE_POSTHOG=false    # Set to "true" to enable PostHog analytics

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -17,7 +17,10 @@ import UtmSaver from '@gitroom/helpers/utils/utm.saver';
 const chakra = Chakra_Petch({ weight: '400', subsets: ['latin'] });
 
 export default async function AppLayout({ children }: { children: ReactNode }) {
-  const Plausible = !!process.env.STRIPE_PUBLISHABLE_KEY
+  const enablePlausible = process.env.ENABLE_PLAUSIBLE === 'true';
+  const enablePosthog = process.env.ENABLE_POSTHOG === 'true';
+  
+  const Plausible = (!!process.env.STRIPE_PUBLISHABLE_KEY && enablePlausible)
     ? PlausibleProvider
     : Fragment;
 
@@ -38,6 +41,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           billingEnabled={!!process.env.STRIPE_PUBLISHABLE_KEY}
+          analyticsEnabled={enablePlausible || enablePosthog}
           discordUrl={process.env.NEXT_PUBLIC_DISCORD_SUPPORT!}
           frontEndUrl={process.env.FRONTEND_URL!}
           isGeneral={!!process.env.IS_GENERAL}
@@ -49,6 +53,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
             <PHProvider
               phkey={process.env.NEXT_PUBLIC_POSTHOG_KEY}
               host={process.env.NEXT_PUBLIC_POSTHOG_HOST}
+              enabled={enablePosthog}
             >
               <UtmSaver />
               <LayoutContext>{children}</LayoutContext>

--- a/libraries/helpers/src/utils/use.fire.events.ts
+++ b/libraries/helpers/src/utils/use.fire.events.ts
@@ -5,14 +5,14 @@ import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { useUser } from '@gitroom/frontend/components/layout/user.context';
 
 export const useFireEvents = () => {
-  const { billingEnabled } = useVariables();
+  const { billingEnabled, analyticsEnabled } = useVariables();
   const plausible = usePlausible();
   const posthog = usePostHog();
   const user = useUser();
 
   return useCallback(
     (name: string, props?: any) => {
-      if (!billingEnabled) {
+      if (!billingEnabled || !analyticsEnabled) {
         return;
       }
 
@@ -23,6 +23,6 @@ export const useFireEvents = () => {
       posthog.capture(name, props);
       plausible(name, { props });
     },
-    [user]
+    [user, analyticsEnabled]
   );
 };

--- a/libraries/react-shared-libraries/src/helpers/posthog.tsx
+++ b/libraries/react-shared-libraries/src/helpers/posthog.tsx
@@ -8,9 +8,10 @@ export const PHProvider: FC<{
   children: ReactNode;
   phkey?: string;
   host?: string;
-}> = ({ children, phkey, host }) => {
+  enabled?: boolean;
+}> = ({ children, phkey, host, enabled = false }) => {
   useEffect(() => {
-    if (!phkey || !host) {
+    if (!enabled || !phkey || !host) {
       return;
     }
 
@@ -19,9 +20,9 @@ export const PHProvider: FC<{
       person_profiles: 'identified_only',
       capture_pageview: false, // Disable automatic pageview capture, as we capture manually
     });
-  }, []);
+  }, [enabled]);
 
-  if (!phkey || !host) {
+  if (!enabled || !phkey || !host) {
     return <>{children}</>;
   }
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;

--- a/libraries/react-shared-libraries/src/helpers/variable.context.tsx
+++ b/libraries/react-shared-libraries/src/helpers/variable.context.tsx
@@ -11,6 +11,7 @@ interface VariableContextInterface {
   backendUrl: string;
   discordUrl: string;
   uploadDirectory: string;
+  analyticsEnabled: boolean;
 }
 const VariableContext = createContext({
   billingEnabled: false,


### PR DESCRIPTION
#427

# What kind of change does this PR introduce?

Feature - Makes analytics optional for self-hosted installations by introducing environment variable controls.

# Why was this change needed?

Self-hosted users are typically more privacy-conscious and may not want analytics tracking enabled by default. Additionally, the analytics data being collected wasn't accessible to self-hosted users, making the feature unnecessary for their installations.
This change gives users more control over their privacy settings and aligns better with the expectations of self-hosted users who prefer to have explicit control over tracking and analytics.


# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
