### PR TITLE
fix: replace Mastodon 'profile' scope with 'read:accounts'

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -14,7 +14,7 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
   identifier = 'mastodon';
   name = 'Mastodon';
   isBetweenSteps = false;
-  scopes = ['write:statuses', 'profile', 'write:media'];
+  scopes = ['write:statuses', 'read:accounts', 'write:media'];
   editor = 'normal' as const;
   maxLength() {
     return 500;


### PR DESCRIPTION
## Summary

Fixes #1245

The \`profile\` scope is not supported by all Mastodon instances (e.g., noc.social). Replace with \`read:accounts\` which provides the same profile data access and is universally supported per the Mastodon OAuth specification.

## Test plan

- [ ] Connect a Mastodon account on an instance that previously rejected \`profile\` scope
- [ ] Verify profile data (display name, avatar) is still retrieved correctly
- [ ] Post to Mastodon — should publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)