### PR TITLE
fix: wrap MCP schedule post error returns in output key

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
@@ -152,7 +152,7 @@ If the tools return errors, you would need to rerun it with the right parameters
             const errors = await validate(obj);
             if (errors.length) {
               return {
-                errors: JSON.stringify(errors),
+                output: { errors: JSON.stringify(errors) },
               };
             }
 
@@ -174,7 +174,7 @@ If the tools return errors, you would need to rerun it with the right parameters
 
             if (errorsLength.length) {
               return {
-                errors: JSON.stringify(errorsLength),
+                output: { errors: JSON.stringify(errorsLength) },
               };
             }
           }


### PR DESCRIPTION
## Summary

The `integrationSchedulePostTool` has an `outputSchema` that expects all returns wrapped in `{ output: ... }`, but both error paths (DTO validation and character length validation) return `{ errors: ... }` directly. This causes Mastra/MCP schema validation to reject error responses, making scheduling failures silent — the MCP client gets no useful error message.

**2-line fix:** wrap both error returns in the `output` key to match the declared schema.

## Reproduction

1. Connect to Postiz via MCP (Streamable HTTP transport)
2. Call `integrationSchedulePostTool` with content that exceeds a platform's character limit
3. Expected: `{ output: { errors: "..." } }`
4. Actual (before fix): `{ errors: "..." }` — rejected by schema validation

## Test plan

- [ ] Schedule a post with content exceeding platform character limit — error message should be returned to MCP client
- [ ] Schedule a post with invalid DTO settings — error message should be returned to MCP client
- [ ] Schedule a valid post — should succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)