### PR TITLE
BugFix - Reading Mastodon's instance max characters setting

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/mastodon/mastodon.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/mastodon/mastodon.provider.tsx
@@ -11,5 +11,9 @@ export default withProvider({
   CustomPreviewComponent: undefined,
   dto: undefined,
   checkValidity: undefined,
-  maximumCharacters: 500,
+  maximumCharacters: (settings) => {
+    const value = settings?.find((s: any) => s?.title === 'Max characters')?.value;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 500;
+  },
 });

--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -89,6 +89,19 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
       })
     ).json();
 
+    let maxCharacters = 500;
+    try {
+      const instanceInfo = await (
+        await this.fetch(`${url}/api/v1/instance`, {
+          method: 'GET',
+        })
+      ).json();
+      maxCharacters =
+        instanceInfo?.configuration?.statuses?.max_characters ?? 500;
+    } catch {
+      // Keep default maxCharacters = 500 on failure
+    }
+
     return {
       id: personalInformation.id,
       name: personalInformation.display_name || personalInformation.acct,
@@ -97,6 +110,14 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
       expiresIn: dayjs().add(100, 'years').unix() - dayjs().unix(),
       picture: personalInformation?.avatar || '',
       username: personalInformation.username,
+      additionalSettings: [
+        {
+          title: 'Max characters',
+          description: 'Maximum characters per post for this instance',
+          type: 'text' as const,
+          value: maxCharacters,
+        },
+      ],
     };
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug Fix (according to the issue)

# Why was this change needed?

Fixing max length setting for Mastodon posts.

> It is impossible to write a post longer than 500 characters regardless of the Mastodon instance’s limit.  (...) Postiz uses a hardcoded 500-character limit.

Fixes [#1083 ](https://github.com/gitroomhq/postiz-app/issues/1083)

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
