### PR TITLE
Commented out Bluesky alt text line

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -192,7 +192,7 @@ export class BlueskyProvider extends SocialAbstract implements SocialProvider {
                 $type: 'app.bsky.embed.images',
                 images: images.map((p) => ({
                   // can be an array up to 4 values
-                  alt: 'image', // the alt text
+                  // alt: 'image', // the alt text - commented this out for now until there is a way to set this from within Postiz
                   image: p.data.blob,
                 })),
               },


### PR DESCRIPTION
Commented out the Bluesky alt text line for now until there is a way to set this from within Postiz.

# What kind of change does this PR introduce?
Bug fix 

# Why was this change needed?
Current code assigns alt text 'image' to every uploaded image. Presence of alt text adds bars/empty space above and below the posted image and when the image is clicked on the word 'image' is visible at the lower left. Absence of alt text fixes this problem. There does not seem to be a way to edit/disable the alt text from within Postiz so have commented it out for now (commented out rather than deleted as I presume this feature might be implemented at some point).

# Other information:


# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily removed the default alternative text for images in posts in preparation for a future, dynamic description feature. This update maintains overall image display and embedding behavior without affecting user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->