### PR TITLE
fix(ci): Force fresh base image in Docker builds

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -53,6 +53,8 @@ jobs:
             -f Dockerfile.dev \
             -t ghcr.io/gitroomhq/postiz-app:${{ env.CONTAINERVER }}-${{ matrix.arch }} \
             --build-arg NEXT_PUBLIC_VERSION=${{ env.NEXT_PUBLIC_VERSION }} \
+            --pull \
+            --no-cache \
             --provenance=false --sbom=false \
             --output "type=registry,name=ghcr.io/gitroomhq/postiz-app:${{ env.CONTAINERVER }}-${{ matrix.arch }}" .
 


### PR DESCRIPTION
## Summary

This PR fixes the Docker build workflow to ensure published images contain the correct Node.js version as specified in `Dockerfile.dev`.

## Problem

As reported in #1079, the published Docker images contain Node.js v20.18.x instead of the expected v22.20.x specified in `Dockerfile.dev`. This causes Prisma 7 compatibility failures:

```
Prisma only supports Node.js versions 20.19+, 22.12+, 24.0+.
Please upgrade your Node.js version.
```

## Root Cause

The Docker buildx command was potentially reusing cached base image layers from previous builds, resulting in older Node.js versions being included in the final image.

## Solution

Added two flags to the `docker buildx build` command:
- `--pull`: Always pull the latest base image (`node:22.20-alpine`)
- `--no-cache`: Disable build cache to ensure fresh builds

## Trade-offs

- **Build time**: Builds will take longer since no caching is used
- **Reliability**: Images will always contain the exact dependencies specified in `Dockerfile.dev`

For a project like Postiz where dependency version accuracy is critical (Prisma/Node compatibility), reliability should take precedence over build speed.

## Testing

After this change is merged and a new release is tagged, verify the published image contains the correct Node.js version:

```bash
docker run --rm ghcr.io/gitroomhq/postiz-app:latest node --version
# Should output: v22.20.x (or newer)
```

Fixes #1079