### PR TITLE
Added max length validation in user registration, company name and password which solve unhandled error in backend

### DIFF
--- a/libraries/nestjs-libraries/src/dtos/auth/create.org.user.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/auth/create.org.user.dto.ts
@@ -1,29 +1,31 @@
-import {IsDefined, IsEmail, IsString, MinLength, ValidateIf} from "class-validator";
+import {IsDefined, IsEmail, IsString, MaxLength, MinLength, ValidateIf} from "class-validator";
 import {Provider} from '@prisma/client';
 
 export class CreateOrgUserDto {
-    @IsString()
-    @MinLength(3)
-    @IsDefined()
-    @ValidateIf(o => !o.providerToken)
-    password: string;
+  @IsString()
+  @MinLength(3)
+  @MaxLength(64)
+  @IsDefined()
+  @ValidateIf((o) => !o.providerToken)
+  password: string;
 
-    @IsString()
-    @IsDefined()
-    provider: Provider;
+  @IsString()
+  @IsDefined()
+  provider: Provider;
 
-    @IsString()
-    @IsDefined()
-    @ValidateIf(o => !o.password)
-    providerToken: string;
+  @IsString()
+  @IsDefined()
+  @ValidateIf((o) => !o.password)
+  providerToken: string;
 
-    @IsEmail()
-    @IsDefined()
-    @ValidateIf(o => !o.providerToken)
-    email: string;
+  @IsEmail()
+  @IsDefined()
+  @ValidateIf((o) => !o.providerToken)
+  email: string;
 
-    @IsString()
-    @IsDefined()
-    @MinLength(3)
-    company: string;
+  @IsString()
+  @IsDefined()
+  @MinLength(3)
+  @MaxLength(128)
+  company: string;
 }


### PR DESCRIPTION


# What kind of change does this PR introduce?

Bug Fix: Resolves issues with excessive input lengths for password and company name during user registration.
Use 64 characters for passwords and 128 characters for company names. This strikes a balance between practicality, security, and efficiency.

![Screenshot from 2024-12-22 00-10-38](https://github.com/user-attachments/assets/f6640df9-743b-4af9-8eb7-e2d7b345b8a2)


# Why was this change needed?

Related Issues:
#493 
#494 

Both issues stemmed from the absence of well-defined input length restrictions for the password and company fields during the user registration process.

# Other information:
Enforced a maximum character limit for password and company fields:
Password: Max 64 characters.
Company Name: Max 128 characters.
Future plans: Extend similar validation rules to other input fields across the application.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X ] I checked that there were not similar issues or PRs already open for this.
- [ X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added maximum length validation for password (64 characters) and company name (128 characters) fields in the user creation process.
  
- **Style**
	- Improved formatting of validation decorators for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->