### PR TITLE
Fix integration failures due to profile picture 403 errors

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -104,11 +104,23 @@ export class IntegrationService {
     timezone?: number,
     customInstanceDetails?: string
   ) {
-    const uploadedPicture = picture
-      ? picture?.indexOf('imagedelivery.net') > -1
-        ? picture
-        : await this.storage.uploadSimple(picture)
-      : undefined;
+    let uploadedPicture = undefined;
+
+    if (picture) {
+      if (picture?.indexOf('imagedelivery.net') > -1) {
+        uploadedPicture = picture;
+      } else {
+        try {
+          uploadedPicture = await this.storage.uploadSimple(picture);
+        } catch (error) {
+          console.error(
+            'Failed to upload profile picture, continuing without it:',
+            error.message || error
+          );
+          // uploadedPicture remains undefined - integration continues
+        }
+      }
+    }
 
     return this._integrationRepository.createOrUpdateIntegration(
       additionalSettings,


### PR DESCRIPTION
## Problem

When connecting LinkedIn Pages, LinkedIn Personal, Discord, and other platforms, the integration fails completely with a 403 Forbidden error when trying to download profile pictures from Cloudflare-protected CDNs.

This affects users who are not using Cloudflare R2 storage, preventing them from connecting these platforms at all.

Related issues:
- Fixes #972
- Related to #447

## Root Cause

The `IntegrationService.createOrUpdateIntegration` method in `integration.service.ts` attempts to download and store profile pictures using `this.storage.uploadSimple(picture)`. When the profile picture URL is protected by Cloudflare (as is the case with LinkedIn and Discord), this request fails with a 403 Forbidden error, causing the entire integration process to crash.

## Solution

This PR wraps the profile picture upload in a try/catch block to gracefully handle 403 errors and other download failures. When the profile picture cannot be downloaded, the integration continues without the picture instead of failing completely.

### Changes Made

Modified `libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts`:

- Wrapped `this.storage.uploadSimple(picture)` in a try/catch block
- Added error logging for debugging purposes
- Allows `uploadedPicture` to remain `undefined` when download fails
- Integration continues successfully without profile picture

## Benefits

1. **Fixes LinkedIn Page integration** for users without Cloudflare R2
2. **Fixes LinkedIn Personal integration** for users without Cloudflare R2
3. **Fixes Discord integration** for users without Cloudflare R2
4. **Graceful degradation** - users can still connect platforms, just without profile pictures
5. **No breaking changes** - existing integrations continue to work as before
6. **Better error visibility** - logs the failure for debugging instead of silently crashing

## Testing

Tested locally with LinkedIn Page integration:
- Previously: Integration failed with "Could not add provider"
- After fix: Integration succeeds, account connected without profile picture

## Alternative Solutions Considered

1. **Cloudflare R2 setup** - Works but requires additional infrastructure setup
2. **Retry logic** - Doesn't solve the Cloudflare protection issue
3. **Proxy server** - Adds unnecessary complexity

This solution provides the best user experience by allowing integrations to succeed while maintaining simplicity.