### PR TITLE
feat: add MCP tools for listing and deleting posts

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/delete.post.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/delete.post.tool.ts
@@ -1,0 +1,56 @@
+import {
+  AgentToolInterface,
+  ToolReturn,
+} from '@gitroom/nestjs-libraries/chat/agent.tool.interface';
+import { createTool } from '@mastra/core/tools';
+import { Injectable } from '@nestjs/common';
+import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import z from 'zod';
+import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
+
+@Injectable()
+export class DeletePostTool implements AgentToolInterface {
+  constructor(private _postsService: PostsService) {}
+  name = 'deletePostTool';
+
+  run() {
+    return createTool({
+      id: 'deletePostTool',
+      description: `This tool deletes a scheduled or draft post by its post ID`,
+      inputSchema: z.object({
+        postId: z.string().describe('The ID of the post to delete'),
+      }),
+      outputSchema: z.object({
+        success: z.boolean(),
+        message: z.string(),
+      }),
+      execute: async (args, options) => {
+        const { context, runtimeContext } = args;
+        checkAuth(args, options);
+        const organizationId = JSON.parse(
+          // @ts-ignore
+          runtimeContext.get('organization') as string
+        ).id;
+
+        const post = await this._postsService.getPost(
+          organizationId,
+          context.postId
+        );
+
+        if (!post || !post.group) {
+          return {
+            success: false,
+            message: `Post with ID ${context.postId} not found`,
+          };
+        }
+
+        await this._postsService.deletePost(organizationId, post.group);
+
+        return {
+          success: true,
+          message: `Post ${context.postId} deleted successfully`,
+        };
+      },
+    });
+  }
+}

--- a/libraries/nestjs-libraries/src/chat/tools/list.posts.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/list.posts.tool.ts
@@ -1,0 +1,91 @@
+import {
+  AgentToolInterface,
+  ToolReturn,
+} from '@gitroom/nestjs-libraries/chat/agent.tool.interface';
+import { createTool } from '@mastra/core/tools';
+import { Injectable } from '@nestjs/common';
+import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import z from 'zod';
+import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+dayjs.extend(utc);
+
+@Injectable()
+export class ListPostsTool implements AgentToolInterface {
+  constructor(private _postsService: PostsService) {}
+  name = 'listPostsTool';
+
+  run() {
+    return createTool({
+      id: 'listPostsTool',
+      description: `This tool lists scheduled, queued, and draft posts. Returns posts from today up to one year ahead by default.`,
+      inputSchema: z.object({
+        startDate: z
+          .string()
+          .optional()
+          .describe(
+            'Start date in ISO format (e.g. 2025-01-01). Defaults to today.'
+          ),
+        endDate: z
+          .string()
+          .optional()
+          .describe(
+            'End date in ISO format (e.g. 2025-12-31). Defaults to one year from today.'
+          ),
+      }),
+      outputSchema: z.object({
+        output: z.array(
+          z.object({
+            id: z.string(),
+            content: z.string(),
+            publishDate: z.string(),
+            state: z.string(),
+            group: z.string(),
+            integration: z.object({
+              id: z.string(),
+              name: z.string(),
+              providerIdentifier: z.string(),
+            }),
+          })
+        ),
+      }),
+      execute: async (args, options) => {
+        const { context, runtimeContext } = args;
+        checkAuth(args, options);
+        const organizationId = JSON.parse(
+          // @ts-ignore
+          runtimeContext.get('organization') as string
+        ).id;
+
+        const startDate =
+          context.startDate || dayjs.utc().format('YYYY-MM-DD');
+        const endDate =
+          context.endDate || dayjs.utc().add(1, 'year').format('YYYY-MM-DD');
+
+        const posts = await this._postsService.getPosts(organizationId, {
+          startDate,
+          endDate,
+          customer: '',
+        });
+
+        return {
+          output: posts.map((p: any) => ({
+            id: p.id,
+            content: p.content,
+            publishDate: p.publishDate
+              ? dayjs(p.publishDate).toISOString()
+              : '',
+            state: p.state,
+            group: p.group,
+            integration: {
+              id: p.integration?.id || '',
+              name: p.integration?.name || '',
+              providerIdentifier: p.integration?.providerIdentifier || '',
+            },
+          })),
+        };
+      },
+    });
+  }
+}

--- a/libraries/nestjs-libraries/src/chat/tools/tool.list.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/tool.list.ts
@@ -6,6 +6,8 @@ import { VideoFunctionTool } from '@gitroom/nestjs-libraries/chat/tools/video.fu
 import { GenerateVideoTool } from '@gitroom/nestjs-libraries/chat/tools/generate.video.tool';
 import { GenerateImageTool } from '@gitroom/nestjs-libraries/chat/tools/generate.image.tool';
 import { IntegrationListTool } from '@gitroom/nestjs-libraries/chat/tools/integration.list.tool';
+import { DeletePostTool } from '@gitroom/nestjs-libraries/chat/tools/delete.post.tool';
+import { ListPostsTool } from '@gitroom/nestjs-libraries/chat/tools/list.posts.tool';
 
 export const toolList = [
   IntegrationListTool,
@@ -16,4 +18,6 @@ export const toolList = [
   VideoFunctionTool,
   GenerateVideoTool,
   GenerateImageTool,
+  DeletePostTool,
+  ListPostsTool,
 ];


### PR DESCRIPTION
## Summary
- Adds `deletePostTool` MCP tool — deletes a post by ID (looks up the group, then delegates to `PostsService.deletePost()`)
- Adds `listPostsTool` MCP tool — lists scheduled/queued/draft posts within a date range using `PostsService.getPosts()` (unminified)
- Registers both tools in `tool.list.ts`

These tools enable post management through the MCP chat agent without requiring the web UI, complementing the existing `integrationSchedulePostTool`.

## Test plan
- [ ] Schedule a test post with `integrationSchedulePostTool`
- [ ] List posts with `listPostsTool` — verify the scheduled post appears
- [ ] Delete the post with `deletePostTool` — verify success response
- [ ] List again to confirm deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)