### PR TITLE
feat: Added integrations filter multiselect.

### DIFF
--- a/apps/frontend/src/components/launches/calendar.context.tsx
+++ b/apps/frontend/src/components/launches/calendar.context.tsx
@@ -30,6 +30,7 @@ export const CalendarContext = createContext({
   startDate: newDayjs().startOf('isoWeek').format('YYYY-MM-DD'),
   endDate: newDayjs().endOf('isoWeek').format('YYYY-MM-DD'),
   customer: null as string | null,
+  channels: null as string | null,
   loading: true,
   sets: [] as { name: string; id: string; content: string[] }[],
   signature: undefined as any,
@@ -58,6 +59,7 @@ export const CalendarContext = createContext({
     endDate: string;
     display: 'week' | 'month' | 'day' | 'list';
     customer: string | null;
+    channels: string | null;
   }) => {
     /** empty **/
   },
@@ -148,6 +150,7 @@ export const CalendarWeekProvider: FC<{
   const initStartDate = searchParams.get('startDate');
   const initEndDate = searchParams.get('endDate');
   const initCustomer = searchParams.get('customer');
+  const initChannels = searchParams.get('integrations');
 
   const initialRange =
     initStartDate && initEndDate
@@ -158,6 +161,7 @@ export const CalendarWeekProvider: FC<{
     startDate: initialRange.startDate,
     endDate: initialRange.endDate,
     customer: initCustomer || null,
+    channels: initChannels || null,
     display,
   });
 
@@ -167,6 +171,7 @@ export const CalendarWeekProvider: FC<{
       startDate: filters.startDate,
       endDate: filters.endDate,
       customer: filters?.customer?.toString() || '',
+      integrations: filters?.channels?.toString() || '',
     }).toString();
   }, [filters]);
 
@@ -175,6 +180,7 @@ export const CalendarWeekProvider: FC<{
     const modifiedParams = new URLSearchParams({
       display: filters.display,
       customer: filters?.customer?.toString() || '',
+      integrations: filters?.channels?.toString() || '',
       startDate: newDayjs(filters.startDate).startOf('day').utc().format(),
       endDate: newDayjs(filters.endDate).endOf('day').utc().format(),
     }).toString();
@@ -189,8 +195,9 @@ export const CalendarWeekProvider: FC<{
       page: listPage.toString(),
       limit: '100',
       customer: filters?.customer?.toString() || '',
+      integrations: filters?.channels?.toString() || '',
     }).toString();
-  }, [listPage, filters.customer]);
+  }, [listPage, filters.customer, filters.channels]);
 
   const loadListData = useCallback(async () => {
     const response = await fetch(`/posts/list?${listParams}`);
@@ -260,6 +267,7 @@ export const CalendarWeekProvider: FC<{
       endDate: string;
       display: 'week' | 'month' | 'day' | 'list';
       customer: string | null;
+      channels: string | null;
     }) => {
       setDisplaySaved(newFilters.display);
       setFilters(newFilters);
@@ -275,6 +283,7 @@ export const CalendarWeekProvider: FC<{
         `endDate=${newFilters.endDate}`,
         `display=${newFilters.display}`,
         newFilters.customer ? `customer=${newFilters.customer}` : ``,
+        newFilters.channels ? `integrations=${newFilters.channels}` : ``,
       ].filter((f) => f);
       window.history.replaceState(null, '', `/launches?${path.join('&')}`);
     },

--- a/apps/frontend/src/components/launches/filters.tsx
+++ b/apps/frontend/src/components/launches/filters.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import dayjs from 'dayjs';
 import { useCallback } from 'react';
 import { SelectCustomer } from '@gitroom/frontend/components/launches/select.customer';
+import { SelectChannel } from '@gitroom/frontend/components/launches/select.channel';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import i18next from 'i18next';
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
@@ -84,6 +85,7 @@ export const Filters = () => {
       endDate: currentRange.endDate,
       display: calendar.display as 'day' | 'week' | 'month',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -102,6 +104,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: 'day',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -120,6 +123,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: 'week',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -138,6 +142,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: 'month',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -152,6 +157,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: 'list',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -166,6 +172,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: 'week',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -179,6 +186,23 @@ export const Filters = () => {
         endDate: calendar.endDate,
         display: calendar.display as 'day' | 'week' | 'month',
         customer: customer,
+        channels: calendar.channels,
+      });
+    },
+    [calendar]
+  );
+
+  const setChannels = useCallback(
+    (channels: string) => {
+      if (calendar.channels === channels) {
+        return; // No need to set the same channels
+      }
+      calendar.setFilters({
+        startDate: calendar.startDate,
+        endDate: calendar.endDate,
+        display: calendar.display as 'day' | 'week' | 'month',
+        customer: calendar.customer,
+        channels: channels,
       });
     },
     [calendar]
@@ -211,6 +235,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: calendar.display as 'day' | 'week' | 'month',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -241,6 +266,7 @@ export const Filters = () => {
       endDate: range.endDate,
       display: calendar.display as 'day' | 'week' | 'month',
       customer: calendar.customer,
+      channels: calendar.channels,
     });
   }, [calendar]);
 
