### PR TITLE
Fix LinkedIn OAuth scope format to use plus signs instead of spaces

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -99,7 +99,7 @@ export class LinkedinPageProvider
       process.env.LINKEDIN_CLIENT_ID
     }&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin-page`
-    )}&state=${state}&scope=${encodeURIComponent(this.scopes.join(' '))}`;
+    )}&state=${state}&scope=${this.scopes.join('+')}`;
     return {
       url,
       codeVerifier,

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -87,7 +87,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       process.env.LINKEDIN_CLIENT_ID
     }&prompt=none&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin`
-    )}&state=${state}&scope=${encodeURIComponent(this.scopes.join(' '))}`;
+    )}&state=${state}&scope=${this.scopes.join('+')}`;
     return {
       url,
       codeVerifier,


### PR DESCRIPTION
Here's the filled template for your PR:

# What kind of change does this PR introduce?  
**Bug fix**  

# Why was this change needed?  
LinkedIn made an undocumented API change to their OAuth scope parameter format, requiring scopes to be joined with plus signs (`+`) instead of URL-encoded spaces. This was causing authentication issues with the LinkedIn OAuth flow. The change ensures compatibility with LinkedIn's current API requirements by updating the scope formatting in both `LinkedinProvider.generateAuthUrl()` and `LinkedinPageProvider.generateAuthUrl()` to match the expected format (e.g., `scope=openid+profile+w_member_social+email`).  [source](https://stackoverflow.com/a/78855286)

# Other information:  
This change was prompted by observed authentication failures in production. While LinkedIn's API documentation wasn't updated, testing confirmed the new format is required for successful OAuth flows. No breaking changes are expected as this only modifies the internal scope parameter formatting.  

# Checklist:  
Put a "X" in the boxes below to indicate you have followed the checklist;  

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.  
- [X] I checked that there were not similar issues or PRs already open for this.  
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LinkedIn OAuth integration to ensure correct formatting of authorization URL scopes, enhancing compatibility with LinkedIn authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->