### PR TITLE
fix(auth): fix public API middleware user role structure

### DIFF
--- a/apps/backend/src/services/auth/public.auth.middleware.ts
+++ b/apps/backend/src/services/auth/public.auth.middleware.ts
@@ -28,7 +28,7 @@ export class PublicAuthMiddleware implements NestMiddleware {
       }
 
       // @ts-ignore
-      req.org = { ...org, users: [{ users: { role: 'SUPERADMIN' } }] };
+      req.org = { ...org, users: [{ role: 'SUPERADMIN' }] };
     } catch (err) {
       throw new HttpForbiddenException();
     }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The public API authentication middleware (`public.auth.middleware.ts`) was setting an incorrect nested structure for the mock user role:

// Before (incorrect)
`req.org = { ...org, users: [{ users: { role: 'SUPERADMIN' } }] };`

// After (correct)
`req.org = { ...org, users: [{ role: 'SUPERADMIN' }] };`
The permissions guard at `permissions.guard.ts:46` accesses `org.users[0].role` to check user permissions. With the incorrect nested structure, this returned `undefined` instead of `'SUPERADMIN'`, causing `@CheckPolicies` decorated endpoints to fail when `STRIPE_PUBLISHABLE_KEY` is configured.

This bug was masked in environments without Stripe because the permissions service automatically grants all permissions when `STRIPE_PUBLISHABLE_KEY` is not set.

The fix aligns the structure with what `getOrgsByUserId` returns: `users: [{ disabled, role }]`.

# Other information:

This was discovered while adding new public API endpoints for integration management. The existing public API endpoints with `@CheckPolicies` (like `POST /public/v1/posts`) were also affected by this bug in production environments with Stripe enabled.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.