### PR TITLE
feat(short-linking): make Dub provider configurable for self-hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,3 +100,8 @@ POSTIZ_OAUTH_USERINFO_URL="https://authentik.example.com/application/o/userinfo"
 POSTIZ_OAUTH_CLIENT_ID=""
 POSTIZ_OAUTH_CLIENT_SECRET=""
 # POSTIZ_OAUTH_SCOPE="openid profile email" # default values
+
+# Short Link Service Settings
+# DUB_TOKEN="" # Your self-hosted Dub API token
+# DUB_API_ENDPOINT="https://api.dub.co" # Your self-hosted Dub API endpoint
+# DUB_SHORT_LINK_DOMAIN="dub.sh" # Your self-hosted Dub domain

--- a/libraries/nestjs-libraries/src/short-linking/providers/dub.ts
+++ b/libraries/nestjs-libraries/src/short-linking/providers/dub.ts
@@ -1,20 +1,23 @@
 import { ShortLinking } from '@gitroom/nestjs-libraries/short-linking/short-linking.interface';
 
-const options = {
+const DUB_API_ENDPOINT = process.env.DUB_API_ENDPOINT || 'https://api.dub.co';
+const DUB_SHORT_LINK_DOMAIN = process.env.DUB_SHORT_LINK_DOMAIN || 'dub.sh';
+
+const getOptions = () => ({
   headers: {
     Authorization: `Bearer ${process.env.DUB_TOKEN}`,
     'Content-Type': 'application/json',
   },
-};
+});
 
 export class Dub implements ShortLinking {
-  shortLinkDomain = 'dub.sh';
+  shortLinkDomain = DUB_SHORT_LINK_DOMAIN;
 
   async linksStatistics(links: string[]) {
     return Promise.all(
       links.map(async (link) => {
         const response = await (
-          await fetch(`https://api.dub.co/links/info?domain=${this.shortLinkDomain}&key=${link.split('/').pop()}`, options)
+          await fetch(`${DUB_API_ENDPOINT}/links/info?domain=${this.shortLinkDomain}&key=${link.split('/').pop()}`, getOptions())
         ).json();
 
         return {
@@ -29,8 +32,8 @@ export class Dub implements ShortLinking {
   async convertLinkToShortLink(id: string, link: string) {
     return (
       await (
-        await fetch(`https://api.dub.co/links`, {
-          ...options,
+        await fetch(`${DUB_API_ENDPOINT}/links`, {
+          ...getOptions(),
           method: 'POST',
           body: JSON.stringify({
             url: link,
@@ -46,8 +49,8 @@ export class Dub implements ShortLinking {
     return await (
       await (
         await fetch(
-          `https://api.dub.co/links/info?domain=${shortLink}`,
-          options
+          `${DUB_API_ENDPOINT}/links/info?domain=${shortLink}`,
+          getOptions()
         )
       ).json()
     ).url;
@@ -60,8 +63,8 @@ export class Dub implements ShortLinking {
   ): Promise<{ short: string; original: string; clicks: string }[]> {
     const response = await (
       await fetch(
-        `https://api.dub.co/links?tenantId=${id}&page=${page}&pageSize=100`,
-        options
+        `${DUB_API_ENDPOINT}/links?tenantId=${id}&page=${page}&pageSize=100`,
+        getOptions()
       )
     ).json();
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature to support selfhosted dub shortlink service.

# Why was this change needed?

Implements #749 

# Other information:

Maybe in the future someone can add the vercel team id `TEAM_ID_VERCEL`, but for now this seems like a small change to support custom short url domains.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new placeholders and descriptions for short link service environment variables in the configuration example file.

- **Refactor**
  - Improved configuration flexibility for the short link service, allowing runtime customization of API endpoint, domain, and authorization token via environment variables. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->