### PR TITLE
fix: Video dimensions and alt tag for Bluesky

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "md5": "^2.3.0",
     "mime": "^3.0.0",
     "mime-types": "^2.1.35",
+    "mp4box": "^2.1.0",
     "multer": "^1.4.5-lts.1",
     "music-metadata": "^7.14.0",
     "nestjs-command": "^3.1.4",


### PR DESCRIPTION
# What kind of change does this PR introduce?

This is a bug fix, currently video posts to bluesky do not include dimension information or alt tags.  To accomplish this the mp4box library was added and a helper function to grab dimensions was added in the bluesky provider code.

# Why was this change needed?

This is somewhat related to #885 which was this same issue, but specific to images.  I believe the image issue was resolved but videos lacked the same fix.  This adds the dimension information to correct the display issue with videos as well as adding in the alt tag to improve accessibility and compliance.

# Other information:

Did not discuss but posted some rambling train of thought in #885 

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
