### PR TITLE
fix: pass bearer token when downloading profile pictures

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -103,11 +103,21 @@ export class IntegrationService {
     timezone?: number,
     customInstanceDetails?: string
   ) {
-    const uploadedPicture = picture
-      ? picture?.indexOf('imagedelivery.net') > -1
-        ? picture
-        : await this.storage.uploadSimple(picture)
-      : undefined;
+    let uploadedPicture: string | undefined;
+    try {
+      uploadedPicture = picture
+        ? picture?.indexOf('imagedelivery.net') > -1
+          ? picture
+          : await this.storage.uploadSimple(picture, {
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            })
+        : undefined;
+    } catch (e: any) {
+      console.warn(`Failed to upload profile picture: ${e.message}`);
+      uploadedPicture = undefined;
+    }
 
     return this._integrationRepository.createOrUpdateIntegration(
       additionalSettings,

--- a/libraries/nestjs-libraries/src/upload/cloudflare.storage.ts
+++ b/libraries/nestjs-libraries/src/upload/cloudflare.storage.ts
@@ -4,7 +4,7 @@ import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import mime from 'mime-types';
 // @ts-ignore
 import { getExtension } from 'mime';
-import { IUploadProvider } from './upload.interface';
+import { IUploadProvider, UploadSimpleOptions } from './upload.interface';
 import axios from 'axios';
 
 class CloudflareStorage implements IUploadProvider {
@@ -57,8 +57,14 @@ class CloudflareStorage implements IUploadProvider {
     );
   }
 
-  async uploadSimple(path: string) {
-    const loadImage = await fetch(path);
+  async uploadSimple(path: string, options?: UploadSimpleOptions) {
+    const loadImage = await fetch(path, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; Postiz/1.0)',
+        Accept: 'image/*',
+        ...options?.headers,
+      },
+    });
     const contentType =
       loadImage?.headers?.get('content-type') ||
       loadImage?.headers?.get('Content-Type');

--- a/libraries/nestjs-libraries/src/upload/local.storage.ts
+++ b/libraries/nestjs-libraries/src/upload/local.storage.ts
@@ -1,4 +1,4 @@
-import { IUploadProvider } from './upload.interface';
+import { IUploadProvider, UploadSimpleOptions } from './upload.interface';
 import { mkdirSync, unlink, writeFileSync } from 'fs';
 // @ts-ignore
 import mime from 'mime';
@@ -8,8 +8,15 @@ import axios from 'axios';
 export class LocalStorage implements IUploadProvider {
   constructor(private uploadDirectory: string) {}
 
-  async uploadSimple(path: string) {
-    const loadImage = await axios.get(path, { responseType: 'arraybuffer' });
+  async uploadSimple(path: string, options?: UploadSimpleOptions) {
+    const loadImage = await axios.get(path, {
+      responseType: 'arraybuffer',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; Postiz/1.0)',
+        Accept: 'image/*',
+        ...options?.headers,
+      },
+    });
     const contentType =
       loadImage?.headers?.['content-type'] ||
       loadImage?.headers?.['Content-Type'];

--- a/libraries/nestjs-libraries/src/upload/upload.interface.ts
+++ b/libraries/nestjs-libraries/src/upload/upload.interface.ts
@@ -1,5 +1,9 @@
+export interface UploadSimpleOptions {
+  headers?: Record<string, string>;
+}
+
 export interface IUploadProvider {
-  uploadSimple(path: string): Promise<string>;
+  uploadSimple(path: string, options?: UploadSimpleOptions): Promise<string>;
   uploadFile(file: Express.Multer.File): Promise<any>;
   removeFile(filePath: string): Promise<void>;
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

LinkedIn integration fails during OAuth callback because Postiz cannot download the user's profile picture from LinkedIn's CDN. The CDN returns HTTP 403 (Forbidden), causing the entire integration to fail.

**Root cause:** `LocalStorage.uploadSimple()` performs a bare `axios.get(url)` with no headers. LinkedIn's CDN blocks this request because:
- No User-Agent header (axios default is `axios/x.x.x`)
- No Authorization header (Bearer token not passed)
- Server-to-server request detected (non-browser fingerprint)

**Related issue:** Fixes #972

## Solution

Two-part fix:

1. **Pass Bearer token:** Add optional headers parameter to `uploadSimple()` and pass the Authorization header when downloading profile pictures
2. **Graceful fallback:** Wrap picture upload in try-catch so integration succeeds even if picture download fails (user gets placeholder avatar instead)

## Changes

- **`upload.interface.ts`**: Added `UploadSimpleOptions` interface with optional headers
- **`local.storage.ts`**: Added browser-like User-Agent and accepts optional headers
- **`cloudflare.storage.ts`**: Same changes for Cloudflare storage provider
- **`integration.service.ts`**: Pass Bearer token, wrap in try-catch for graceful fallback

## Testing

Tested in combination with #1134 using a `deployment` branch on my fork. Successfully added LinkedIn Channel to self-hosted Postiz instance.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR)