### PR TITLE
(fix) Make Caddyfile use /uploads/ as default root but variable UPLOAD_DIRECTORY when set

### DIFF
--- a/var/docker/Caddyfile
+++ b/var/docker/Caddyfile
@@ -4,7 +4,7 @@
 	}
 
 	handle_path /uploads/* {
-		root * /uploads/
+		root * {$UPLOAD_DIRECTORY:/uploads/}
 		file_server
 	}
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

It improves the handling of the Caddyfile to catch user errors when setting the `UPLOAD_DIRECTORY` to a local path.
Without this change, users will have to change the Caddyfile manually.
This way, nothing needs to be done, except set the `UPLOAD_DIRECTORY` variable when Caddy gets started.

# Why was this change needed?

Because there is/was no documentation for this "issue" and why document more when you can improve and make it prevent user erros.

# Other information:

None

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