@@ -399,6 +425,11 @@ export const Filters = () => {
       <SelectCustomer
         customer={calendar.customer as string}
         onChange={(customer: string) => setCustomer(customer)}
+        integrations={calendar.integrations}
+      />
+      <SelectChannel
+        channels={calendar.channels as string}
+        onChange={(channels: string) => setChannels(channels)}
         integrations={calendar.integrations}
       />
       {!isListView && (

--- a/apps/frontend/src/components/launches/select.channel.tsx
+++ b/apps/frontend/src/components/launches/select.channel.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { FC, useCallback, useState } from 'react';
+import { Integrations } from '@gitroom/frontend/components/launches/calendar.context';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import clsx from 'clsx';
+import { useClickOutside } from '@mantine/hooks';
+import { useToaster } from '@gitroom/react/toaster/toaster';
+import { DropdownArrowIcon } from '@gitroom/frontend/components/ui/icons';
+
+export const SelectChannel: FC<{
+  onChange: (value: string) => void;
+  integrations: Integrations[];
+  channels?: string;
+}> = (props) => {
+  const { onChange, integrations, channels: currentChannels } = props;
+  const toaster = useToaster();
+  const t = useT();
+  const [selectedChannels, setSelectedChannels] = useState<string[]>(
+    currentChannels ? currentChannels.split(',') : []
+  );
+  const [pos, setPos] = useState<any>({});
+  const [open, setOpen] = useState(false);
+  const ref = useClickOutside(() => {
+    if (open) {
+      setOpen(false);
+    }
+  });
+
+  const openClose = useCallback(() => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+
+    const { x, y, height } = ref.current?.getBoundingClientRect();
+    setPos({ top: y + height, left: x });
+    setOpen(true);
+  }, [open]);
+
+  const toggleChannel = useCallback(
+    (channelId: string) => {
+      const newSelected = selectedChannels.includes(channelId)
+        ? selectedChannels.filter((id) => id !== channelId)
+        : [...selectedChannels, channelId];
+
+      setSelectedChannels(newSelected);
+      onChange(newSelected.join(','));
+
+      if (newSelected.length === 0) {
+        toaster.show(t('all_channels_selected', 'All channels selected'), 'success');
+      } else {
+        toaster.show(
+          t('channels_filtered', `${newSelected.length} channel(s) selected`),
+          'success'
+        );
+      }
+    },
+    [selectedChannels, onChange, toaster, t]
+  );
+
+  const clearAll = useCallback(() => {
+    setSelectedChannels([]);
+    onChange('');
+    toaster.show(t('all_channels_selected', 'All channels selected'), 'success');
+  }, [onChange, toaster, t]);
+
+  return (
+    <div className="relative select-none z-[500]" ref={ref}>
+      <div
+        data-tooltip-id="tooltip"
+        data-tooltip-content={t('select_channel_tooltip', 'Select Channels')}
+        onClick={openClose}
+        className={clsx(
+          'relative z-[20] cursor-pointer h-[42px] rounded-[8px] pl-[16px] pr-[12px] gap-[8px] border flex items-center',
+          open ? 'border-[#612BD3]' : 'border-newColColor'
+        )}
+      >
+        <div className="flex items-center gap-[6px]">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+          </svg>
+          {selectedChannels.length > 0 && (
+            <span className="text-[12px] bg-[#612BD3] text-white rounded-full w-[18px] h-[18px] flex items-center justify-center">
+              {selectedChannels.length}
+            </span>
+          )}
+        </div>
+        <div>
+          <DropdownArrowIcon rotated={open} />
+        </div>
+      </div>
+      {open && (
+        <div
+          style={pos}
+          className="flex flex-col fixed pt-[12px] bg-newBgColorInner menu-shadow min-w-[300px] max-h-[400px] overflow-y-auto"
+        >
+          <div className="flex justify-between items-center px-[12px] mb-[8px]">
+            <div className="text-[14px] font-[600]">
+              {t('channels', 'Channels')}
+            </div>
+            {selectedChannels.length > 0 && (
+              <button
+                onClick={clearAll}
+                className="text-[12px] text-[#612BD3] hover:underline"
+              >
+                {t('clear_all', 'Clear All')}
+              </button>
+            )}
+          </div>
+          {integrations.map((integration) => (
+            <div
+              key={integration.id}
+              onClick={() => toggleChannel(integration.id)}
+              className={clsx(
+                'p-[12px] hover:bg-newBgColor text-[14px] font-[500] flex items-center gap-[12px] cursor-pointer',
+                selectedChannels.includes(integration.id) && 'bg-newBgColor'
+              )}
+            >
+              <div
+                className={clsx(
+                  'w-[18px] h-[18px] border-2 rounded-[4px] flex items-center justify-center',
+                  selectedChannels.includes(integration.id)
+                    ? 'border-[#612BD3] bg-[#612BD3]'
+                    : 'border-newColColor'
+                )}
+              >
+                {selectedChannels.includes(integration.id) && (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                  </svg>
+                )}
+              </div>
+              <img
+                src={integration.picture}
+                alt={integration.name}
+                className="w-[24px] h-[24px] rounded-full"
+              />
+              <div className="flex-1">
+                <div className="font-[500]">{integration.name}</div>
+                <div className="text-[12px] text-gray-500">
+                  {integration.identifier}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -153,6 +153,13 @@ export class PostsRepository {
         ],
         integration: {
           deletedAt: null,
+          ...(query.integrations
+          ? {
+              id: {
+                in: query.integrations.split(','),
+              }
+            }
+          : {}),
         },
         deletedAt: null,
         parentPostId: null,

--- a/libraries/nestjs-libraries/src/dtos/posts/get.posts.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/get.posts.dto.ts
@@ -14,4 +14,8 @@ export class GetPostsDto {
   @IsOptional()
   @IsString()
   customer: string;
+
+  @IsOptional()
+  @IsString()
+  integrations: string;
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature: Multi-select channel filter for calendar/launches view

# Why was this change needed?

This change adds the ability to filter posts by specific integration channels (social media accounts) in the calendar and list views. Previously, users could only filter by customer, but not by individual channels/integrations.

As per request: https://github.com/gitroomhq/postiz-app/issues/1248

# Other information:

No, I din't discuss but thought of it as good first PR. 
Changes Made:
  1. Backend Fix: Updated posts.repository.ts to use Prisma's in operator for filtering multiple integration IDs
  2. New Component: Created SelectChannel component with multi-select dropdown
  3. Context Update: Added channels filter support to calendar.context.tsx
  4. UI Integration: Added channel filter to filters.tsx alongside existing customer filter

Future Enhancements (not included in this PR):
  - Could add "Select All" button
  - Could add integration grouping by platform type
  - Could add saved filter presets

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.