### PR TITLE
feat: Responsive calendar, post editor, analytics & settings (Phases 2-4)

### DIFF
--- a/apps/frontend/src/components/hooks/use-mobile.tsx
+++ b/apps/frontend/src/components/hooks/use-mobile.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook to detect mobile viewport (≤768px)
+ * Returns true when viewport width is 768px or less
+ */
+export function useMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    // Initial check
+    checkMobile();
+
+    // Listen for resize events
+    window.addEventListener('resize', checkMobile);
+
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+    };
+  }, []);
+
+  return isMobile;
+}

--- a/apps/frontend/src/components/launches/time.table.tsx
+++ b/apps/frontend/src/components/launches/time.table.tsx
@@ -128,7 +128,7 @@ export const TimeTable: FC<{
   }, [currentTimes]);
 
   return (
-    <div className="relative w-full max-w-[400px] mx-auto">
+    <div className="relative w-full max-w-[400px] mobile:max-w-full mx-auto mobile:px-[16px]">
       {/* Add Time Slot Section */}
       <div className="bg-newBgColorInner rounded-[12px] p-[20px] border border-newTableBorder">
         <div className="text-[15px] font-semibold mb-[16px] flex items-center gap-[8px]">


### PR DESCRIPTION
## 👋 Hey Postiz team!

Continuing our responsive design work from PR #1223 (Phase 1 - Sidebar + Navigation).

## What this PR does

### Mobile Calendar List View
- **Desktop:** Zero changes — grid calendar works exactly as before
- **Mobile (≤768px):** Replaces the 8-column grid with a vertical list view
  - Posts grouped by day with clear day headers
  - Each post shows time, preview text, platform icons, and status
  - "Today" indicator on current day
  - All post actions accessible (edit, delete, duplicate, stats)
  - Drag-and-drop gracefully disabled on touch (tap-to-edit instead)

### Time Table Fix
- Changed `max-w-[400px]` to responsive with `mobile:max-w-full`

### New Files
- `apps/frontend/src/components/hooks/use-mobile.tsx` — reusable viewport detection hook

### Design Principles
- ✅ Desktop completely untouched
- ✅ Touch-optimized interactions
- ✅ No horizontal scrolling on mobile
- ✅ Tailwind utilities only, no custom CSS

Part of our responsive design contribution series. More phases coming!

*Contributed by the Travelsats team (@travelsatsargentina) 🇦🇷*