### PR TITLE
added environment port setting in backend

### DIFF
--- a/var/docker/supervisord/backend.conf
+++ b/var/docker/supervisord/backend.conf
@@ -7,3 +7,4 @@ redirect_stderr=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 startsecs=10
+environment=PORT=3000


### PR DESCRIPTION
# What kind of change does this PR introduce?
Bug fix 


# Why was this change needed?

 #632
The backend was defaulting to PORT=8080 on Railway, causing a misconfiguration issue. This PR updates backend.conf to set PORT=3000, ensuring proper deployment explicitly.


# Other information:
No breaking changes are introduced.


# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x ] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
