### PR TITLE
Fix: Handle docker build trying to access empty plugin directory not being created by docker copy

### DIFF
--- a/build.plugins.js
+++ b/build.plugins.js
@@ -1,4 +1,4 @@
-const { readdirSync, statSync, writeFileSync } = require('fs');
+const { readdirSync, statSync, writeFileSync, existsSync } = require('fs');
 const { join } = require('path');
 
 function isNonEmptyFolder(folderPath) {
@@ -18,6 +18,10 @@ function isNonEmptyFolder(folderPath) {
 // Function to get all non-empty folders
 function getNonEmptyFolders(rootFolder) {
   const result = [];
+  if (!existsSync(rootFolder)) {
+    return result;
+  }
+
   const items = readdirSync(rootFolder);
 
   items.forEach((item) => {


### PR DESCRIPTION
# What kind of change does this PR introduce?

CI Fix

# Why was this change needed?

I guess some versions of docker don't create empty directories when doing a COPY statement
So local building (was trying to test #703 with act) was failing

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I checked that there were not similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
