### PR TITLE
Support for "Announcement" channels in Discord

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
@@ -117,7 +117,7 @@ export class DiscordProvider extends SocialAbstract implements SocialProvider {
     ).json();
 
     return list
-      .filter((p: any) => p.type === 0 || p.type === 15)
+      .filter((p: any) => p.type === 0 || p.type === 5 || p.type === 15)
       .map((p: any) => ({
         id: String(p.id),
         name: p.name,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Allow the Discord provider to post in "GUILD_ANNOUNCEMENT" text channels, also known as announcement channels.

# Why was this change needed?

This PR was made due to my issue #582.

# Other information:

If Discord were to change the API, either by deprecating or altering the ID for the "GUILD_ANNOUNCEMENT" channel type, it could break overnight. However, that's somewhat hard to believe since the channel has been part of Discord for quite some time.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced Discord channel filtering to include additional channel types in the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->