### PR TITLE
feat: Display user information in settings logout section

### DIFF
--- a/apps/frontend/src/components/layout/settings.component.tsx
+++ b/apps/frontend/src/components/layout/settings.component.tsx
@@ -20,6 +20,7 @@ import clsx from 'clsx';
 import { TeamsComponent } from '@gitroom/frontend/components/settings/teams.component';
 import { useUser } from '@gitroom/frontend/components/layout/user.context';
 import { LogoutComponent } from '@gitroom/frontend/components/layout/logout.component';
+import { UserInfo } from '@gitroom/frontend/components/layout/user-info.component';
 import { useSearchParams } from 'next/navigation';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { PublicComponent } from '@gitroom/frontend/components/public-api/public.component';
@@ -141,7 +142,8 @@ export const SettingsPopup: FC<{
         </div>
         <div>
           {showLogout && (
-            <div className="mt-4">
+            <div className="mt-4 flex flex-col gap-[12px]">
+              <UserInfo />
               <LogoutComponent />
             </div>
           )}

--- a/apps/frontend/src/components/layout/user-info.component.tsx
+++ b/apps/frontend/src/components/layout/user-info.component.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { FC } from 'react';
+import { useUser } from '@gitroom/frontend/components/layout/user.context';
+import clsx from 'clsx';
+
+interface UserInfoProps {
+  compact?: boolean;
+  showEmail?: boolean;
+}
+
+export const UserInfo: FC<UserInfoProps> = ({ compact = false, showEmail = true }) => {
+  const user = useUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const displayName = user.name 
+    ? (user.lastName ? `${user.name} ${user.lastName}` : user.name)
+    : null;
+  
+  const hasName = !!displayName;
+  const hasEmail = !!user.email && showEmail;
+
+  // If nothing to display, return null
+  if (!hasName && !hasEmail) {
+    return null;
+  }
+
+  const avatarSize = compact ? 'w-[32px] h-[32px]' : 'w-[40px] h-[40px]';
+  const textSize = compact ? 'text-[12px]' : 'text-[14px]';
+  const emailSize = compact ? 'text-[10px]' : 'text-[12px]';
+
+  return (
+    <div className={clsx(
+      'flex items-center gap-[12px]',
+      compact ? 'p-[8px]' : 'p-[12px]'
+    )}>
+      
+      {/* Name and Email */}
+      {(hasName || hasEmail) && (
+        <div className="flex flex-col min-w-0 flex-1">
+          {hasName && (
+            <div className={clsx(
+              'font-[500] text-newTextColor truncate',
+              textSize
+            )}>
+              {displayName}
+            </div>
+          )}
+          {hasEmail && (
+            <div className={clsx(
+              'text-textItemBlur truncate',
+              emailSize
+            )}>
+              {user.email}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature: Display logged-in user information (name and email) in the logout section of the settings.

# Why was this change needed?

Users need to see their account information (name and email) in the settings/logout area to confirm which account they're using before logging out. This improves clarity and reduces accidental logouts.

# Other information:

- Added a reusable `UserInfo` component that conditionally displays name and email based on available data
- The component handles missing fields gracefully (shows only what's available)
- Integrated into the settings  above the logout button for better visibility
- The component is designed to be reusable for future use cases

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.