### PR TITLE
Fix configuration checker to accept rediss:// (TLS) Redis URLs

### DIFF
--- a/libraries/helpers/src/configuration/configuration.checker.ts
+++ b/libraries/helpers/src/configuration/configuration.checker.ts
@@ -70,8 +70,8 @@ export class ConfigurationChecker {
     try {
       const redisUrl = new URL(this.cfg.REDIS_URL);
 
-      if (redisUrl.protocol !== 'redis:') {
-        this.issues.push('REDIS_URL must start with redis://');
+      if (redisUrl.protocol !== 'redis:' && redisUrl.protocol !== 'rediss:') {
+        this.issues.push('REDIS_URL must start with redis:// or rediss://');
       }
     } catch (error) {
       this.issues.push('REDIS_URL is not a valid URL');

--- a/libraries/helpers/src/configuration/configuration.checker.ts
+++ b/libraries/helpers/src/configuration/configuration.checker.ts
@@ -65,13 +65,19 @@ export class ConfigurationChecker {
   checkRedis() {
     if (!this.cfg.REDIS_URL) {
       this.issues.push('REDIS_URL not set');
+      return;
     }
 
     try {
       const redisUrl = new URL(this.cfg.REDIS_URL);
 
-      if (redisUrl.protocol !== 'redis:' && redisUrl.protocol !== 'rediss:') {
-        this.issues.push('REDIS_URL must start with redis:// or rediss://');
+      if (
+        (redisUrl.protocol !== 'redis:' && redisUrl.protocol !== 'rediss:') ||
+        !redisUrl.host
+      ) {
+        this.issues.push(
+          'REDIS_URL must be a valid URL starting with redis:// or rediss:// and include a host'
+        );
       }
     } catch (error) {
       this.issues.push('REDIS_URL is not a valid URL');


### PR DESCRIPTION
## Summary
- The `checkRedis()` method in `configuration.checker.ts` only accepted `redis://` as a valid protocol
- This caused a false-positive warning for `rediss://` URLs used with TLS-encrypted Redis (e.g., AWS ElastiCache Serverless, Azure Cache for Redis)
- Now accepts both `redis://` and `rediss://`

Fixes #1235

## Test plan
- [ ] Set `REDIS_URL=redis://host:6379` — no warning (unchanged behavior)
- [ ] Set `REDIS_URL=rediss://host:6379` — no warning (previously warned incorrectly)
- [ ] Set `REDIS_URL=http://host:6379` — still warns as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)