### PR TITLE
Use tabular nums to prevent layout jitter when changing the date

### DIFF
--- a/apps/frontend/src/components/launches/helpers/date.picker.tsx
+++ b/apps/frontend/src/components/launches/helpers/date.picker.tsx
@@ -38,7 +38,7 @@ export const DatePicker: FC<{
       onClick={changeShow}
       ref={ref}
     >
-      <div className="cursor-pointer">
+      <div className="cursor-pointer tabular-nums">
         {date.format(isUSCitizen() ? 'MM/DD/YYYY hh:mm A' : 'DD/MM/YYYY HH:mm')}
       </div>
       <div className="cursor-pointer">


### PR DESCRIPTION
# What kind of change does this PR introduce?

A small layout annoyance — look how layout "jumps" when you change the date — it's because we're using a font variant where each digit has slightly different width


https://github.com/user-attachments/assets/571afed5-c365-44c9-95d5-bf4c94a0b5f2


# Why was this change needed?

To fix the distracting layout shift while changing the date/time of the scheduled post

# Other information:

Not much to add

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
