### PR TITLE
Load terms and privacy links from environment variable

### DIFF
--- a/apps/frontend/src/components/auth/register.tsx
+++ b/apps/frontend/src/components/auth/register.tsx
@@ -90,6 +90,16 @@ export function RegisterAfter({
   const t = useT();
   const { isGeneral, genericOauth, neynarClientId, billingEnabled } =
     useVariables();
+  const termsLink =
+    process.env.TERMS_OF_SERVICE_URL &&
+    process.env.TERMS_OF_SERVICE_URL.trim() !== ''
+      ? process.env.TERMS_OF_SERVICE_URL
+      : 'https://postiz.com/terms';
+  const privacyLink =
+    process.env.PRIVACY_POLICY_URL &&
+    process.env.PRIVACY_POLICY_URL.trim() !== ''
+      ? process.env.PRIVACY_POLICY_URL
+      : 'https://postiz.com/privacy';
   const [loading, setLoading] = useState(false);
   const router = useRouter();
   const fireEvents = useFireEvents();
@@ -216,7 +226,7 @@ export function RegisterAfter({
                 )}
                 &nbsp;
                 <a
-                  href={`https://postiz.com/terms`}
+                  href={termsLink}
                   className="underline hover:font-bold"
                   rel="nofollow"
                 >
@@ -225,7 +235,7 @@ export function RegisterAfter({
                 &nbsp;
                 {t('and', 'and')}&nbsp;
                 <a
-                  href={`https://postiz.com/privacy`}
+                  href={privacyLink}
                   rel="nofollow"
                   className="underline hover:font-bold"
                 >

--- a/apps/frontend/src/components/auth/register.tsx
+++ b/apps/frontend/src/components/auth/register.tsx
@@ -91,14 +91,14 @@ export function RegisterAfter({
   const { isGeneral, genericOauth, neynarClientId, billingEnabled } =
     useVariables();
   const termsLink =
-    process.env.TERMS_OF_SERVICE_URL &&
-    process.env.TERMS_OF_SERVICE_URL.trim() !== ''
-      ? process.env.TERMS_OF_SERVICE_URL
+    process.env.NEXT_PUBLIC_TERMS_OF_SERVICE_URL &&
+    process.env.NEXT_PUBLIC_TERMS_OF_SERVICE_URL.trim() !== ''
+      ? process.env.NEXT_PUBLIC_TERMS_OF_SERVICE_URL
       : 'https://postiz.com/terms';
   const privacyLink =
-    process.env.PRIVACY_POLICY_URL &&
-    process.env.PRIVACY_POLICY_URL.trim() !== ''
-      ? process.env.PRIVACY_POLICY_URL
+    process.env.NEXT_PUBLIC_PRIVACY_POLICY_URL &&
+    process.env.NEXT_PUBLIC_PRIVACY_POLICY_URL.trim() !== ''
+      ? process.env.NEXT_PUBLIC_PRIVACY_POLICY_URL
       : 'https://postiz.com/privacy';
   const [loading, setLoading] = useState(false);
   const router = useRouter();


### PR DESCRIPTION
# What kind of change does this PR introduce?

The links to Privacy Policy and Terms of Service shown on the Registration page are now dynamically loaded from the environment variables `PRIVACY_POLICY_URL` and `TERMS_OF_SERVICE_URL`.

# Why was this change needed?

TikTok providers (and possibly) others needs you to provide URLs to Privacy Policy and Terms of Service which have to fulfill the following requirements:
* must be linked on the landing page (registration page) of you app
* must be hosted on a domain which you own (has to be proved by DNS entry)

This is currently impossible for the hardcoded links to https://postiz.com/privacy and https://postiz.com/terms

# Other information:

The problem with the Privacy Policy and Terms of Service URLs has been discussed in issue #835

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
