### PR TITLE
feat: add WebP image upload support

### DIFF
--- a/apps/frontend/src/components/media/new.uploader.tsx
+++ b/apps/frontend/src/components/media/new.uploader.tsx
@@ -88,7 +88,7 @@ export function useUppyUploader(props: {
         // Expand generic types to specific ones
         const expandedTypes = allowedTypes.flatMap((type) => {
           if (type === 'image/*') {
-            return ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'];
+            return ['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp'];
           }
           if (type === 'video/*') {
             return ['video/mp4', 'video/mpeg'];

--- a/libraries/helpers/src/utils/valid.url.path.ts
+++ b/libraries/helpers/src/utils/valid.url.path.ts
@@ -12,6 +12,7 @@ export class ValidUrlExtension implements ValidatorConstraintInterface {
       !!text?.split?.('?')?.[0].endsWith('.jpg') ||
       !!text?.split?.('?')?.[0].endsWith('.jpeg') ||
       !!text?.split?.('?')?.[0].endsWith('.gif') ||
+      !!text?.split?.('?')?.[0].endsWith('.webp') ||
       !!text?.split?.('?')?.[0].endsWith('.mp4')
     );
   }
@@ -19,7 +20,7 @@ export class ValidUrlExtension implements ValidatorConstraintInterface {
   defaultMessage(args: ValidationArguments) {
     // here you can provide default error message if validation failed
     return (
-      'File must have a valid extension: .png, .jpg, .jpeg, .gif, or .mp4'
+      'File must have a valid extension: .png, .jpg, .jpeg, .gif, .webp, or .mp4'
     );
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature: Add WebP image upload support

# Why was this change needed?

Closes #1055

WebP is a modern, efficient image format that provides smaller file sizes and better quality compared to JPEG or PNG. Users were receiving errors when trying to upload WebP images:

- **Frontend**: `File type "image/webp" is not allowed`
- **API**: `File must have a valid extension: .png, .jpg, .jpeg, .gif, or .mp4`

This PR adds WebP support to both the frontend file uploader and the backend validation.

## Changes Made

### Frontend (`apps/frontend/src/components/media/new.uploader.tsx`)
- Added `image/webp` to the list of expanded MIME types when validating file uploads

### Backend (`libraries/helpers/src/utils/valid.url.path.ts`)
- Added `.webp` extension to the `ValidUrlExtension` validator
- Updated the error message to include `.webp` in the list of valid extensions

# Other information:

This is a straightforward feature addition that aligns Postiz with current web standards. WebP is widely supported by modern browsers and social media platforms.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR).