### PR TITLE
fix(api): preserve file extension in upload-from-url endpoint

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -29,7 +29,7 @@ import { VideoFunctionDto } from '@gitroom/nestjs-libraries/dtos/videos/video.fu
 import { UploadDto } from '@gitroom/nestjs-libraries/dtos/media/upload.dto';
 import axios from 'axios';
 import { Readable } from 'stream';
-import { lookup } from 'mime-types';
+import { lookup, extension } from 'mime-types';
 import * as Sentry from '@sentry/nestjs';
 
 @ApiTags('Public API')
@@ -73,17 +73,21 @@ export class PublicIntegrationsController {
     });
 
     const buffer = Buffer.from(response.data);
+    const responseMime = response.headers?.['content-type']?.split(';')[0]?.trim();
+    const urlMime = lookup(body?.url?.split?.('?')?.[0]);
+    const mimetype = (urlMime || responseMime || 'image/jpeg') as string;
+    const ext = extension(mimetype) || 'jpg';
 
     const getFile = await this.storage.uploadFile({
       buffer,
-      mimetype: lookup(body?.url?.split?.('?')?.[0]) || 'image/jpeg',
+      mimetype,
       size: buffer.length,
       path: '',
       fieldname: '',
       destination: '',
       stream: new Readable(),
       filename: '',
-      originalname: '',
+      originalname: `upload.${ext}`,
       encoding: '',
     });
 


### PR DESCRIPTION
The upload-from-url endpoint passed an empty originalname to uploadFile(), causing extname('') to return '' and files to be saved without an extension. Derive
  the extension from the response Content-Type header (or URL fallback) so files are stored with the correct extension on disk.                                   
                                                                           
  Fixes gitroomhq/postiz-app#1147

  What kind of change does this PR introduce?

  Bug fix

  Why was this change needed?

  The /public/v1/upload-from-url endpoint constructs a synthetic Multer.File object with originalname: '' before passing it to storage.uploadFile(). Inside
  LocalStorage.uploadFile(), the filename is built using extname(file.originalname) — and extname('') returns an empty string, so files end up saved without any
  extension (e.g. /uploads/2026/02/06/a1b2c3d4 instead of /uploads/2026/02/06/a1b2c3d4.webp). This causes the "Create Post" endpoint to reject the media with a
  validation error requiring a valid extension (.png, .jpg, .jpeg, .gif, .webp, or .mp4).

  The fix derives the file extension from the HTTP response Content-Type header (with a URL-based fallback via mime-types lookup, then a final fallback to
  image/jpeg) and sets originalname to upload.{ext} so the file is saved with the correct extension.

  Other information:

  The direct file upload endpoint (/public/v1/upload) and the internal uploadSimple() method already handle extensions correctly. This bug only affected the
  URL-based upload path in the public API.

  Checklist:

  Put a "X" in the boxes below to indicate you have followed the checklist;

  - I have read the https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md guide.
  - I checked that there were not similar issues or PRs already open for this.
  - This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new
  dependencies in the same PR.