### PR TITLE
Use name field instead of username for Threads provider

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -147,15 +147,15 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
   }
 
   async fetchPageInformation(accessToken: string) {
-    const { id, username, threads_profile_picture_url, access_token } = await (
+    const { id, name, username, threads_profile_picture_url, access_token } = await (
       await this.fetch(
-        `https://graph.threads.net/v1.0/me?fields=id,username,threads_profile_picture_url&access_token=${accessToken}`
+        `https://graph.threads.net/v1.0/me?fields=id,name,username,threads_profile_picture_url&access_token=${accessToken}`
       )
     ).json();
 
     return {
       id,
-      name: username,
+      name,
       access_token,
       picture: { data: { url: threads_profile_picture_url } },
       username,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Uses the `name` field from Threads Graph API instead of using the `username` field

# Why was this change needed?

Keeps the display name consistent with other channels.

# Other information:

I made a post in Discord about it.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
