### PR TITLE
fix: stop inserting slash into OAuth url

### DIFF
--- a/apps/backend/src/services/auth/providers/oauth.provider.ts
+++ b/apps/backend/src/services/auth/providers/oauth.provider.ts
@@ -56,7 +56,7 @@ export class OauthProvider implements ProvidersInterface {
       redirect_uri: `${this.frontendUrl}/settings`,
     });
 
-    return `${this.authUrl}/?${params.toString()}`;
+    return `${this.authUrl}?${params.toString()}`;
   }
 
   async getToken(code: string): Promise<string> {


### PR DESCRIPTION
# What kind of change does this PR introduce?

This PR is a bug fix. It corrects the malformed OAuth authorization URL and resolves the post-login redirect loop when using Pocket-ID (and potentially other generic OIDC providers).

# Why was this change needed?

When using the generic OIDC provider configuration, Postiz generated an incorrect authorization URL containing an extra slash before the query string:

```
/authorize/?client_id=...
```

instead of:

```
/authorize?client_id=...
```

This causes a 404 error when redirecting to the OIDC provider for authentication.

#877 

# Other information:

-

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
