### PR TITLE
feat: update MediaDto to allow optional id and transform url

### DIFF
--- a/libraries/nestjs-libraries/src/dtos/media/media.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/media/media.dto.ts
@@ -1,11 +1,13 @@
-import { IsDefined, IsString, IsUrl, ValidateIf, Validate } from 'class-validator';
+import { IsDefined, IsOptional, IsString, IsUrl, ValidateIf, Validate } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ValidUrlExtension, ValidUrlPath } from '@gitroom/helpers/utils/valid.url.path';
 
 export class MediaDto {
+  @IsOptional()
   @IsString()
-  @IsDefined()
-  id: string;
+  id?: string;
 
+  @Transform(({ value, obj }) => value ?? obj?.url)
   @IsString()
   @IsDefined()
   @Validate(ValidUrlPath)


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature: update `MediaDto` to accept `url` as an alias for `path` and make `id` optional. Closes #1225

# Why was this change needed?

Previously, `MediaDto` required both an `id` and a `path`. In practice, callers may only have a public URL, and `updateMedia` already treats `id` as optional when a valid path is present. This PR aligns the DTO with that behavior and broadens the accepted request shapes without breaking existing clients.

- `url` is now accepted as an alias for `path`.
- A `@Transform` copies `url` into `path` when `path` is missing.
- `id` is now optional on `MediaDto`.

So all of these are now valid:

- `{ "id": "xxx", "path": "https://uploads.postiz.com/..." }` (unchanged)
- `{ "id": "xxx", "url": "https://uploads.postiz.com/..." }` (now supported)
- `{ "path": "https://uploads.postiz.com/..." }`
- `{ "url": "https://uploads.postiz.com/..." }`

Existing behavior is preserved: `updateMedia` still calls `getMediaById` only when `!p.path && p.id`, so when a valid `path` (or `url` after transform) is present, `id` is not required.

## Supported request shapes for images

The following payloads are supported for images:

- `{ "image": [{ "id": "xxx", "path": "https://uploads.postiz.com/filename.png" }] }` (upload response format)
- `{ "image": [{ "id": "xxx", "url": "https://uploads.postiz.com/filename.png" }] }`
- `{ "image": [{ "path": "https://uploads.postiz.com/filename.png" }] }`
- `{ "image": [{ "url": "https://uploads.postiz.com/filename.png" }] }`

The URL must still:

- Contain the configured upload domain (e.g. `uploads.postiz.com` when `RESTRICT_UPLOAD_DOMAINS` is set), and
- Use an allowed extension: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.mp4`.

# Other information

This change is backwards compatible and only broadens the accepted request shapes for media while maintaining domain and extension validation.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
