### PR TITLE
feat: disable AI features (chat, MCP) via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ EXTENSION_ID=""
 
 # Misc Settings
 OPENAI_API_KEY=""
+# Set to "1", "true", or "yes" to disable MCP server (no AI/MCP features)
+# DISABLE_MCP=""
 NEXT_PUBLIC_DISCORD_SUPPORT=""
 NEXT_PUBLIC_POLOTNO=""
 # NOT_SECURED=false

--- a/apps/backend/src/api/api.module.ts
+++ b/apps/backend/src/api/api.module.ts
@@ -20,6 +20,7 @@ import { OpenaiService } from '@gitroom/nestjs-libraries/openai/openai.service';
 import { ExtractContentService } from '@gitroom/nestjs-libraries/openai/extract.content.service';
 import { CodesService } from '@gitroom/nestjs-libraries/services/codes.service';
 import { CopilotController } from '@gitroom/backend/api/routes/copilot.controller';
+import { CopilotFeaturesController } from '@gitroom/backend/api/routes/copilot-features.controller';
 import { PublicController } from '@gitroom/backend/api/routes/public.controller';
 import { RootController } from '@gitroom/backend/api/routes/root.controller';
 import { TrackService } from '@gitroom/nestjs-libraries/track/track.service';
@@ -57,6 +58,7 @@ const authenticatedController = [
     StripeController,
     AuthController,
     PublicController,
+    CopilotFeaturesController,
     MonitorController,
     EnterpriseController,
     NoAuthIntegrationsController,

--- a/apps/backend/src/api/routes/copilot-features.controller.ts
+++ b/apps/backend/src/api/routes/copilot-features.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import { Response } from 'express';
+
+/**
+ * Public controller for GET /copilot/features only.
+ * Used by the frontend during SSR (layout) without auth, so it must not require authentication.
+ */
+@Controller('/copilot')
+export class CopilotFeaturesController {
+  @Get('/features')
+  getFeatures(@Res() res: Response) {
+    const chatEnabled =
+      !!process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim() !== '';
+    const mcpDisabled =
+      process.env.DISABLE_MCP === '1' ||
+      process.env.DISABLE_MCP === 'true' ||
+      process.env.DISABLE_MCP === 'yes';
+    return res.json({
+      chatEnabled,
+      mcpEnabled: !mcpDisabled,
+    });
+  }
+}

--- a/apps/backend/src/api/routes/copilot.controller.ts
+++ b/apps/backend/src/api/routes/copilot.controller.ts
@@ -35,20 +35,6 @@ export class CopilotController {
     private _subscriptionService: SubscriptionService,
     private _mastraService: MastraService
   ) {}
-  @Get('/features')
-  getFeatures(@Res() res: Response) {
-    const chatEnabled =
-      !!process.env.OPENAI_API_KEY && process.env.OPENAI_API_KEY.trim() !== '';
-    const mcpDisabled =
-      process.env.DISABLE_MCP === '1' ||
-      process.env.DISABLE_MCP === 'true' ||
-      process.env.DISABLE_MCP === 'yes';
-    return res.json({
-      chatEnabled,
-      mcpEnabled: !mcpDisabled,
-    });
-  }
-
   @Post('/chat')
   chatAgent(@Req() req: Request, @Res() res: Response) {
     if (

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -44,7 +44,13 @@ async function start() {
     },
   });
 
-  await startMcp(app);
+  const mcpDisabled =
+    process.env.DISABLE_MCP === '1' ||
+    process.env.DISABLE_MCP === 'true' ||
+    process.env.DISABLE_MCP === 'yes';
+  if (!mcpDisabled) {
+    await startMcp(app);
+  }
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -50,6 +50,8 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           disableXAnalytics={!!process.env.DISABLE_X_ANALYTICS}
           sentryDsn={process.env.NEXT_PUBLIC_SENTRY_DSN!}
           extensionId={process.env.EXTENSION_ID || ''}
+          chatEnabled={false}
+          mcpEnabled={false}
           transloadit={
             process.env.TRANSLOADIT_AUTH && process.env.TRANSLOADIT_TEMPLATE
               ? [

--- a/apps/frontend/src/components/agents/agent.tsx
+++ b/apps/frontend/src/components/agents/agent.tsx
@@ -22,6 +22,7 @@ import { Integration } from '@prisma/client';
 import Link from 'next/link';
 import { useParams, usePathname, useRouter } from 'next/navigation';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useVariables } from '@gitroom/react/helpers/variable.context';
 
 export const MediaPortal: FC<{
   media: { path: string; id: string }[];
@@ -199,6 +200,26 @@ export const AgentList: FC<{ onChange: (arr: any[]) => void }> = ({
 export const PropertiesContext = createContext({ properties: [] });
 export const Agent: FC<{ children: ReactNode }> = ({ children }) => {
   const [properties, setProperties] = useState([]);
+  const { chatEnabled } = useVariables();
+  const t = useT();
+
+  if (!chatEnabled) {
+    return (
+      <div className="bg-newBgColorInner flex flex-1 items-center justify-center p-[24px]">
+        <div className="text-center text-newTextColor max-w-[400px]">
+          <p className="font-[600] text-[18px] mb-[8px]">
+            {t('ai_features_disabled', 'AI features are disabled')}
+          </p>
+          <p className="text-[14px] opacity-80">
+            {t(
+              'ai_features_disabled_description',
+              'Chat and AI features are not configured on this installation. Set OPENAI_API_KEY to enable.'
+            )}
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <PropertiesContext.Provider value={{ properties }}>

--- a/apps/frontend/src/components/launches/launches.component.tsx
+++ b/apps/frontend/src/components/launches/launches.component.tsx
@@ -348,7 +348,7 @@ export const MenuComponent: FC<
 export const LaunchesComponent = () => {
   const fetch = useFetch();
   const user = useUser();
-  const { billingEnabled } = useVariables();
+  const { billingEnabled, chatEnabled } = useVariables();
   const router = useRouter();
   const search = useSearchParams();
   const toast = useToaster();
@@ -537,7 +537,8 @@ export const LaunchesComponent = () => {
                 {sortedIntegrations?.length > 0 && <NewPost />}
                 {sortedIntegrations?.length > 0 &&
                   user?.tier?.ai &&
-                  billingEnabled && <GeneratorComponent />}
+                  billingEnabled &&
+                  chatEnabled && <GeneratorComponent />}
               </div>
             </div>
             <div className="gap-[32px] flex flex-col select-none flex-1">

--- a/apps/frontend/src/components/layout/top.menu.tsx
+++ b/apps/frontend/src/components/layout/top.menu.tsx
@@ -16,7 +16,7 @@ interface MenuItemInterface {
 }
 
 export const useMenuItem = () => {
-  const { isGeneral } = useVariables();
+  const { isGeneral, chatEnabled } = useVariables();
   const t = useT();
 
   const firstMenu = [
@@ -58,6 +58,7 @@ export const useMenuItem = () => {
         </svg>
       ),
       path: '/agents',
+      hide: !chatEnabled,
     },
     {
       name: t('analytics', 'Analytics'),

--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -44,6 +44,7 @@ import { useHasScroll } from '@gitroom/frontend/components/ui/is.scroll.hook';
 import { useShortlinkPreference } from '@gitroom/frontend/components/settings/shortlink-preference.component';
 import dayjs from 'dayjs';
 import { Button } from '@gitroom/react/form/button';
+import { useVariables } from '@gitroom/react/helpers/variable.context';
 
 function countCharacters(text: string, type: string): number {
   if (type !== 'x') {
@@ -62,6 +63,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
   const modal = useModals();
   const [showSettings, setShowSettings] = useState(false);
   const { data: shortlinkPreferenceData } = useShortlinkPreference();
+  const { chatEnabled } = useVariables();
 
   const { addEditSets, mutate, customClose, dummy } = props;
 
@@ -663,6 +665,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
           </div>
         </div>
       </div>
+      {chatEnabled && (
       <CopilotPopup
         hitEscapeToClose={false}
         clickOutsideToClose={true}
@@ -685,6 +688,7 @@ After using the addPostFor{num} it will create a new addPostContentFor{num+ 1} f
           ),
         }}
       />
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/components/new-layout/layout.component.tsx
+++ b/apps/frontend/src/components/new-layout/layout.component.tsx
@@ -50,7 +50,7 @@ const jakartaSans = Plus_Jakarta_Sans({
 export const LayoutComponent = ({ children }: { children: ReactNode }) => {
   const fetch = useFetch();
 
-  const { backendUrl, billingEnabled, isGeneral } = useVariables();
+  const { backendUrl, billingEnabled, isGeneral, chatEnabled } = useVariables();
 
   // Feedback icon component attaches Sentry feedback to a top-bar icon when DSN is present
   const searchParams = useSearchParams();
@@ -67,77 +67,85 @@ export const LayoutComponent = ({ children }: { children: ReactNode }) => {
 
   if (!user) return null;
 
-  return (
-    <ContextWrapper user={user}>
-      <CopilotKit
-        credentials="include"
-        runtimeUrl={backendUrl + '/copilot/chat'}
-        showDevConsole={false}
-      >
-        <MantineWrapper>
-          <ToolTip />
-          <Toaster />
-          <CheckPayment check={searchParams.get('check') || ''} mutate={mutate}>
-            <ShowMediaBoxModal />
-            <ShowLinkedinCompany />
-            <MediaSettingsLayout />
-            <ShowPostSelector />
-            <PreConditionComponent />
-            <NewSubscription />
-            <ContinueProvider />
-            <div
-              className={clsx(
-                'flex flex-col min-h-screen min-w-screen text-newTextColor p-[12px]',
-                jakartaSans.className
-              )}
-            >
-              <div>{user?.admin ? <Impersonate /> : <div />}</div>
-              {user.tier === 'FREE' && isGeneral && billingEnabled ? (
-                <FirstBillingComponent />
-              ) : (
-                <div className="flex-1 flex gap-[8px]">
-                  <Support />
-                  <div className="flex flex-col bg-newBgColorInner w-[80px] rounded-[12px]">
-                    <div
-                      className={clsx(
-                        'fixed h-full w-[64px] start-[17px] flex flex-1 top-0',
-                        user?.admin && 'pt-[60px] max-h-[1000px]:w-[500px]'
-                      )}
-                    >
-                      <div className="flex flex-col h-full gap-[32px] flex-1 py-[12px]">
-                        <Logo />
-                        <TopMenu />
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex-1 bg-newBgLineColor rounded-[12px] overflow-hidden flex flex-col gap-[1px] blurMe">
-                    <div className="flex bg-newBgColorInner h-[80px] px-[20px] items-center">
-                      <div className="text-[24px] font-[600] flex flex-1">
-                        <Title />
-                      </div>
-                      <div className="flex gap-[20px] text-textItemBlur">
-                        <StreakComponent />
-                        <div className="w-[1px] h-[20px] bg-blockSeparator" />
-                        <OrganizationSelector />
-                        <div className="hover:text-newTextColor">
-                          <ModeComponent />
-                        </div>
-                        <div className="w-[1px] h-[20px] bg-blockSeparator" />
-                        <LanguageComponent />
-                        <ChromeExtensionComponent />
-                        <div className="w-[1px] h-[20px] bg-blockSeparator" />
-                        <AttachToFeedbackIcon />
-                        <NotificationComponent />
-                      </div>
-                    </div>
-                    <div className="flex flex-1 gap-[1px]">{children}</div>
+  const content = (
+    <MantineWrapper>
+      <ToolTip />
+      <Toaster />
+      <CheckPayment check={searchParams.get('check') || ''} mutate={mutate}>
+        <ShowMediaBoxModal />
+        <ShowLinkedinCompany />
+        <MediaSettingsLayout />
+        <ShowPostSelector />
+        <PreConditionComponent />
+        <NewSubscription />
+        <ContinueProvider />
+        <div
+          className={clsx(
+            'flex flex-col min-h-screen min-w-screen text-newTextColor p-[12px]',
+            jakartaSans.className
+          )}
+        >
+          <div>{user?.admin ? <Impersonate /> : <div />}</div>
+          {user.tier === 'FREE' && isGeneral && billingEnabled ? (
+            <FirstBillingComponent />
+          ) : (
+            <div className="flex-1 flex gap-[8px]">
+              <Support />
+              <div className="flex flex-col bg-newBgColorInner w-[80px] rounded-[12px]">
+                <div
+                  className={clsx(
+                    'fixed h-full w-[64px] start-[17px] flex flex-1 top-0',
+                    user?.admin && 'pt-[60px] max-h-[1000px]:w-[500px]'
+                  )}
+                >
+                  <div className="flex flex-col h-full gap-[32px] flex-1 py-[12px]">
+                    <Logo />
+                    <TopMenu />
                   </div>
                 </div>
-              )}
+              </div>
+              <div className="flex-1 bg-newBgLineColor rounded-[12px] overflow-hidden flex flex-col gap-[1px] blurMe">
+                <div className="flex bg-newBgColorInner h-[80px] px-[20px] items-center">
+                  <div className="text-[24px] font-[600] flex flex-1">
+                    <Title />
+                  </div>
+                  <div className="flex gap-[20px] text-textItemBlur">
+                    <StreakComponent />
+                    <div className="w-[1px] h-[20px] bg-blockSeparator" />
+                    <OrganizationSelector />
+                    <div className="hover:text-newTextColor">
+                      <ModeComponent />
+                    </div>
+                    <div className="w-[1px] h-[20px] bg-blockSeparator" />
+                    <LanguageComponent />
+                    <ChromeExtensionComponent />
+                    <div className="w-[1px] h-[20px] bg-blockSeparator" />
+                    <AttachToFeedbackIcon />
+                    <NotificationComponent />
+                  </div>
+                </div>
+                <div className="flex flex-1 gap-[1px]">{children}</div>
+              </div>
             </div>
-          </CheckPayment>
-        </MantineWrapper>
-      </CopilotKit>
+          )}
+        </div>
+      </CheckPayment>
+    </MantineWrapper>
+  );
+
+  return (
+    <ContextWrapper user={user}>
+      {chatEnabled ? (
+        <CopilotKit
+          credentials="include"
+          runtimeUrl={backendUrl + '/copilot/chat'}
+          showDevConsole={false}
+        >
+          {content}
+        </CopilotKit>
+      ) : (
+        content
+      )}
     </ContextWrapper>
   );
 };

--- a/apps/frontend/src/components/preview/preview.wrapper.tsx
+++ b/apps/frontend/src/components/preview/preview.wrapper.tsx
@@ -10,7 +10,7 @@ import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { CopilotKit } from '@copilotkit/react-core';
 export const PreviewWrapper = ({ children }: { children: ReactNode }) => {
   const fetch = useFetch();
-  const { backendUrl } = useVariables();
+  const { backendUrl, chatEnabled } = useVariables();
   const load = useCallback(async (path: string) => {
     return await (await fetch(path)).json();
   }, []);
@@ -21,18 +21,25 @@ export const PreviewWrapper = ({ children }: { children: ReactNode }) => {
     refreshWhenOffline: false,
     refreshWhenHidden: false,
   });
+  const content = (
+    <MantineWrapper>
+      <Toaster />
+      {children}
+    </MantineWrapper>
+  );
   return (
     <ContextWrapper user={user}>
-      <CopilotKit
-        credentials="include"
-        runtimeUrl={backendUrl + '/copilot/chat'}
-        showDevConsole={false}
-      >
-        <MantineWrapper>
-          <Toaster />
-          {children}
-        </MantineWrapper>
-      </CopilotKit>
+      {chatEnabled ? (
+        <CopilotKit
+          credentials="include"
+          runtimeUrl={backendUrl + '/copilot/chat'}
+          showDevConsole={false}
+        >
+          {content}
+        </CopilotKit>
+      ) : (
+        content
+      )}
     </ContextWrapper>
   );
 };

--- a/apps/frontend/src/components/public-api/public.component.tsx
+++ b/apps/frontend/src/components/public-api/public.component.tsx
@@ -12,7 +12,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { useDecisionModal } from '@gitroom/frontend/components/layout/new-modal';
 export const PublicComponent = () => {
   const user = useUser();
-  const { backendUrl, frontEndUrl } = useVariables();
+  const { backendUrl, frontEndUrl, mcpEnabled } = useVariables();
   const toaster = useToaster();
   const fetch = useFetch();
   const decision = useDecisionModal();
@@ -110,6 +110,7 @@ export const PublicComponent = () => {
         </div>
       </div>
 
+      {mcpEnabled && (
       <div className="flex flex-col">
         <h3 className="text-[20px]">{t('mcp', 'MCP')}</h3>
         <div className="text-customColor18 mt-[4px]">
@@ -144,6 +145,7 @@ export const PublicComponent = () => {
           </div>
         </div>
       </div>
+      )}
 
       <div className="flex flex-col">
         <h3 className="text-[20px]">Building your Postiz payload</h3>

--- a/libraries/react-shared-libraries/src/helpers/variable.context.tsx
+++ b/libraries/react-shared-libraries/src/helpers/variable.context.tsx
@@ -26,6 +26,8 @@ interface VariableContextInterface {
   transloadit: string[];
   sentryDsn: string;
   extensionId: string;
+  chatEnabled: boolean;
+  mcpEnabled: boolean;
 }
 const VariableContext = createContext({
   stripeClient: '',
@@ -51,6 +53,8 @@ const VariableContext = createContext({
   transloadit: [],
   sentryDsn: '',
   extensionId: '',
+  chatEnabled: false,
+  mcpEnabled: false,
 } as VariableContextInterface);
 export const VariableContextComponent: FC<
   VariableContextInterface & {


### PR DESCRIPTION
Closes #1214

## Summary
- **Chat**: Only enabled when `OPENAI_API_KEY` is set. When missing, `/copilot/chat` and `/copilot/agent` return 503 immediately (no timeout).
- **MCP**: Disabled when `DISABLE_MCP` is set to `1`, `true`, or `yes`; otherwise MCP server is started as before.

## Backend
- `main.ts`: Start MCP only when `DISABLE_MCP` is not set.
- `GET /copilot/features`: Returns `{ chatEnabled, mcpEnabled }` for the frontend.
- `/copilot/chat`, `/copilot/agent`, `/copilot/:thread/list`, `/copilot/list`: Return 503 with `CHAT_DISABLED` when `OPENAI_API_KEY` is missing.

## Frontend
- Variable context and app layout: `chatEnabled` and `mcpEnabled` from `/copilot/features`.
- CopilotKit is only rendered when `chatEnabled` (layout + preview wrapper).
- Agent menu item and GeneratorComponent gated by `chatEnabled`.
- Agents page shows a short "AI disabled" message when `!chatEnabled`.
- CopilotPopup in manage modal and MCP section in Settings only when enabled.

## Config
- `.env.example`: Documented `DISABLE_MCP`.