### PR TITLE
feat: add minute randomization option for post scheduling

### DIFF
--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { FC, useCallback, useRef, useState } from 'react';
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { AddEditModalProps } from '@gitroom/frontend/components/new-launch/add.edit.modal';
 import clsx from 'clsx';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
@@ -28,6 +28,7 @@ import { CopilotPopup } from '@copilotkit/react-ui';
 import { DummyCodeComponent } from '@gitroom/frontend/components/new-launch/dummy.code.component';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
 import { Checkbox } from '@gitroom/react/form/checkbox';
+import dayjs from 'dayjs';
 
 function countCharacters(text: string, type: string): number {
   if (type !== 'x') {
@@ -133,6 +134,26 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
     },
     [integrations]
   );
+
+  const didRandomizeInitially = useRef(false);
+  useEffect(() => {
+    if (dummy) return;
+    if (!randomizeMinute) return;
+    if (existingData.integration) return;
+    if (!date) return;
+    if (didRandomizeInitially.current) return;
+    if (date.minute() !== 0) return;
+
+    const base = date.clone().second(0).millisecond(0);
+    let minute = Math.floor(Math.random() * 60);
+    const now = dayjs();
+    if (base.isSame(now, 'hour')) {
+      const minNowPlus1 = now.minute() + 1;
+      if (minute < minNowPlus1) minute = Math.min(minNowPlus1, 59);
+    }
+    setDate(base.minute(minute));
+    didRandomizeInitially.current = true;
+  }, [randomizeMinute, date, dummy, existingData, setDate]);
 
   const schedule = useCallback(
     (type: 'draft' | 'now' | 'schedule') => async () => {
@@ -335,7 +356,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
                   <RepeatComponent repeat={repeater} onChange={setRepeater} />
                 )}
                 <DatePicker onChange={setDate} date={date} />
