### PR TITLE
Fix LinkedIn Page channel to also find pages for Content Admins

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -136,7 +136,7 @@ export class LinkedinPageProvider
   }
 
   async companies(accessToken: string) {
-    const roles = ['ADMINISTRATOR', 'CONTENT_ADMIN'];
+    const roles = ['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR'];
     const allElements: any[] = [];
 
     for (const role of roles) {

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -140,19 +140,23 @@ export class LinkedinPageProvider
     const allElements: any[] = [];
 
     for (const role of roles) {
-      const { elements } = await (
-        await fetch(
-          `https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=${role}&projection=(elements*(organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              'X-Restli-Protocol-Version': '2.0.0',
-              'LinkedIn-Version': '202601',
-            },
-          }
-        )
-      ).json();
-      allElements.push(...(elements || []));
+      try {
+        const { elements } = await (
+          await fetch(
+            `https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=${role}&projection=(elements*(organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))`,
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'X-Restli-Protocol-Version': '2.0.0',
+                'LinkedIn-Version': '202601',
+              },
+            }
+          )
+        ).json();
+        allElements.push(...(elements || []));
+      } catch (e) {
+        // Continue with other roles if one fails
+      }
     }
 
     // Deduplicate by organizational target

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -136,20 +136,35 @@ export class LinkedinPageProvider
   }
 
   async companies(accessToken: string) {
-    const { elements, ...all } = await (
-      await fetch(
-        'https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=ADMINISTRATOR&projection=(elements*(organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))',
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'X-Restli-Protocol-Version': '2.0.0',
-            'LinkedIn-Version': '202601',
-          },
-        }
-      )
-    ).json();
+    const roles = ['ADMINISTRATOR', 'CONTENT_ADMIN'];
+    const allElements: any[] = [];
 
-    return (elements || []).map((e: any) => ({
+    for (const role of roles) {
+      const { elements } = await (
+        await fetch(
+          `https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=${role}&projection=(elements*(organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'X-Restli-Protocol-Version': '2.0.0',
+              'LinkedIn-Version': '202601',
+            },
+          }
+        )
+      ).json();
+      allElements.push(...(elements || []));
+    }
+
+    // Deduplicate by organizational target
+    const seen = new Set<string>();
+    const uniqueElements = allElements.filter((e: any) => {
+      const id = e.organizationalTarget;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+
+    return uniqueElements.map((e: any) => ({
       id: e.organizationalTarget.split(':').pop(),
       page: e.organizationalTarget.split(':').pop(),
       username: e['organizationalTarget~'].vanityName,

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -138,6 +138,7 @@ export class LinkedinPageProvider
   async companies(accessToken: string) {
     const roles = ['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR'];
     const allElements: any[] = [];
+    const errors: Error[] = [];
 
     for (const role of roles) {
       try {
@@ -155,8 +156,13 @@ export class LinkedinPageProvider
         ).json();
         allElements.push(...(elements || []));
       } catch (e) {
-        // Continue with other roles if one fails
+        errors.push(e instanceof Error ? e : new Error(String(e)));
       }
+    }
+
+    // If all role queries failed, re-throw so the caller can surface the error
+    if (errors.length === roles.length) {
+      throw errors[errors.length - 1];
     }
 
     // Deduplicate by organizational target


### PR DESCRIPTION
## Summary
- The `companies()` method in `linkedin.page.provider.ts` only queried for organizations where the user has the `ADMINISTRATOR` role
- Content Admins (`CONTENT_ADMIN`) could not connect their LinkedIn Pages, even though they have posting permissions via `w_organization_social`
- Now queries for both `ADMINISTRATOR` and `CONTENT_ADMIN` roles, deduplicating results

Fixes #1234

## Test plan
- [ ] Connect a LinkedIn Page where user is an Administrator — should work as before
- [ ] Connect a LinkedIn Page where user is a Content Admin — should now appear in the page list
- [ ] Verify no duplicate pages appear when user has both roles on the same page

🤖 Generated with [Claude Code](https://claude.com/claude-code)