### PR TITLE
fix: allow scheduling posts with images (fixes #1152)

### DIFF
--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -413,12 +413,25 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
       }
 
       if (!dummy) {
-        addEditSets
-          ? addEditSets(data)
-          : await fetch('/posts', {
-              method: 'POST',
-              body: JSON.stringify(data),
-            });
+        if (addEditSets) {
+          addEditSets(data);
+        } else {
+          const response = await fetch('/posts', {
+            method: 'POST',
+            body: JSON.stringify(data),
+          });
+          if (!response.ok) {
+            const errBody = await response.json().catch(() => ({}));
+            const message =
+              (Array.isArray(errBody?.message)
+                ? errBody.message.join(', ')
+                : errBody?.message) ||
+              t('schedule_failed', 'Failed to schedule. Please try again.');
+            toaster.show(message, 'error');
+            setLoading(false);
+            return;
+          }
+        }
 
         if (!addEditSets) {
           mutate();

--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -427,7 +427,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
                 ? errBody.message.join(', ')
                 : errBody?.message) ||
               t('schedule_failed', 'Failed to schedule. Please try again.');
-            toaster.show(message, 'error');
+            toaster.show(message, 'warning');
             setLoading(false);
             return;
           }

--- a/libraries/helpers/src/utils/valid.url.path.ts
+++ b/libraries/helpers/src/utils/valid.url.path.ts
@@ -4,17 +4,14 @@ import {
   ValidatorConstraint,
 } from 'class-validator';
 
+const VALID_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.mp4'];
+
 @ValidatorConstraint({ name: 'checkValidExtension', async: false })
 export class ValidUrlExtension implements ValidatorConstraintInterface {
   validate(text: string, args: ValidationArguments) {
-    return (
-      !!text?.split?.('?')?.[0].endsWith('.png') ||
-      !!text?.split?.('?')?.[0].endsWith('.jpg') ||
-      !!text?.split?.('?')?.[0].endsWith('.jpeg') ||
-      !!text?.split?.('?')?.[0].endsWith('.gif') ||
-      !!text?.split?.('?')?.[0].endsWith('.webp') ||
-      !!text?.split?.('?')?.[0].endsWith('.mp4')
-    );
+    const pathWithoutQuery = text?.split?.('?')?.[0] ?? '';
+    const lower = pathWithoutQuery.toLowerCase();
+    return VALID_EXTENSIONS.some((ext) => lower.endsWith(ext));
   }
 
   defaultMessage(args: ValidationArguments) {


### PR DESCRIPTION
## Summary
Fixes #1152 – posts containing images showed "Scheduled successfully" but did not appear in the calendar and were never published.

## Root cause
- **Image URL validation**: `ValidUrlExtension` only allowed lowercase extensions (`.jpg`, `.png`, etc.). Uploaded filenames with uppercase (`.JPG`, `.PNG`) failed validation, so the API returned 400.
- **Frontend**: The schedule `POST /posts` response was never checked, so the UI always showed success and closed the modal even when the API failed.

## Changes
1. **`libraries/helpers/src/utils/valid.url.path.ts`**  
   - `ValidUrlExtension` now checks the path in lowercase so `.JPG`, `.PNG`, etc. are accepted.

2. **`apps/frontend/src/components/new-launch/manage.modal.tsx`**  
   - After `POST /posts`, the code now checks `response.ok`.  
   - On failure: show the API error message in the toaster, keep loading state correct, and do not show success or close the modal.