### PR TITLE
fix: Twitter/X thread finisher posting with HTML tags

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -405,7 +405,11 @@ export class XProvider extends SocialAbstract implements SocialProvider {
         await this.runInConcurrent(async () =>
           client.v2.tweet({
             text:
-              postDetails?.[0]?.settings?.thread_finisher! +
+              stripHtmlValidation(
+                'normal',
+                postDetails?.[0]?.settings?.thread_finisher!,
+                true
+              ) +
               '\n' +
               ids[0].releaseURL,
             reply: { in_reply_to_tweet_id: ids[ids.length - 1].postId },


### PR DESCRIPTION
Previously, Twitter/X was posting thread finisher (message ending signature) with HTML <p> elements hardcoded into the message text. This was because the thread_finisher content was being used directly without HTML stripping.

This fix wraps the thread_finisher text with stripHtmlValidation() to remove HTML tags and convert them to plain text, consistent with how other platforms (Bluesky, Threads, Mastodon) handle this feature.

Changes:
- Added stripHtmlValidation() call for thread_finisher in X provider
- Now matches the implementation pattern used in Bluesky provider
- Ensures thread finisher posts plain text instead of HTML markup

The working set up is live and I've used it. Here's the proof of it working fine:

<https://x.com/Meysamazing/status/1987512859727729141?s=20>

fixes #1013 

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