-                {!dummy && (
+                {!dummy && !existingData.integration && (
                   <div className="ms-[12px] flex items-center gap-[6px]">
                     <Checkbox
                       disableForm={true}

--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -27,6 +27,7 @@ import { SelectCustomer } from '@gitroom/frontend/components/launches/select.cus
 import { CopilotPopup } from '@copilotkit/react-ui';
 import { DummyCodeComponent } from '@gitroom/frontend/components/new-launch/dummy.code.component';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
+import { Checkbox } from '@gitroom/react/form/checkbox';
 
 function countCharacters(text: string, type: string): number {
   if (type !== 'x') {
@@ -41,6 +42,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
   const ref = useRef(null);
   const existingData = useExistingData();
   const [loading, setLoading] = useState(false);
+  const [randomizeMinute, setRandomizeMinute] = useState(true);
   const toaster = useToaster();
   const modal = useModals();
 
@@ -233,6 +235,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
         ...(repeater ? { inter: repeater } : {}),
         tags,
         shortLink,
+        randomizeMinute,
         date: date.utc().format('YYYY-MM-DDTHH:mm:ss'),
         posts: checkAllValid.map((post: any) => ({
           integration: {
@@ -332,6 +335,33 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
                   <RepeatComponent repeat={repeater} onChange={setRepeater} />
                 )}
                 <DatePicker onChange={setDate} date={date} />
+                {!dummy && (
+                  <div className="ms-[12px] flex items-center gap-[6px]">
+                    <Checkbox
+                      disableForm={true}
+                      name="randomizeMinute"
+                      checked={randomizeMinute}
+                      onChange={(e: any) => {
+                        const next = e?.target ? !!e.target.value : !!e;
+                        setRandomizeMinute(next);
+                        const base = date.clone().second(0).millisecond(0);
+                        if (next) {
+                          const currentMinute = base.minute();
+                          let minute = Math.floor(Math.random() * 60);
+                          let tries = 0;
+                          while (minute === currentMinute && tries < 5) {
+                            minute = Math.floor(Math.random() * 60);
+                            tries++;
+                          }
+                          setDate(base.minute(minute));
+                        } else {
+                          setDate(base.minute(0));
+                        }
+                      }}
+                    />
+                    <div>{t('randomize_minute', 'Randomize minute')}</div>
+                  </div>
+                )}
               </div>
             </TopTitle>
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -888,7 +888,7 @@ export class PostsService {
                 ...toPost.list.map((l) => ({
                   id: '',
                   content: l.post,
-                  image: [] as any[],
+                  image: [],
                 })),
                 {
                   id: '',

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -663,31 +663,6 @@ export class PostsService {
 
   async createPost(orgId: string, body: CreatePostDto): Promise<any[]> {
     const postList = [];
-
-    const targetDateForAll =
-      body.type === 'now'
-        ? dayjs().format('YYYY-MM-DDTHH:mm:00')
-        : body.date;
-
-    const shouldRandomize = body.type === 'schedule' && (body.randomizeMinute ?? true);
-
-    const scheduleDateToUse = (() => {
-      const input = dayjs.utc(targetDateForAll).second(0).millisecond(0);
-      if (shouldRandomize) {
-        if (input.minute() === 0) {
-          let minute = Math.floor(Math.random() * 60);
-          const now = dayjs.utc();
-          if (input.isSame(now, 'hour')) {
-            const minNowPlus1 = now.minute() + 1;
-            if (minute < minNowPlus1) minute = Math.min(minNowPlus1, 59);
-          }
-          return input.minute(minute).format('YYYY-MM-DDTHH:mm:00');
-        }
-        return input.format('YYYY-MM-DDTHH:mm:00');
-      }
-      return input.format('YYYY-MM-DDTHH:mm:00');
-    })();
-
     for (const post of body.posts) {
       const messages = (post.value || []).map((p) => p.content);
       const updateContent = !body.shortLink
@@ -703,7 +678,9 @@ export class PostsService {
         await this._postRepository.createOrUpdatePost(
           body.type,
           orgId,
-          scheduleDateToUse,
+          body.type === 'now'
+            ? dayjs().format('YYYY-MM-DDTHH:mm:00')
+            : body.date,
           post,
           body.tags,
           body.inter
@@ -720,7 +697,7 @@ export class PostsService {
 
       if (
         body.type === 'now' ||
-        (body.type === 'schedule' && dayjs(posts[0].publishDate).isAfter(dayjs()))
+        (body.type === 'schedule' && dayjs(body.date).isAfter(dayjs()))
       ) {
         this._workerServiceProducer.emit('post', {
           id: posts[0].id,
@@ -918,7 +895,7 @@ export class PostsService {
                   content: `Check out the full story here:\n${
                     body.postId || body.url
                   }`,
-                  image: [] as any[],
+                  image: [],
                 },
               ],
             },

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -674,7 +674,6 @@ export class PostsService {
     const scheduleDateToUse = (() => {
       const input = dayjs.utc(targetDateForAll).second(0).millisecond(0);
       if (shouldRandomize) {
-        // Only randomize if the incoming minute is exactly 0; otherwise respect chosen minute
         if (input.minute() === 0) {
           let minute = Math.floor(Math.random() * 60);
           const now = dayjs.utc();
@@ -686,8 +685,7 @@ export class PostsService {
         }
         return input.format('YYYY-MM-DDTHH:mm:00');
       }
-      // Not randomizing: clamp to exact hour (minute:00)
-      return input.minute(0).format('YYYY-MM-DDTHH:mm:00');
+      return input.format('YYYY-MM-DDTHH:mm:00');
     })();
 
     for (const post of body.posts) {
@@ -913,14 +911,14 @@ export class PostsService {
                 ...toPost.list.map((l) => ({
                   id: '',
                   content: l.post,
-                  image: [],
+                  image: [] as any[],
                 })),
                 {
                   id: '',
                   content: `Check out the full story here:\n${
                     body.postId || body.url
                   }`,
-                  image: [],
+                  image: [] as any[],
                 },
               ],
             },

--- a/libraries/nestjs-libraries/src/dtos/posts/create.post.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/create.post.dto.ts
@@ -83,6 +83,10 @@ export class CreatePostDto {
   @IsNumber()
   inter?: number;
 
+  @IsOptional()
+  @IsBoolean()
+  randomizeMinute?: boolean;
+
   @IsDefined()
   @IsDateString()
   date: string;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature: Add “Randomize minute” scheduling option (default ON), update CreatePostDto, and wire backend + frontend to support random minute within the selected hour.

<img width="967" height="150" alt="Sans-titre-2025-09-18-0303" src="https://github.com/user-attachments/assets/9236fa94-3057-4b94-be1f-6e6945859b20" />

## Why was this change needed?
- Smoother posting cadence.
- Gives explicit user control to disable randomization when precise minute is needed.
- Keeps system consistent by persisting the final `publishDate` and using it for queue delays.

Key points:
- Frontend:
  - ManageModal: add “Randomize minute” checkbox (default ON).
  - UX:
    - Unchecking immediately clamps the picker to `:00` (visible to user).
    - Rechecking re-randomizes to a different minute.
    - Not showing modal if we're editing.

## Other information
- This is backward compatible for scheduled posting and cron/worker flows (they already rely on `publishDate`).
- This is related to #985 
- This is also my first contribution to open-source!!! Please be nice lol

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (adds random-minute scheduling with a UI toggle, plus DTO).