### PR TITLE
Fix: Frontend 404 and React warnings

### DIFF
--- a/apps/frontend/src/app/(app)/(site)/page.tsx
+++ b/apps/frontend/src/app/(app)/(site)/page.tsx
@@ -1,0 +1,6 @@
+export default function RootPage() {
+  // This page will never actually render because middleware
+  // redirects to /launches or /analytics before it can load
+  // But having it here prevents Next.js from showing 404
+  return null;
+}

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -34,9 +34,9 @@ const jakartaSans = Plus_Jakarta_Sans({
 
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const allHeaders = headers();
-  const Plausible = !!process.env.STRIPE_PUBLISHABLE_KEY
-    ? PlausibleProvider
-    : Fragment;
+  const isPlausibleEnabled = !!process.env.STRIPE_PUBLISHABLE_KEY;
+  const plausibleDomain = !!process.env.IS_GENERAL ? 'postiz.com' : 'gitroom.com';
+
   return (
     <html>
       <head>
@@ -83,9 +83,19 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
             <HtmlComponent />
             <ToltScript />
             <FacebookComponent />
-            <Plausible
-              domain={!!process.env.IS_GENERAL ? 'postiz.com' : 'gitroom.com'}
-            >
+            {isPlausibleEnabled ? (
+              <PlausibleProvider domain={plausibleDomain}>
+                <PHProvider
+                  phkey={process.env.NEXT_PUBLIC_POSTHOG_KEY}
+                  host={process.env.NEXT_PUBLIC_POSTHOG_HOST}
+                >
+                  <LayoutContext>
+                    <UtmSaver />
+                    {children}
+                  </LayoutContext>
+                </PHProvider>
+              </PlausibleProvider>
+            ) : (
               <PHProvider
                 phkey={process.env.NEXT_PUBLIC_POSTHOG_KEY}
                 host={process.env.NEXT_PUBLIC_POSTHOG_HOST}
@@ -95,7 +105,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
                   {children}
                 </LayoutContext>
               </PHProvider>
-            </Plausible>
+            )}
           </SentryComponent>
         </VariableContextComponent>
       </body>


### PR DESCRIPTION
## 🐛 Fix: Frontend 404 and React warnings

### Problem
1. Accessing root path (`/`) shows 404 before middleware redirect executes
2. React Fragment prop warning when Plausible analytics is disabled

### Solution
1. Add empty `page.tsx` at `(app)/(site)/` route to prevent 404 flash
2. Use conditional rendering for PlausibleProvider instead of dynamic component assignment

### Changes
- `apps/frontend/src/app/(app)/(site)/page.tsx` (NEW FILE)
- `apps/frontend/src/app/(app)/layout.tsx` (refactored lines 35-114)

### Testing
- [x] Root path loads without 404
- [x] No React Fragment warnings in console
- [x] Existing OAuth login flows still work
- [x] All frontend tests pass

### Breaking Changes
None - pure improvements, backward compatible

### Why This Matters
- Improves initial user experience by eliminating 404 flash
- Removes console warnings that can confuse developers
- Better aligns with Next.js App Router best practices