### PR TITLE
fix: add alt text support to Mastodon media uploads

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -109,9 +109,12 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
     );
   }
 
-  async uploadFile(instanceUrl: string, fileUrl: string, accessToken: string) {
+  async uploadFile(instanceUrl: string, fileUrl: string, accessToken: string, description?: string) {
     const form = new FormData();
     form.append('file', await fetch(fileUrl).then((r) => r.blob()));
+    if (description) {
+      form.append('description', description);
+    }
     const media = await (
       await this.fetch(`${instanceUrl}/api/v1/media`, {
         method: 'POST',
@@ -135,7 +138,7 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
     for (const getPost of postDetails) {
       const uploadFiles = await Promise.all(
         getPost?.media?.map((media) =>
-          this.uploadFile(url, media.path, accessToken)
+          this.uploadFile(url, media.path, accessToken, media.alt)
         ) || []
       );
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Adds support for alt text in Mastodon media uploads by passing the description parameter to Mastodon's API

# Why was this change needed?

https://github.com/gitroomhq/postiz-app/issues/948

# Other information:

Not yet

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
