### PR TITLE
fix: remove incorrect RefreshToken throw from Bluesky provider

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -7,7 +7,6 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import {
   BadBody,
-  RefreshToken,
   SocialAbstract,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import {
@@ -248,14 +247,13 @@ export class BlueskyProvider extends SocialAbstract implements SocialProvider {
       service: body.service,
     });
 
-    try {
-      await agent.login({
-        identifier: body.identifier,
-        password: body.password,
-      });
-    } catch (err) {
-      throw new RefreshToken('bluesky', JSON.stringify(err), {} as BodyInit);
-    }
+    // Re-authenticate using stored credentials
+    // Unlike OAuth providers, Bluesky uses password-based auth so we login fresh each time
+    // If login fails, it's likely due to invalid credentials, not expired tokens
+    await agent.login({
+      identifier: body.identifier,
+      password: body.password,
+    });
 
     return agent;
   }


### PR DESCRIPTION
## Summary

- Removes the `RefreshToken` exception throw from `getAgent()` in the Bluesky provider
- Bluesky uses password-based auth (stored in `customInstanceDetails`), not OAuth tokens
- The `refreshToken()` method returns empty values, so throwing `RefreshToken` caused integrations to disconnect

## Problem

When the Bluesky `getAgent()` method encountered a login error, it threw `RefreshToken`. This triggered the token refresh flow in `RefreshIntegrationService`, which:

1. Called `refreshToken()` on the Bluesky provider
2. Got empty/invalid values back (since Bluesky doesn't implement token refresh)
3. Called `disconnectChannel()` since refresh "failed"

This caused Bluesky integrations to be marked as disconnected even for transient errors.

## Solution

Let login errors propagate naturally instead of wrapping them in `RefreshToken`. This allows upstream code to handle the error appropriately without triggering the token refresh flow that doesn't apply to password-based providers.

## Test plan

- [ ] Connect a Bluesky account and verify posting works
- [ ] Temporarily use invalid credentials and verify the error is handled gracefully (not triggering token refresh)
- [ ] Verify the integration doesn't get disconnected on transient network errors
