### PR TITLE
Added support for different database provider 

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,9 +14,9 @@ ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN apk add --no-cache \
-	caddy \
-	bash=5.2.21-r0 \
-	supervisor=4.2.5-r4
+    caddy \
+    bash=5.2.21-r0 \
+    supervisor=4.2.5-r4
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ EXPOSE 3000
 EXPOSE 4200
 EXPOSE 5000
 
-COPY var/docker/entrypoint.sh /app/entrypoint.sh
+COPY var/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY var/docker/supervisord.conf /etc/supervisord.conf
 COPY var/docker/supervisord /app/supervisord_available_configs/
 COPY var/docker/Caddyfile /app/Caddyfile
@@ -35,19 +35,23 @@ VOLUME /uploads
 
 LABEL org.opencontainers.image.source=https://github.com/gitroomhq/postiz-app
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+# Make the entrypoint script executable
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Builder image
 FROM base AS devcontainer
 
 RUN apk add --no-cache \
-	pkgconfig \
-	gcc \
-	pixman-dev \
-	cairo-dev \
-	pango-dev \
-	make \
-	build-base
+    pkgconfig \
+    gcc \
+    pixman-dev \
+    cairo-dev \
+    pango-dev \
+    make \
+    build-base
 
 COPY nx.json tsconfig.base.json package.json package-lock.json build.plugins.js /app/
 COPY apps /app/apps/

--- a/var/docker/entrypoint.sh
+++ b/var/docker/entrypoint.sh
@@ -2,19 +2,34 @@
 
 set -o xtrace
 
+# Determine the provider based on the DATABASE_URL
+if [[ "$DATABASE_URL" == mysql://* ]]; then
+  provider="mysql"
+elif [[ "$DATABASE_URL" == postgresql://* ]]; then
+  provider="postgresql"
+elif [[ "$DATABASE_URL" == mariadb://* ]]; then
+  provider="mariadb"
+else
+  echo "Unsupported database provider in DATABASE_URL"
+  exit 1
+fi
+
+# Update the datasource provider in the schema.prisma file
+sed -i "s/provider = \".*\"/provider = \"$provider\"/" ./libraries/nestjs-libraries/src/database/prisma/schema.prisma
+
 if [[ "$SKIP_CONFIG_CHECK" != "true" ]]; then
-	echo "Entrypoint: Copying /config/postiz.env into /app/.env"
+  echo "Entrypoint: Copying /config/postiz.env into /app/.env"
 
-	if [ ! -f /config/postiz.env ]; then
-		echo "Entrypoint: WARNING: No postiz.env file found in /config/postiz.env"
-	fi
+  if [ ! -f /config/postiz.env ]; then
+    echo "Entrypoint: WARNING: No postiz.env file found in /config/postiz.env"
+  fi
 
-	cp -vf /config/postiz.env /app/.env
+  cp -vf /config/postiz.env /app/.env
 fi
 
 if [[ "$POSTIZ_APPS" -eq "" ]]; then
-	echo "Entrypoint: POSTIZ_APPS is not set, starting everything!"
-	POSTIZ_APPS="frontend workers cron backend"
+  echo "Entrypoint: POSTIZ_APPS is not set, starting everything!"
+  POSTIZ_APPS="frontend workers cron backend"
 fi
 
 echo "Entrypoint: Running database migrations"
@@ -23,24 +38,24 @@ npm run prisma-db-push
 mkdir -p /etc/supervisor.d/
 
 if [[ "$INTERNAL_PROXY_ENABLED" != "false" ]]; then
-	echo "Entrypoint: Starting internal proxy"
-	cp -vf /app/supervisord_available_configs/caddy.conf /etc/supervisor.d/
+  echo "Entrypoint: Starting internal proxy"
+  cp -vf /app/supervisord_available_configs/caddy.conf /etc/supervisor.d/
 fi
 
 if [[ "$POSTIZ_APPS" == *"frontend"* ]]; then
-	ln -sf /app/supervisord_available_configs/frontend.conf /etc/supervisor.d/
+  ln -sf /app/supervisord_available_configs/frontend.conf /etc/supervisor.d/
 fi
 
 if [[ $POSTIZ_APPS == *"workers"* ]]; then
-	ln -sf /app/supervisord_available_configs/workers.conf /etc/supervisor.d/
+  ln -sf /app/supervisord_available_configs/workers.conf /etc/supervisor.d/
 fi
 
 if [[ $POSTIZ_APPS == *"cron"* ]]; then
-	ln -sf /app/supervisord_available_configs/cron.conf /etc/supervisor.d/
+  ln -sf /app/supervisord_available_configs/cron.conf /etc/supervisor.d/
 fi
 
 if [[ $POSTIZ_APPS == *"backend"* ]]; then
-	ln -sf /app/supervisord_available_configs/backend.conf /etc/supervisor.d/
+  ln -sf /app/supervisord_available_configs/backend.conf /etc/supervisor.d/
 fi
 
 /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
# What kind of change does this PR introduce?
Database support for different providers

eg: Bug fix, feature, docs update, ...

# Why was this change needed?
Application was not able to automatically adjust itself to different provider based on the "DATABASE" string, it was hardcoded, if someone wants to use mariadb they may need to pull the image, get inside the image and change the provider. It would have been a lot better if it can automatically set the provider in prisma

Please link to related issues when possible, and explain WHY you changed things, not WHAT you changed.

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). 
I discussed with the fellow Develop relations, since they already had mysql/mariadb and they didn't want to spin up a new PostgreSQL they thought it was a much better idea, they were already doing image modification in order to support mariadb as provider

Any plans for the future, etc?
I also want to add the guideline in docs how to choose different database and add some sample docker-compose file with different database

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfile development configuration
	- Modified entrypoint script to dynamically set database provider based on environment variable
	- Improved script consistency and error handling for database configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->