### PR TITLE
feat: implement tiktok upload provider

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.upload.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.upload.provider.ts
@@ -1,0 +1,65 @@
+import {
+  AuthTokenDetails,
+  PostDetails,
+  PostResponse,
+  SocialProvider,
+} from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import dayjs from 'dayjs';
+import {
+  BadBody,
+  SocialAbstract,
+} from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import { TikTokDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/tiktok.dto';
+import { timer } from '@gitroom/helpers/utils/timer';
+import { Integration } from '@prisma/client';
+import { TiktokProvider } from './tiktok.provider';
+
+export class TiktokUploadProvider extends TiktokProvider {
+  override identifier = 'tiktok-upload';
+  override name = 'Tiktok Upload';
+
+  override async post(
+    id: string,
+    accessToken: string,
+    postDetails: PostDetails<TikTokDto>[],
+    integration: Integration
+  ): Promise<PostResponse[]> {
+    const [firstPost, ...comments] = postDetails;
+
+    const {
+      data: { publish_id },
+    } = await (
+      await this.fetch(
+        'https://open.tiktokapis.com/v2/post/publish/inbox/video/init/',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json; charset=UTF-8',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({
+            source_info: {
+              source: 'PULL_FROM_URL',
+              video_url: firstPost?.media?.[0]?.url!,
+            },
+          }),
+        }
+      )
+    ).json();
+
+    const { url, id: videoId } = await this.uploadedVideoSuccess(
+      integration.profile!,
+      publish_id,
+      accessToken
+    );
+
+    return [
+      {
+        id: firstPost.id,
+        releaseURL: url,
+        postId: String(videoId),
+        status: 'success',
+      },
+    ];
+  }
+}


### PR DESCRIPTION
# What kind of change does this PR introduce?

This PR adds a TikTok provider variant which is based on [TikTok's Video Upload API](https://developers.tiktok.com/doc/content-posting-api-reference-upload-video).

# Why was this change needed?

The current TikTok provider is based on the [Direct Post API](https://developers.tiktok.com/doc/content-posting-api-reference-direct-post). The way to extend this and enable TikTok Draft Uploads is by introducing a new TikTok provider variant.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for TikTok video uploads through a new provider
	- Implemented functionality to upload videos to TikTok platform using access tokens and post details
	- Enables automatic video publishing with detailed response tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->