### PR TITLE
feat: enhance webhook functionality for post events

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Injectable,
+  Logger,
   ValidationPipe,
 } from '@nestjs/common';
 import { PostsRepository } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.repository';
@@ -35,6 +36,7 @@ import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
 import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
+import { WebhooksService } from '@gitroom/nestjs-libraries/database/prisma/webhooks/webhooks.service';
 
 type PostWithConditionals = Post & {
   integration?: Integration;
@@ -43,6 +45,7 @@ type PostWithConditionals = Post & {
 
 @Injectable()
 export class PostsService {
+  private readonly logger = new Logger(PostsService.name);
   private storage = UploadFactory.createStorage();
   constructor(
     private _postRepository: PostsRepository,
@@ -52,7 +55,8 @@ export class PostsService {
     private _shortLinkService: ShortLinkService,
     private _openaiService: OpenaiService,
     private _temporalService: TemporalService,
-    private _refreshIntegrationService: RefreshIntegrationService
+    private _refreshIntegrationService: RefreshIntegrationService,
+    private _webhooksService: WebhooksService
   ) {}
 
   searchForMissingThreeHoursPosts() {
@@ -503,6 +507,13 @@ export class PostsService {
   }
 
   async deletePost(orgId: string, group: string) {
+    // fetch post data before soft-delete for webhook payload
+    const postsInGroup = await this._postRepository.getPostsByGroup(
+      orgId,
+      group
+    );
+    const firstPost = postsInGroup?.[0];
+
     const post = await this._postRepository.deletePost(orgId, group);
 
     if (post?.id) {
@@ -528,6 +539,38 @@ export class PostsService {
           } catch (err) {}
         }
       } catch (err) {}
+    }
+
+    // send webhook for post.deleted
+    if (firstPost) {
+      try {
+        const data = {
+          id: firstPost.id,
+          content: firstPost.content,
+          publishDate: firstPost.publishDate,
+          releaseURL: firstPost.releaseURL,
+          state: firstPost.state,
+          integration: firstPost.integration
+            ? {
+                id: firstPost.integration.id,
+                name: firstPost.integration.name,
+                providerIdentifier: firstPost.integration.providerIdentifier,
+                picture: firstPost.integration.picture,
+                type: firstPost.integration.type,
+              }
+            : undefined,
+        };
+        await this._webhooksService.sendPostEvent(
+          orgId,
+          firstPost.integrationId,
+          'post.deleted',
+          data as Record<string, unknown>
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Webhook send failed for post.deleted (postId=${firstPost.id}, orgId=${orgId}): ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
     }
 
     return { error: true };
@@ -634,6 +677,24 @@ export class PostsService {
           orgId,
           posts[0].state
         ).catch((err) => {});
+      }
+
+      // send webhook for post.created or post.updated
+      try {
+        const webhookData = await this.getPostByForWebhookId(posts[0].id);
+        const data = Array.isArray(webhookData) ? webhookData[0] : webhookData;
+        if (data) {
+          await this._webhooksService.sendPostEvent(
+            orgId,
+            post.integration.id,
+            body.type === 'update' ? 'post.updated' : 'post.created',
+            data as Record<string, unknown>
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Webhook send failed for ${body.type === 'update' ? 'post.updated' : 'post.created'} (postId=${posts[0].id}, orgId=${orgId}): ${err instanceof Error ? err.message : String(err)}`
+        );
       }
 
       Sentry.metrics.count('post_created', 1);

--- a/libraries/nestjs-libraries/src/database/prisma/webhooks/webhooks.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/webhooks/webhooks.service.ts
@@ -1,9 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { WebhooksRepository } from '@gitroom/nestjs-libraries/database/prisma/webhooks/webhooks.repository';
 import { WebhooksDto } from '@gitroom/nestjs-libraries/dtos/webhooks/webhooks.dto';
 
+export type PostWebhookEvent =
+  | 'post.created'
+  | 'post.updated'
+  | 'post.deleted'
+  | 'post.published'
+  | 'post.failed';
+
 @Injectable()
 export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+
   constructor(private _webhooksRepository: WebhooksRepository) {}
 
   getTotal(orgId: string) {
@@ -20,5 +29,81 @@ export class WebhooksService {
 
   deleteWebhook(orgId: string, id: string) {
     return this._webhooksRepository.deleteWebhook(orgId, id);
+  }
+
+  /**
+   * Sends a post-related event to all configured webhooks for the org that match the integration.
+   * Webhooks with no integrations configured receive all events; otherwise only when integrationId matches.
+   */
+  async sendPostEvent(
+    orgId: string,
+    integrationId: string,
+    event: PostWebhookEvent,
+    data: Record<string, unknown>
+  ): Promise<void> {
+    let webhooks: Awaited<ReturnType<WebhooksRepository['getWebhooks']>>;
+    try {
+      webhooks = (await this._webhooksRepository.getWebhooks(orgId)).filter(
+        (w) =>
+          w.integrations.length === 0 ||
+          w.integrations.some((i) => i.integration.id === integrationId)
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to load webhooks for org ${orgId}: ${err instanceof Error ? err.message : String(err)}`,
+        err instanceof Error ? err.stack : undefined
+      );
+      return;
+    }
+
+    if (webhooks.length === 0) {
+      this.logger.debug(
+        `No webhooks configured for org ${orgId} (integration ${integrationId}), event ${event}`
+      );
+      return;
+    }
+
+    const payload = {
+      event,
+      timestamp: new Date().toISOString(),
+      data,
+    };
+
+    this.logger.log(
+      `Sending webhook event ${event} to ${webhooks.length} endpoint(s) (orgId=${orgId})`
+    );
+
+    const results = await Promise.allSettled(
+      webhooks.map((webhook: (typeof webhooks)[number]) =>
+        fetch(webhook.url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+      )
+    );
+
+    results.forEach(
+      (result: PromiseSettledResult<Response>, index: number) => {
+        const webhook = webhooks[index];
+        if (result.status === 'fulfilled') {
+          const res = result.value;
+          if (!res.ok) {
+            this.logger.warn(
+              `Webhook ${webhook.url} returned ${res.status} for event ${event} (orgId=${orgId}, webhookId=${webhook.id})`
+            );
+          } else {
+            this.logger.debug(
+              `Webhook delivered to ${webhook.url} for event ${event} (webhookId=${webhook.id})`
+            );
+          }
+        } else {
+          this.logger.error(
+            `Webhook failed for ${webhook.url} (event=${event}, orgId=${orgId}, webhookId=${webhook.id}): ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+            result.reason instanceof Error ? result.reason.stack : undefined
+          );
+        }
+      }
+    );
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

**Feature** – Webhooks are sent for all post lifecycle events (create, update, delete, publish, fail) to configured webhook URLs.

---

# Why was this change needed?

Users and automation tools (N8N, Make, Zapier, etc.) need to react when something happens to a post in Postiz. The app already has a Webhooks UI and says users can “get notified when something happens in Postiz via an HTTP request,” but post events were not consistently sent.

This change:

- Sends a **standardized webhook** for: `post.created`, `post.updated`, `post.deleted`, `post.published`, and `post.failed`.
- Uses a single payload shape: `{ event, timestamp, data }` so integrations can rely on one contract.
- Keeps delivery **fire-and-forget** with error handling and logging so failed or slow endpoints don’t block create/update/delete/publish flows.

*(Link the GitHub issue here if you created one, e.g. “Fixes #123” or “Related to #123.”)*

---

# Other information:

- **Implementation:**  
  - `WebhooksService.sendPostEvent()` loads org webhooks (filtered by integration), POSTs to each URL with the payload, and uses `Promise.allSettled` so one failure doesn’t block others.  
  - PostsService triggers webhooks on create (post.created/updated) and delete (post.deleted).  
  - Post workflow triggers webhooks on success (post.published) and on failure (post.failed), using the internal post id and proper error payload.  
- **Logging:** Errors and non-2xx responses are logged; successful sends can be logged at debug level.  
- **Future:** Optional retries or dead-letter handling could be added later if needed.

---

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.

---