### PR TITLE
fix: only validate first post for content, not comment slots

### DIFF
--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -248,14 +248,14 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
       const checkAllValid = await ref.current.checkAllValid();
 
       const notEnoughChars = checkAllValid.filter((p: any) => {
-        return p.values.some((a: any) => {
-          return (
-            countCharacters(
-              stripHtmlValidation('normal', a.content, true),
-              p?.integration?.identifier || ''
-            ) === 0 && a.media?.length === 0
-          );
-        });
+        const firstValue = p.values?.[0];
+        if (!firstValue) return true;
+        return (
+          countCharacters(
+            stripHtmlValidation('normal', firstValue.content, true),
+            p?.integration?.identifier || ''
+          ) === 0 && firstValue.media?.length === 0
+        );
       });
 
       for (const item of notEnoughChars) {


### PR DESCRIPTION
## Summary
- Fixes #1241
- The "content or image" validation used `.some()` to check ALL entries in the values array, including empty comment slots
- This caused every provider to fail validation when comment slots existed but were empty, even if the actual post had content
- Providers without comment support (like YouTube) had no workaround since users couldn't fill in comment slots
- Now only the first value (the actual post) is checked for the "needs content or image" requirement

## Test plan
- [ ] Create a post with content in the main editor for any provider — verify it passes validation
- [ ] Create a multi-provider post where some providers support comments and some don't — verify all pass validation when the main post has content
- [ ] Verify a truly empty post (no content, no media in the first value) still shows the validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)