### PR TITLE
feat: Add rich link previews on posts to Bluesky, LinkedIn, and Facebook

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -8,9 +8,63 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
 import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import axios from 'axios';
+import { JSDOM } from 'jsdom';
 
-export class FacebookProvider extends SocialAbstract implements SocialProvider {
-  identifier = 'facebook';
+interface OpenGraphData {
+  title?: string;
+  description?: string;
+  image?: string;
+}
+
+async function fetchOpenGraphData(url: string): Promise<OpenGraphData> {
+  try {
+    const response = await axios.get(url, { 
+      timeout: 10000,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; PostizBot/1.0; +https://postiz.com/)'
+      }
+    });
+    const html = response.data;
+    const dom = new JSDOM(html);
+    const document = dom.window.document;
+
+    const getMetaContent = (property: string) => {
+      const element = document.querySelector(`meta[property="${property}"]`) || 
+                    document.querySelector(`meta[name="${property}"]`);
+      return element?.getAttribute('content') || '';
+    };
+
+    const ogImage = getMetaContent('og:image');
+    let imageUrl = ogImage;
+    
+    // Handle relative URLs for images
+    if (ogImage && !ogImage.startsWith('http')) {
+      try {
+        imageUrl = new URL(ogImage, url).href;
+      } catch {
+        imageUrl = ogImage; // Fallback to original if URL parsing fails
+      }
+    }
+
+    return {
+      title: getMetaContent('og:title') || getMetaContent('title') || 
+             document.querySelector('title')?.textContent || '',
+      description: getMetaContent('og:description') || getMetaContent('description') || '',
+      image: imageUrl || ''
+    };
+  } catch (error) {
+    console.error('Error fetching OpenGraph data:', error);
+    return {};
+  }
+}
+
+function extractUrls(text: string): string[] {
+  const urlRegex = /https?:\/\/[^\s/$.?#].[^\s]*/g;
+  return text.match(urlRegex) || [];
+}
+
+export class FacebookProvider extends SocialAbstract implements SocialProvider {  identifier = 'facebook';
   name = 'Facebook Page';
   isBetweenSteps = true;
   scopes = [
@@ -176,7 +230,18 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
 
     let finalId = '';
     let finalUrl = '';
+    
+    // Enhanced URL detection for Facebook link previews
+    const urls = extractUrls(firstPost.message);
+    const hasUrls = urls.length > 0;
+    
+    // Log URL detection for debugging
+    if (hasUrls) {
+      console.log('Facebook: Detected URLs for potential link preview:', urls);
+    }
+    
     if ((firstPost?.media?.[0]?.url?.indexOf('mp4') || -2) > -1) {
+      // Handle video posts
       const {
         id: videoId,
         permalink_url,
@@ -202,6 +267,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       finalUrl = 'https://www.facebook.com/reel/' + videoId;
       finalId = videoId;
     } else {
+      // Handle image/text posts with potential link previews
       const uploadPhotos = !firstPost?.media?.length
         ? []
         : await Promise.all(
@@ -227,6 +293,36 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
             })
           );
 
+      // Enhanced post payload for better link preview handling
+      const postPayload: any = {
+        message: firstPost.message,
+        published: true,
+      };
+
+      // Add media if available
+      if (uploadPhotos?.length) {
+        postPayload.attached_media = uploadPhotos;
+      }
+      // CRITICAL: Use Facebook's 'link' parameter for URL previews
+      else if (hasUrls && !uploadPhotos?.length) {
+        console.log('Facebook: Detected URL for link preview:', urls[0]);
+        
+        // Remove URL from message text since we're putting it in the link field
+        const messageWithoutUrl = firstPost.message.replace(urls[0], '').trim();
+        
+        postPayload.message = messageWithoutUrl;
+        postPayload.link = urls[0]; // Facebook's link parameter for previews
+        
+        console.log('Facebook: Using link parameter for preview generation');
+        
+        // Optional: Pre-warm Facebook's scraper by hitting their debug API
+        try {
+          await this.prewarmFacebookScraper(urls[0], accessToken);
+        } catch (error) {
+          console.log('Facebook: Could not prewarm scraper, proceeding with normal post');
+        }
+      }
+
       const {
         id: postId,
         permalink_url,
@@ -239,11 +335,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({
-              ...(uploadPhotos?.length ? { attached_media: uploadPhotos } : {}),
-              message: firstPost.message,
-              published: true,
-            }),
+            body: JSON.stringify(postPayload),
           },
           'finalize upload'
         )
@@ -253,6 +345,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       finalId = postId;
     }
 
+    // Handle comment posts
     const postsArray = [];
     for (const comment of comments) {
       const data = await (
@@ -281,6 +374,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
         status: 'success',
       });
     }
+
     return [
       {
         id: firstPost.id,
@@ -290,6 +384,26 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       },
       ...postsArray,
     ];
+  }
+
+  // Optional: Pre-warm Facebook's link scraper for better preview generation
+  private async prewarmFacebookScraper(url: string, accessToken: string): Promise<void> {
+    try {
+      // Use Facebook's debug API to pre-scrape the URL
+      await this.fetch(
+        `https://graph.facebook.com/v20.0/?id=${encodeURIComponent(url)}&scrape=true&access_token=${accessToken}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      console.log('Facebook: Successfully prewarmed scraper for URL:', url);
+    } catch (error) {
+      console.log('Facebook: Prewarm scraper failed (this is optional):', error);
+      // Don't throw - this is just an optimization
+    }
   }
 
   async analytics(


### PR DESCRIPTION
Uses OpenGraph scraping for LinkedIn, API link parameter for Facebook, and app.bsky.embed.external for Bluesky. Adds PostizBot user agents to metadata fetching to make it distinguishable to firewalls.

# What kind of change does this PR introduce?

Before, Postiz posts to Bluesky, LinkedIn, and Facebook would appear without dedicated link previews. They'd appear as plain URLs, without the headline/description/thumbnail you'd get if you posted to the platforms directly. This PR adds custom code for those three platforms to deliver those URLs as distinct objects in the ways their various APIs prefer. Now there are link previews!

# Why was this change needed?

I was frustrated seeing these subpar posts appear on social networks important to my website, and it was preventing me from pushing to adopt Postiz for our organization — knowing that the output wasn't as good in this particular way as Buffer or other competitors. (This PR also fixes #667.)

# Other information:

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rich link previews in Bluesky, Facebook, and LinkedIn posts when sharing URLs without media attachments. Posts now display enhanced previews with title, description, and thumbnail where available.
  - Improved Facebook link preview reliability by prewarming Facebook's scraper for shared links.
  - Enhanced LinkedIn Page and personal post workflows to include OpenGraph-based link previews and thumbnails.

- **Bug Fixes**
  - Improved error handling to ensure posts are still created even if link metadata or thumbnails cannot be fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->