### PR TITLE
fix: remove LinkedIn org scopes that require Community Management API

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -29,10 +29,6 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     'openid',
     'profile',
     'w_member_social',
-    'r_basicprofile',
-    'rw_organization_admin',
-    'w_organization_social',
-    'r_organization_social',
   ];
   override maxConcurrentJob = 2; // LinkedIn has professional posting limits
   refreshWait = true;


### PR DESCRIPTION
## Summary

Fixes #1243

The default LinkedIn scopes include `rw_organization_admin`, `w_organization_social`, and `r_organization_social` which require Community Management API product approval. Personal LinkedIn accounts can't complete the OAuth flow with these scopes.

This removes the org-level scopes, keeping only `openid`, `profile`, and `w_member_social` which are sufficient for personal posting.

**Note:** This change affects `linkedin.provider.ts` only, not `linkedin-page.provider.ts` which is specifically for organization pages.

## Test plan

- [ ] Connect a personal LinkedIn account — OAuth should succeed
- [ ] Post to LinkedIn — should publish successfully
- [ ] Verify LinkedIn page provider still has full org scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)