### PR TITLE
feat(integrations): introduce optional SocialProviderCapabilities con…

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -4,6 +4,7 @@ import {
   PostDetails,
   PostResponse,
   SocialProvider,
+  SocialProviderCapabilities,
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { timer } from '@gitroom/helpers/utils/timer';
@@ -22,6 +23,14 @@ export class InstagramProvider
 {
   identifier = 'instagram';
   name = 'Instagram\n(Facebook Business)';
+  capabilities: SocialProviderCapabilities = {
+    supportsThreads: false,
+    supportsPolling: false,
+    supportsMedia: true,
+    maxMediaCount: 10,
+    supportsComments: false,
+    supportsAnalytics: true,
+  };
   isBetweenSteps = true;
   toolTip = 'Instagram must be business and connected to a Facebook page';
   scopes = [

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -3,6 +3,7 @@ import {
   PostDetails,
   PostResponse,
   SocialProvider,
+  SocialProviderCapabilities,
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import sharp from 'sharp';
@@ -22,6 +23,14 @@ import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorato
 export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   identifier = 'linkedin';
   name = 'LinkedIn';
+  capabilities: SocialProviderCapabilities = {
+    supportsThreads: false,
+    supportsPolling: false,
+    supportsMedia: true,
+    maxMediaCount: 1,
+    supportsComments: false,
+    supportsAnalytics: true,
+  };
   oneTimeToken = true;
 
   isBetweenSteps = false;

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -56,6 +56,15 @@ export interface AnalyticsData {
   percentageChange: number;
 }
 
+export interface SocialProviderCapabilities {
+  supportsThreads?: boolean;
+  supportsPolling?: boolean;
+  supportsMedia?: boolean;
+  maxMediaCount?: number;
+  supportsComments?: boolean;
+  supportsAnalytics?: boolean;
+}
+
 
 export type GenerateAuthUrlResponse = {
   url: string;
@@ -139,6 +148,7 @@ export interface SocialProvider
   extends IAuthenticator,
     ISocialMediaIntegration {
   identifier: string;
+  capabilities?: SocialProviderCapabilities;
   refreshWait?: boolean;
   convertToJPEG?: boolean;
   refreshCron?: boolean;

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -5,6 +5,7 @@ import {
   PostDetails,
   PostResponse,
   SocialProvider,
+  SocialProviderCapabilities,
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { lookup } from 'mime-types';
 import sharp from 'sharp';
@@ -26,6 +27,14 @@ import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorato
 export class XProvider extends SocialAbstract implements SocialProvider {
   identifier = 'x';
   name = 'X';
+  capabilities: SocialProviderCapabilities = {
+    supportsThreads: true,
+    supportsPolling: true,
+    supportsMedia: true,
+    maxMediaCount: 4,
+    supportsComments: true,
+    supportsAnalytics: true,
+  };
   isBetweenSteps = false;
   scopes = [] as string[];
   override maxConcurrentJob = 1; // X has strict rate limits (300 posts per 3 hours)


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (non-breaking architectural enhancement)

# Why was this change needed?

As the number of supported social providers grows, feature support (e.g. threads, polling, analytics, media limits, comments) is currently inferred implicitly through optional methods and scattered flags across provider implementations.

This can lead to:

- Implicit assumptions about provider capabilities
- Reduced clarity when introducing new providers
- Harder feature introspection in the future (e.g. dynamic UI behavior or validation)

To address this, this PR introduces a structured and backward-compatible `SocialProviderCapabilities` interface and extends the existing `SocialProvider` contract with an optional `capabilities` property.

This allows providers to explicitly declare supported features without introducing breaking changes or modifying existing behavior.

This change:
- Does NOT alter any existing method signatures
- Does NOT make new fields required
- Maintains full backward compatibility
- Keeps the change isolated to the integrations layer

The capability property has been implemented for:
- X
- LinkedIn
- Instagram

Other providers continue to function unchanged.

# Other information:

This change was designed to be minimal and surgical, focusing only on extending the integration abstraction layer without refactoring unrelated code.

The goal is to provide a scalable foundation for future feature introspection (e.g. dynamic UI rendering, validation rules, or provider-specific feature toggling) while maintaining compatibility with all existing providers.

No configuration, infrastructure, or dependency changes were introduced.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR)