### PR TITLE
Add link field in Pinterest component

### DIFF
--- a/apps/frontend/src/components/launches/providers/pinterest/pinterest.provider.tsx
+++ b/apps/frontend/src/components/launches/providers/pinterest/pinterest.provider.tsx
@@ -11,6 +11,7 @@ const PinterestSettings: FC = () => {
   return (
     <div className="flex flex-col">
       <Input label={'Title'} {...register('title')} />
+      <Input label={'Link'} {...register('link')} />
       <PinterestBoard {...register('board')} />
       <ColorPicker
         label="Select Pin Color"


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature

# Why was this change needed?

Closes https://github.com/gitroomhq/postiz-app/issues/434

# Other information:

Link handling logic [already exists](https://github.com/gitroomhq/postiz-app/blob/main/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts#L223), it was just missing the frontend part.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Link" input field to the Pinterest settings form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->