### PR TITLE
Fix typo in logout text

### DIFF
--- a/apps/frontend/src/components/layout/logout.component.tsx
+++ b/apps/frontend/src/components/layout/logout.component.tsx
@@ -34,7 +34,7 @@ export const LogoutComponent = () => {
   return (
     <div className="text-red-400 cursor-pointer" onClick={logout}>
       {t('logout_from', 'Logout from')}
-      {isGeneral ? 'Postiz' : 'Gitroom'}
+      {isGeneral ? ' Postiz' : ' Gitroom'}
     </div>
   );
 };


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The text has a missing space:

![image](https://github.com/user-attachments/assets/2e860bd9-d817-4bb8-a499-a5581ddf9bd0)


Please link to related issues when possible, and explain WHY you changed things, not WHAT you changed.

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved visual spacing in the logout message by adding a space before the brand name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->