### PR TITLE
Feature/external review sharing link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,10 @@ POSTIZ_OAUTH_CLIENT_ID=""
 POSTIZ_OAUTH_CLIENT_SECRET=""
 # POSTIZ_OAUTH_SCOPE="openid profile email" # default values
 
+# External Review Workflow
+EXTERNAL_REVIEW_ENABLED="true"
+NEXT_PUBLIC_EXTERNAL_REVIEW_ENABLED="true"
+
 # Short Link Service Settings
 # DUB_TOKEN="" # Your self-hosted Dub API token
 # DUB_API_ENDPOINT="https://api.dub.co" # Your self-hosted Dub API endpoint

--- a/apps/backend/src/api/routes/posts.controller.spec.ts
+++ b/apps/backend/src/api/routes/posts.controller.spec.ts
@@ -1,0 +1,84 @@
+import { HttpException } from '@nestjs/common';
+import { PostsController } from './posts.controller';
+
+describe('PostsController review-link routes', () => {
+  const reviewService = {
+    createReviewLink: jest.fn(),
+    revokeActiveReview: jest.fn(),
+  } as any;
+
+  const controller = new PostsController(
+    {} as any,
+    {} as any,
+    {} as any,
+    reviewService
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXTERNAL_REVIEW_ENABLED = 'true';
+  });
+
+  it('creates review link for a post', async () => {
+    reviewService.createReviewLink.mockResolvedValue({
+      token: 'abc',
+      status: 'PENDING',
+      url: 'http://localhost:4200/share/abc',
+    });
+
+    const result = await controller.createReviewLink(
+      { id: 'org-1' } as any,
+      'post-1'
+    );
+
+    expect(result.status).toBe('PENDING');
+    expect(reviewService.createReviewLink).toHaveBeenCalledWith('org-1', 'post-1');
+  });
+
+  it('throws 404 when post does not exist', async () => {
+    reviewService.createReviewLink.mockResolvedValue(null);
+
+    await expect(
+      controller.createReviewLink({ id: 'org-1' } as any, 'missing-post')
+    ).rejects.toBeInstanceOf(HttpException);
+  });
+
+  it('revokes active review link', async () => {
+    reviewService.revokeActiveReview.mockResolvedValue({
+      ok: true,
+      code: 200,
+      status: 'REVOKED',
+    });
+
+    const result = await controller.revokeReviewLink(
+      { id: 'org-1' } as any,
+      'post-1'
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('REVOKED');
+    expect(reviewService.revokeActiveReview).toHaveBeenCalledWith(
+      'org-1',
+      'post-1'
+    );
+  });
+
+  it('throws when revoke fails', async () => {
+    reviewService.revokeActiveReview.mockResolvedValue({
+      ok: false,
+      code: 404,
+      message: 'No active review link found',
+    });
+
+    await expect(
+      controller.revokeReviewLink({ id: 'org-1' } as any, 'post-1')
+    ).rejects.toBeInstanceOf(HttpException);
+  });
+
+  it('throws not found when feature flag is disabled', async () => {
+    process.env.EXTERNAL_REVIEW_ENABLED = 'false';
+    await expect(
+      controller.createReviewLink({ id: 'org-1' } as any, 'post-1')
+    ).rejects.toBeInstanceOf(HttpException);
+  });
+});

--- a/apps/backend/src/api/routes/posts.controller.ts
+++ b/apps/backend/src/api/routes/posts.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   Post,
   Put,
@@ -27,6 +29,7 @@ import {
   AuthorizationActions,
   Sections,
 } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
+import { ReviewService } from '@gitroom/nestjs-libraries/review/review.service';
 
 @ApiTags('Posts')
 @Controller('/posts')
@@ -34,8 +37,15 @@ export class PostsController {
   constructor(
     private _postsService: PostsService,
     private _agentGraphService: AgentGraphService,
-    private _shortLinkService: ShortLinkService
+    private _shortLinkService: ShortLinkService,
+    private _reviewService: ReviewService
   ) {}
+
+  private assertExternalReviewEnabled() {
+    if (process.env.EXTERNAL_REVIEW_ENABLED === 'false') {
+      throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+    }
+  }
 
   @Get('/:id/statistics')
   async getStatistics(
@@ -213,5 +223,34 @@ export class PostsController {
     @Body() body: { content: string; len: number }
   ) {
     return this._postsService.separatePosts(body.content, body.len);
+  }
+
+  @Post('/:id/review-link')
+  async createReviewLink(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string
+  ) {
+    this.assertExternalReviewEnabled();
+    const review = await this._reviewService.createReviewLink(org.id, id);
+    if (!review) {
+      throw new HttpException('Post not found', HttpStatus.NOT_FOUND);
+    }
+    return review;
+  }
+
+  @Post('/:id/review-link/revoke')
+  async revokeReviewLink(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string
+  ) {
+    this.assertExternalReviewEnabled();
+    const result = await this._reviewService.revokeActiveReview(org.id, id);
+    if (!result.ok) {
+      throw new HttpException(
+        result.message,
+        result.code || HttpStatus.BAD_REQUEST
+      );
+    }
+    return result;
   }
 }

--- a/apps/backend/src/api/routes/public.controller.spec.ts
+++ b/apps/backend/src/api/routes/public.controller.spec.ts
@@ -1,0 +1,111 @@
+import { HttpException } from '@nestjs/common';
+import { PublicController } from './public.controller';
+
+describe('PublicController review routes', () => {
+  const reviewService = {
+    getReviewByToken: jest.fn(),
+    decide: jest.fn(),
+  } as any;
+
+  const controller = new PublicController(
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    reviewService
+  );
+
+  const req = {
+    headers: {
+      'x-forwarded-for': '8.8.8.8',
+      'user-agent': 'jest-agent',
+    },
+    ip: '127.0.0.1',
+    socket: { remoteAddress: '127.0.0.1' },
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXTERNAL_REVIEW_ENABLED = 'true';
+  });
+
+  it('returns review payload for valid token', async () => {
+    reviewService.getReviewByToken.mockResolvedValue({
+      status: 'PENDING',
+      posts: [{ id: 'p1' }],
+    });
+
+    const result = await controller.getReview('good-token', req);
+
+    expect(result.status).toBe('PENDING');
+    expect(reviewService.getReviewByToken).toHaveBeenCalledWith(
+      'good-token',
+      expect.objectContaining({ ip: '8.8.8.8' })
+    );
+  });
+
+  it('throws 404 for invalid token', async () => {
+    reviewService.getReviewByToken.mockResolvedValue(null);
+
+    await expect(controller.getReview('bad-token', req)).rejects.toBeInstanceOf(
+      HttpException
+    );
+  });
+
+  it('passes reviewer identity on approve', async () => {
+    reviewService.decide.mockResolvedValue({
+      ok: true,
+      status: 'APPROVED',
+    });
+
+    const result = await controller.approveReview('token-1', req, {
+      reviewerName: 'Alice',
+      reviewerEmail: 'alice@example.com',
+    });
+
+    expect(result.status).toBe('APPROVED');
+    expect(reviewService.decide).toHaveBeenCalledWith(
+      'token-1',
+      'approve',
+      undefined,
+      expect.objectContaining({
+        reviewerName: 'Alice',
+        reviewerEmail: 'alice@example.com',
+      })
+    );
+  });
+
+  it('passes feedback and reviewer identity on reject', async () => {
+    reviewService.decide.mockResolvedValue({
+      ok: true,
+      status: 'REJECTED',
+      feedback: 'Needs edits',
+    });
+
+    const result = await controller.rejectReview('token-1', req, {
+      feedback: 'Needs edits',
+      reviewerName: 'Bob',
+      reviewerEmail: 'bob@example.com',
+    });
+
+    expect(result.status).toBe('REJECTED');
+    expect(result.feedback).toBe('Needs edits');
+    expect(reviewService.decide).toHaveBeenCalledWith(
+      'token-1',
+      'reject',
+      'Needs edits',
+      expect.objectContaining({
+        reviewerName: 'Bob',
+        reviewerEmail: 'bob@example.com',
+      })
+    );
+  });
+
+  it('returns not found when external review feature flag is disabled', async () => {
+    process.env.EXTERNAL_REVIEW_ENABLED = 'false';
+    await expect(controller.getReview('good-token', req)).rejects.toBeInstanceOf(
+      HttpException
+    );
+  });
+});

--- a/apps/backend/src/api/routes/public.controller.ts
+++ b/apps/backend/src/api/routes/public.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   Post,
   Query,
@@ -23,6 +25,7 @@ import { AgentGraphInsertService } from '@gitroom/nestjs-libraries/agent/agent.g
 import { Nowpayments } from '@gitroom/nestjs-libraries/crypto/nowpayments';
 import { Readable, pipeline } from 'stream';
 import { promisify } from 'util';
+import { ReviewService } from '@gitroom/nestjs-libraries/review/review.service';
 
 const pump = promisify(pipeline);
 
@@ -34,8 +37,27 @@ export class PublicController {
     private _trackService: TrackService,
     private _agentGraphInsertService: AgentGraphInsertService,
     private _postsService: PostsService,
-    private _nowpayments: Nowpayments
+    private _nowpayments: Nowpayments,
+    private _reviewService: ReviewService
   ) {}
+
+  private assertExternalReviewEnabled() {
+    if (process.env.EXTERNAL_REVIEW_ENABLED === 'false') {
+      throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+    }
+  }
+
+  private getActorMeta(req: Request) {
+    const forwarded = String(req.headers['x-forwarded-for'] || '');
+    const ip = forwarded
+      ? forwarded.split(',')[0].trim()
+      : req.ip || req.socket?.remoteAddress || '';
+    const userAgent = String(req.headers['user-agent'] || '');
+    return {
+      ip,
+      userAgent,
+    };
+  }
   @Post('/agent')
   async createAgent(@Body() body: { text: string; apiKey: string }) {
     if (
@@ -91,6 +113,80 @@ export class PublicController {
   @Get(`/posts/:id/comments`)
   async getComments(@Param('id') postId: string) {
     return { comments: await this._postsService.getComments(postId) };
+  }
+
+  @Get('/review/:token')
+  async getReview(@Param('token') token: string, @Req() req: Request) {
+    this.assertExternalReviewEnabled();
+    const review = await this._reviewService.getReviewByToken(
+      token,
+      this.getActorMeta(req)
+    );
+    if (!review) {
+      throw new HttpException(
+        'This review link is invalid or expired.',
+        HttpStatus.NOT_FOUND
+      );
+    }
+    return review;
+  }
+
+  @Post('/review/:token/approve')
+  async approveReview(
+    @Param('token') token: string,
+    @Req() req: Request,
+    @Body() body: { reviewerName?: string; reviewerEmail?: string }
+  ) {
+    this.assertExternalReviewEnabled();
+    const result = await this._reviewService.decide(
+      token,
+      'approve',
+      undefined,
+      {
+        ...this.getActorMeta(req),
+        reviewerName: body?.reviewerName,
+        reviewerEmail: body?.reviewerEmail,
+      }
+    );
+    if (!result.ok) {
+      throw new HttpException(
+        result.message,
+        result.code || HttpStatus.BAD_REQUEST
+      );
+    }
+    return {
+      status: result.status,
+    };
+  }
+
+  @Post('/review/:token/reject')
+  async rejectReview(
+    @Param('token') token: string,
+    @Req() req: Request,
+    @Body()
+    body: { feedback?: string; reviewerName?: string; reviewerEmail?: string }
+  ) {
+    this.assertExternalReviewEnabled();
+    const result = await this._reviewService.decide(
+      token,
+      'reject',
+      body?.feedback,
+      {
+        ...this.getActorMeta(req),
+        reviewerName: body?.reviewerName,
+        reviewerEmail: body?.reviewerEmail,
+      }
+    );
+    if (!result.ok) {
+      throw new HttpException(
+        result.message,
+        result.code || HttpStatus.BAD_REQUEST
+      );
+    }
+    return {
+      status: result.status,
+      feedback: result.feedback,
+    };
   }
 
   @Post('/t')

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -15,6 +15,16 @@ import { ChatModule } from '@gitroom/nestjs-libraries/chat/chat.module';
 import { getTemporalModule } from '@gitroom/nestjs-libraries/temporal/temporal.module';
 import { TemporalRegisterMissingSearchAttributesModule } from '@gitroom/nestjs-libraries/temporal/temporal.register';
 import { InfiniteWorkflowRegisterModule } from '@gitroom/nestjs-libraries/temporal/infinite.workflow.register';
+import { TemporalFallbackModule } from '@gitroom/nestjs-libraries/temporal/temporal.fallback.module';
+
+const isTemporalDisabled = process.env.DISABLE_TEMPORAL === 'true';
+const temporalModules = isTemporalDisabled
+  ? [TemporalFallbackModule]
+  : [
+      getTemporalModule(false),
+      TemporalRegisterMissingSearchAttributesModule,
+      InfiniteWorkflowRegisterModule,
+    ];
 
 @Global()
 @Module({
@@ -27,9 +37,7 @@ import { InfiniteWorkflowRegisterModule } from '@gitroom/nestjs-libraries/tempor
     ThirdPartyModule,
     VideoModule,
     ChatModule,
-    getTemporalModule(false),
-    TemporalRegisterMissingSearchAttributesModule,
-    InfiniteWorkflowRegisterModule,
+    ...temporalModules,
     ThrottlerModule.forRoot([
       {
         ttl: 3600000,

--- a/apps/frontend/src/app/(app)/(preview)/p/[id]/page.tsx
+++ b/apps/frontend/src/app/(app)/(preview)/p/[id]/page.tsx
@@ -27,13 +27,9 @@ export const metadata: Metadata = {
 };
 export default async function Auth({
   params: { id },
-  searchParams,
 }: {
   params: {
     id: string;
-  };
-  searchParams?: {
-    share?: string;
   };
 }) {
   const post = await (await internalFetch(`/public/posts/${id}`)).json();
@@ -95,11 +91,9 @@ export default async function Auth({
             </div>
           </div>
           <div className="text-sm text-gray-400 flex items-center gap-[20px]">
-            {!!searchParams?.share && (
-              <div>
-                <CopyClient />
-              </div>
-            )}
+            <div>
+              <CopyClient postId={id} />
+            </div>
             <div className="flex-1">
               {t('publication_date', 'Publication Date:')}{' '}
               <RenderPreviewDate date={post[0].publishDate} />

--- a/apps/frontend/src/app/(app)/(preview)/share/[token]/layout.tsx
+++ b/apps/frontend/src/app/(app)/(preview)/share/[token]/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import { PreviewWrapper } from '@gitroom/frontend/components/preview/preview.wrapper';
+
+export default async function ShareLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="bg-[#000000] min-h-screen">
+      <PreviewWrapper>{children}</PreviewWrapper>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(app)/(preview)/share/[token]/page.tsx
+++ b/apps/frontend/src/app/(app)/(preview)/share/[token]/page.tsx
@@ -167,6 +167,7 @@ export default async function ShareReviewPage({
             token={token}
             initialStatus={status}
             expiresAt={expiresAt}
+            initialFeedback={payload?.feedback}
           />
         </div>
       </div>

--- a/apps/frontend/src/app/(app)/(preview)/share/[token]/page.tsx
+++ b/apps/frontend/src/app/(app)/(preview)/share/[token]/page.tsx
@@ -1,0 +1,175 @@
+import { internalFetch } from '@gitroom/helpers/utils/internal.fetch';
+import { Metadata } from 'next';
+import { isGeneralServerSide } from '@gitroom/helpers/utils/is.general.server.side';
+import Image from 'next/image';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { VideoOrImage } from '@gitroom/react/helpers/video.or.image';
+import { PublicReviewActions } from '@gitroom/frontend/components/review/public.review.actions';
+
+dayjs.extend(utc);
+
+type PreviewPost = {
+  id: string;
+  content?: string;
+  image?: string;
+  integration?: {
+    name?: string;
+    picture?: string;
+    providerIdentifier?: string;
+    profile?: string;
+  };
+};
+
+function extractPosts(payload: any): PreviewPost[] {
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.posts)) return payload.posts;
+  if (Array.isArray(payload?.post)) return payload.post;
+  if (Array.isArray(payload?.preview)) return payload.preview;
+  return [];
+}
+
+function parseMedia(image: string | undefined) {
+  if (!image) return [];
+  try {
+    return JSON.parse(image);
+  } catch {
+    return [];
+  }
+}
+
+export const dynamic = 'force-dynamic';
+export const metadata: Metadata = {
+  title: `${isGeneralServerSide() ? 'Postiz' : 'Gitroom'} Share Review`,
+  description: '',
+};
+
+export default async function ShareReviewPage({
+  params: { token },
+}: {
+  params: {
+    token: string;
+  };
+}) {
+  const response = await internalFetch(`/public/review/${token}`);
+  const payload = await response.json().catch(() => ({}));
+  const posts = extractPosts(payload);
+  const firstPost = posts[0];
+  const status = payload?.status || 'PENDING';
+  const expiresAt = payload?.expiresAt;
+
+  if (!response.ok) {
+    return (
+      <div className="text-white fixed start-0 top-0 w-full h-full flex justify-center items-center text-[20px] text-center p-4">
+        {payload?.message || 'This review link is invalid or expired.'}
+      </div>
+    );
+  }
+
+  if (!posts.length) {
+    return (
+      <div className="text-white fixed start-0 top-0 w-full h-full flex justify-center items-center text-[20px] text-center p-4">
+        No post preview is available for this review token.
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-white">
+      <div className="mx-auto w-full max-w-[1346px] py-4 px-4 lg:px-0">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <Image src="/postiz.svg" width={42} height={42} alt="Postiz logo" />
+            <div>
+              <h1 className="text-[20px] font-semibold">External Review</h1>
+              <p className="text-sm text-gray-400">
+                Please review and approve this scheduled post.
+              </p>
+            </div>
+          </div>
+          {!!payload?.scheduledAt && (
+            <div className="text-sm text-gray-400">
+              Scheduled for {dayjs(payload.scheduledAt).format('MMM D, YYYY h:mm A')}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col lg:flex-row text-white w-full max-w-[1346px] mx-auto gap-5 px-4 lg:px-0 pb-6">
+        <div className="flex-1">
+          <div className="gap-[20px] flex flex-col">
+            {posts.map((post) => (
+              <div
+                key={String(post.id)}
+                className="relative px-4 py-4 bg-third border border-tableBorder rounded-[10px]"
+              >
+                <div className="flex space-x-3">
+                  <div className="flex shrink-0 rounded-full h-30 w-30 relative">
+                    <div className="w-[50px] h-[50px] z-[20]">
+                      <img
+                        className="w-full h-full relative z-[20] bg-black aspect-square rounded-full border-tableBorder"
+                        alt={firstPost?.integration?.name || 'Integration'}
+                        src={firstPost?.integration?.picture || '/no-picture.jpg'}
+                      />
+                    </div>
+                    {!!firstPost?.integration?.providerIdentifier && (
+                      <div className="absolute -end-[5px] -bottom-[5px] w-[30px] h-[30px] z-[20]">
+                        <img
+                          className="w-full h-full bg-black aspect-square rounded-full border-tableBorder"
+                          alt={firstPost.integration.providerIdentifier}
+                          src={`/icons/platforms/${firstPost.integration.providerIdentifier}.png`}
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex-1 space-y-1">
+                    <div className="flex items-center space-x-2">
+                      <h2 className="text-sm font-semibold">
+                        {firstPost?.integration?.name || 'Connected Account'}
+                      </h2>
+                      {!!firstPost?.integration?.profile && (
+                        <span className="text-sm text-gray-500">
+                          @{firstPost.integration.profile}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-col gap-[20px]">
+                      <div
+                        className="text-sm whitespace-pre-wrap"
+                        dangerouslySetInnerHTML={{
+                          __html: post.content || '',
+                        }}
+                      />
+                      <div className="flex w-full gap-[10px]">
+                        {parseMedia(post.image).map((media: { name: string; path: string }) => (
+                          <div
+                            key={media.name}
+                            className="flex-1 rounded-[10px] max-h-[500px] overflow-hidden"
+                          >
+                            <VideoOrImage
+                              isContain={true}
+                              src={media.path}
+                              autoplay={true}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="w-full lg:w-[360px] lg:flex-shrink-0">
+          <PublicReviewActions
+            token={token}
+            initialStatus={status}
+            expiresAt={expiresAt}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -10,7 +10,6 @@ import { Plus_Jakarta_Sans } from 'next/font/google';
 import PlausibleProvider from 'next-plausible';
 import clsx from 'clsx';
 import { VariableContextComponent } from '@gitroom/react/helpers/variable.context';
-import { Fragment } from 'react';
 import { PHProvider } from '@gitroom/react/helpers/posthog';
 import UtmSaver from '@gitroom/helpers/utils/utm.saver';
 import { DubAnalytics } from '@gitroom/frontend/components/layout/dubAnalytics';
@@ -35,9 +34,7 @@ const jakartaSans = Plus_Jakarta_Sans({
 
 export default async function AppLayout({ children }: { children: ReactNode }) {
   const allHeaders = headers();
-  const Plausible = !!process.env.STRIPE_PUBLISHABLE_KEY
-    ? PlausibleProvider
-    : Fragment;
+  const isPlausibleEnabled = !!process.env.STRIPE_PUBLISHABLE_KEY;
   return (
     <html>
       <head>
@@ -79,6 +76,9 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           disableXAnalytics={!!process.env.DISABLE_X_ANALYTICS}
           sentryDsn={process.env.NEXT_PUBLIC_SENTRY_DSN!}
           extensionId={process.env.EXTENSION_ID || ''}
+          externalReviewEnabled={
+            process.env.NEXT_PUBLIC_EXTERNAL_REVIEW_ENABLED !== 'false'
+          }
           language={allHeaders.get(headerName)}
           transloadit={
             process.env.TRANSLOADIT_AUTH && process.env.TRANSLOADIT_TEMPLATE
@@ -94,9 +94,21 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
             <HtmlComponent />
             <DubAnalytics />
             <FacebookComponent />
-            <Plausible
-              domain={!!process.env.IS_GENERAL ? 'postiz.com' : 'gitroom.com'}
-            >
+            {isPlausibleEnabled ? (
+              <PlausibleProvider
+                domain={!!process.env.IS_GENERAL ? 'postiz.com' : 'gitroom.com'}
+              >
+                <PHProvider
+                  phkey={process.env.NEXT_PUBLIC_POSTHOG_KEY}
+                  host={process.env.NEXT_PUBLIC_POSTHOG_HOST}
+                >
+                  <LayoutContext>
+                    <UtmSaver />
+                    {children}
+                  </LayoutContext>
+                </PHProvider>
+              </PlausibleProvider>
+            ) : (
               <PHProvider
                 phkey={process.env.NEXT_PUBLIC_POSTHOG_KEY}
                 host={process.env.NEXT_PUBLIC_POSTHOG_HOST}
@@ -106,7 +118,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
                   {children}
                 </LayoutContext>
               </PHProvider>
-            </Plausible>
+            )}
           </SentryComponent>
         </VariableContextComponent>
       </body>

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -50,6 +50,9 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           disableXAnalytics={!!process.env.DISABLE_X_ANALYTICS}
           sentryDsn={process.env.NEXT_PUBLIC_SENTRY_DSN!}
           extensionId={process.env.EXTENSION_ID || ''}
+          externalReviewEnabled={
+            process.env.NEXT_PUBLIC_EXTERNAL_REVIEW_ENABLED !== 'false'
+          }
           transloadit={
             process.env.TRANSLOADIT_AUTH && process.env.TRANSLOADIT_TEMPLATE
               ? [

--- a/apps/frontend/src/components/layout/layout.context.tsx
+++ b/apps/frontend/src/components/layout/layout.context.tsx
@@ -28,7 +28,8 @@ function LayoutContextInner(params: { children: ReactNode }) {
     async (url: string, options: RequestInit, response: Response) => {
       if (
         typeof window !== 'undefined' &&
-        window.location.href.includes('/p/')
+        (window.location.href.includes('/p/') ||
+          window.location.href.includes('/share/'))
       ) {
         return true;
       }

--- a/apps/frontend/src/components/preview/comments.components.tsx
+++ b/apps/frontend/src/components/preview/comments.components.tsx
@@ -2,32 +2,84 @@
 
 import { useUser } from '@gitroom/frontend/components/layout/user.context';
 import { Button } from '@gitroom/react/form/button';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback } from 'react';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import useSWR from 'swr';
 import { FieldValues, SubmitHandler, useForm } from 'react-hook-form';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
+
+function getCommentAuthor(comment: any, fallback: string) {
+  const firstName = comment?.user?.name?.trim?.() || '';
+  const lastName = comment?.user?.lastName?.trim?.() || '';
+  const fullName = `${firstName} ${lastName}`.trim();
+  if (fullName) {
+    return fullName;
+  }
+  return comment?.user?.email || fallback;
+}
+
+function getExternalReviewerName(content: string) {
+  if (!content?.startsWith('[External Review]')) {
+    return '';
+  }
+  const byMatch = content.match(/\bby\s+([^:]+?)(?::|$)/i);
+  if (!byMatch?.[1]) {
+    return '';
+  }
+  return byMatch[1].trim();
+}
+
+function parseExternalReviewMeta(content: string) {
+  if (!content?.startsWith('[External Review]')) {
+    return null;
+  }
+
+  const approved = /\bapproved\b/i.test(content);
+  const rejected = /\brejected\b/i.test(content);
+  const expired = /\bexpired\b/i.test(content);
+  const decision = approved
+    ? 'APPROVED'
+    : rejected
+    ? 'REJECTED'
+    : expired
+    ? 'EXPIRED'
+    : 'UPDATED';
+
+  const reviewer = getExternalReviewerName(content);
+  const feedbackMatch = content.match(/:\s*(.+)$/);
+  const feedback =
+    rejected && feedbackMatch?.[1] ? feedbackMatch[1].trim() : '';
+
+  return {
+    decision,
+    reviewer,
+    feedback,
+  };
+}
+
+function decisionBadgeClass(decision: string) {
+  if (decision === 'APPROVED') {
+    return 'bg-green-900/40 text-green-300 border border-green-700/60';
+  }
+  if (decision === 'REJECTED') {
+    return 'bg-red-900/40 text-red-300 border border-red-700/60';
+  }
+  if (decision === 'EXPIRED') {
+    return 'bg-gray-700/40 text-gray-300 border border-gray-600';
+  }
+  return 'bg-blue-900/30 text-blue-300 border border-blue-700/60';
+}
+
 export const RenderComponents: FC<{
   postId: string;
 }> = (props) => {
   const { postId } = props;
   const fetch = useFetch();
+  const t = useT();
   const comments = useCallback(async () => {
     return (await fetch(`/public/posts/${postId}/comments`)).json();
   }, [postId]);
-  const { data, mutate, isLoading } = useSWR('comments', comments);
-  const mapUsers = useMemo(() => {
-    return (data?.comments || []).reduce(
-      (all: any, current: any) => {
-        all.users[current.userId] = all.users[current.userId] || all.counter++;
-        return all;
-      },
-      {
-        users: {},
-        counter: 1,
-      }
-    ).users;
-  }, [data]);
+  const { data, mutate, isLoading } = useSWR(['comments', postId], comments);
   const { handleSubmit, register, setValue } = useForm();
   const submit: SubmitHandler<FieldValues> = useCallback(
     async (e) => {
@@ -40,8 +92,6 @@ export const RenderComponents: FC<{
     },
     [postId, mutate]
   );
-
-  const t = useT();
 
   if (isLoading) {
     return <></>;
@@ -85,20 +135,65 @@ export const RenderComponents: FC<{
           <h3 className="text-lg font-semibold">{t('comments', 'Comments')}</h3>
         )}
         {data.comments.map((comment: any) => (
+          (() => {
+            const externalMeta = parseExternalReviewMeta(comment.content);
+            return (
           <div
             key={comment.id}
-            className="flex space-x-3 border-t border-tableBorder py-3"
+            className={`flex space-x-3 border-t py-3 ${
+              externalMeta?.decision === 'APPROVED'
+                ? 'border-green-800/40 bg-green-900/10 rounded-[8px] px-3'
+                : externalMeta?.decision === 'REJECTED'
+                ? 'border-red-800/40 bg-red-900/10 rounded-[8px] px-3'
+                : 'border-tableBorder'
+            }`}
           >
             <div className="flex-1 space-y-1">
-              <div className="flex items-center space-x-2">
-                <h3 className="text-sm font-semibold">
-                  {t('user', 'User')}
-                  {mapUsers[comment.userId]}
-                </h3>
-              </div>
+              {externalMeta ? (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold ${decisionBadgeClass(
+                        externalMeta.decision
+                      )}`}
+                    >
+                      {externalMeta.decision}
+                    </span>
+                    <h3 className="text-sm font-semibold">
+                      {externalMeta.reviewer ||
+                        t('external_reviewer', 'External Reviewer')}
+                    </h3>
+                  </div>
+                  <div className="text-[12px] text-gray-400 space-y-1">
+                    <div>
+                      <span className="font-semibold text-gray-300">Decision by:</span>{' '}
+                      {externalMeta.reviewer ||
+                        t('external_reviewer', 'External Reviewer')}
+                    </div>
+                    <div>
+                      <span className="font-semibold text-gray-300">Date:</span>{' '}
+                      {new Date(comment.createdAt).toLocaleString()}
+                    </div>
+                    {!!externalMeta.feedback && (
+                      <div>
+                        <span className="font-semibold text-gray-300">Feedback:</span>{' '}
+                        {externalMeta.feedback}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center space-x-2">
+                  <h3 className="text-sm font-semibold">
+                    {getCommentAuthor(comment, t('user', 'User'))}
+                  </h3>
+                </div>
+              )}
               <p className="text-sm text-gray-300">{comment.content}</p>
             </div>
           </div>
+            );
+          })()
         ))}
       </div>
     </>

--- a/apps/frontend/src/components/preview/copy.client.tsx
+++ b/apps/frontend/src/components/preview/copy.client.tsx
@@ -5,16 +5,32 @@ import copy from 'copy-to-clipboard';
 import { useCallback } from 'react';
 import { useToaster } from '@gitroom/react/toaster/toaster';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
-export const CopyClient = () => {
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import { useVariables } from '@gitroom/react/helpers/variable.context';
+export const CopyClient = ({ postId }: { postId: string }) => {
   const toast = useToaster();
   const t = useT();
-  const copyToClipboard = useCallback(() => {
-    toast.show(
-      t('link_copied_to_clipboard', 'Link copied to clipboard'),
-      'success'
-    );
-    copy(window.location.href.split?.('?')?.shift()!);
+  const fetch = useFetch();
+  const { externalReviewEnabled } = useVariables();
+  const copyToClipboard = useCallback(async () => {
+    const response = await fetch(`/posts/${postId}/review-link`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      toast.show(
+        t('could_not_generate_review_link', 'Could not generate review link'),
+        'warning'
+      );
+      return;
+    }
+    const { url } = await response.json();
+    copy(url);
+    toast.show(t('link_copied_to_clipboard', 'Link copied to clipboard'), 'success');
   }, []);
+  if (!externalReviewEnabled) {
+    return null;
+  }
+
   return (
     <Button onClick={copyToClipboard}>
       {t('share_with_a_client', 'Share with a client')}

--- a/apps/frontend/src/components/review/public.review.actions.tsx
+++ b/apps/frontend/src/components/review/public.review.actions.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { Button } from '@gitroom/react/form/button';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import { useState } from 'react';
+import { useToaster } from '@gitroom/react/toaster/toaster';
+import dayjs from 'dayjs';
+
+type ReviewStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'EXPIRED';
+
+const TERMINAL_STATES: ReviewStatus[] = ['APPROVED', 'REJECTED', 'EXPIRED'];
+
+function normalizeStatus(status?: string): ReviewStatus {
+  if (status === 'APPROVED') return 'APPROVED';
+  if (status === 'REJECTED') return 'REJECTED';
+  if (status === 'EXPIRED') return 'EXPIRED';
+  return 'PENDING';
+}
+
+async function parseResponse(response: Response) {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+export function PublicReviewActions({
+  token,
+  initialStatus,
+  expiresAt,
+}: {
+  token: string;
+  initialStatus?: string;
+  expiresAt?: string;
+}) {
+  const fetch = useFetch();
+  const toast = useToaster();
+  const [loadingApprove, setLoadingApprove] = useState(false);
+  const [loadingReject, setLoadingReject] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [status, setStatus] = useState<ReviewStatus>(
+    normalizeStatus(initialStatus)
+  );
+
+  const isTerminal = TERMINAL_STATES.includes(status);
+
+  const decide = async (decision: 'approve' | 'reject') => {
+    if (decision === 'reject' && !feedback.trim().length) {
+      toast.show('Please add feedback before rejecting', 'warning');
+      return;
+    }
+
+    if (decision === 'approve') {
+      setLoadingApprove(true);
+    } else {
+      setLoadingReject(true);
+    }
+
+    try {
+      const response = await fetch(`/public/review/${token}/${decision}`, {
+        method: 'POST',
+        body:
+          decision === 'reject'
+            ? JSON.stringify({ feedback: feedback.trim() })
+            : JSON.stringify({}),
+      });
+      const data = await parseResponse(response);
+
+      if (!response.ok) {
+        toast.show(
+          data?.message || 'Could not save your decision. Please try again.',
+          'warning'
+        );
+        return;
+      }
+
+      const nextStatus =
+        decision === 'approve'
+          ? 'APPROVED'
+          : normalizeStatus(data?.status || 'REJECTED');
+
+      setStatus(nextStatus);
+      toast.show(
+        decision === 'approve'
+          ? 'Post approved successfully'
+          : 'Feedback sent successfully',
+        'success'
+      );
+    } finally {
+      setLoadingApprove(false);
+      setLoadingReject(false);
+    }
+  };
+
+  return (
+    <div className="bg-third border border-tableBorder p-4 rounded-[10px] flex flex-col gap-4">
+      <div>
+        <h2 className="text-[18px] font-semibold text-white">Review Decision</h2>
+        <p className="text-[13px] text-gray-400 mt-1">
+          Status: <span className="text-white">{status}</span>
+        </p>
+        {!!expiresAt && (
+          <p className="text-[13px] text-gray-400">
+            Expires: {dayjs(expiresAt).format('MMM D, YYYY h:mm A')}
+          </p>
+        )}
+      </div>
+
+      {isTerminal ? (
+        <div className="text-sm text-gray-300">
+          This review link is closed. No additional action is needed.
+        </div>
+      ) : (
+        <>
+          <textarea
+            className="w-full min-h-[120px] p-3 rounded-[8px] bg-input border border-fifth outline-none text-inputText placeholder-inputText"
+            placeholder="Optional feedback for rejection..."
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+          />
+          <div className="flex gap-2">
+            <Button
+              className="flex-1 !bg-green-700"
+              loading={loadingApprove}
+              onClick={() => decide('approve')}
+            >
+              Approve
+            </Button>
+            <Button
+              className="flex-1 !bg-red-700"
+              loading={loadingReject}
+              onClick={() => decide('reject')}
+            >
+              Reject
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/review/public.review.actions.tsx
+++ b/apps/frontend/src/components/review/public.review.actions.tsx
@@ -6,14 +6,20 @@ import { useState } from 'react';
 import { useToaster } from '@gitroom/react/toaster/toaster';
 import dayjs from 'dayjs';
 
-type ReviewStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'EXPIRED';
+type ReviewStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'EXPIRED' | 'REVOKED';
 
-const TERMINAL_STATES: ReviewStatus[] = ['APPROVED', 'REJECTED', 'EXPIRED'];
+const TERMINAL_STATES: ReviewStatus[] = [
+  'APPROVED',
+  'REJECTED',
+  'EXPIRED',
+  'REVOKED',
+];
 
 function normalizeStatus(status?: string): ReviewStatus {
   if (status === 'APPROVED') return 'APPROVED';
   if (status === 'REJECTED') return 'REJECTED';
   if (status === 'EXPIRED') return 'EXPIRED';
+  if (status === 'REVOKED') return 'REVOKED';
   return 'PENDING';
 }
 
@@ -25,20 +31,41 @@ async function parseResponse(response: Response) {
   }
 }
 
+function getStatusBadgeClass(status: ReviewStatus) {
+  if (status === 'APPROVED') {
+    return 'bg-green-900/40 text-green-300 border border-green-700/60';
+  }
+  if (status === 'REJECTED') {
+    return 'bg-red-900/40 text-red-300 border border-red-700/60';
+  }
+  if (status === 'EXPIRED') {
+    return 'bg-gray-700/40 text-gray-300 border border-gray-600';
+  }
+  if (status === 'REVOKED') {
+    return 'bg-gray-700/40 text-gray-300 border border-gray-600';
+  }
+  return 'bg-blue-900/30 text-blue-300 border border-blue-700/60';
+}
+
 export function PublicReviewActions({
   token,
   initialStatus,
   expiresAt,
+  initialFeedback,
 }: {
   token: string;
   initialStatus?: string;
   expiresAt?: string;
+  initialFeedback?: string;
 }) {
   const fetch = useFetch();
   const toast = useToaster();
   const [loadingApprove, setLoadingApprove] = useState(false);
   const [loadingReject, setLoadingReject] = useState(false);
   const [feedback, setFeedback] = useState('');
+  const [reviewerName, setReviewerName] = useState('');
+  const [reviewerEmail, setReviewerEmail] = useState('');
+  const [savedFeedback, setSavedFeedback] = useState(initialFeedback || '');
   const [status, setStatus] = useState<ReviewStatus>(
     normalizeStatus(initialStatus)
   );
@@ -46,6 +73,11 @@ export function PublicReviewActions({
   const isTerminal = TERMINAL_STATES.includes(status);
 
   const decide = async (decision: 'approve' | 'reject') => {
+    if (!reviewerName.trim().length) {
+      toast.show('Please add your name before submitting', 'warning');
+      return;
+    }
+
     if (decision === 'reject' && !feedback.trim().length) {
       toast.show('Please add feedback before rejecting', 'warning');
       return;
@@ -62,8 +94,15 @@ export function PublicReviewActions({
         method: 'POST',
         body:
           decision === 'reject'
-            ? JSON.stringify({ feedback: feedback.trim() })
-            : JSON.stringify({}),
+            ? JSON.stringify({
+                feedback: feedback.trim(),
+                reviewerName: reviewerName.trim(),
+                reviewerEmail: reviewerEmail.trim() || undefined,
+              })
+            : JSON.stringify({
+                reviewerName: reviewerName.trim(),
+                reviewerEmail: reviewerEmail.trim() || undefined,
+              }),
       });
       const data = await parseResponse(response);
 
@@ -81,6 +120,9 @@ export function PublicReviewActions({
           : normalizeStatus(data?.status || 'REJECTED');
 
       setStatus(nextStatus);
+      if (decision === 'reject') {
+        setSavedFeedback(feedback.trim());
+      }
       toast.show(
         decision === 'approve'
           ? 'Post approved successfully'
@@ -97,9 +139,16 @@ export function PublicReviewActions({
     <div className="bg-third border border-tableBorder p-4 rounded-[10px] flex flex-col gap-4">
       <div>
         <h2 className="text-[18px] font-semibold text-white">Review Decision</h2>
-        <p className="text-[13px] text-gray-400 mt-1">
-          Status: <span className="text-white">{status}</span>
-        </p>
+        <div className="text-[13px] text-gray-400 mt-2 flex items-center gap-2">
+          <span>Status:</span>
+          <span
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-[12px] font-semibold ${getStatusBadgeClass(
+              status
+            )}`}
+          >
+            {status}
+          </span>
+        </div>
         {!!expiresAt && (
           <p className="text-[13px] text-gray-400">
             Expires: {dayjs(expiresAt).format('MMM D, YYYY h:mm A')}
@@ -108,14 +157,42 @@ export function PublicReviewActions({
       </div>
 
       {isTerminal ? (
-        <div className="text-sm text-gray-300">
-          This review link is closed. No additional action is needed.
+        <div
+          className={`text-sm flex flex-col gap-2 p-3 rounded-[8px] ${
+            status === 'APPROVED'
+              ? 'bg-green-900/20 border border-green-800/50 text-green-200'
+              : status === 'REJECTED'
+              ? 'bg-red-900/20 border border-red-800/50 text-red-200'
+              : 'bg-gray-700/20 border border-gray-600 text-gray-300'
+          }`}
+        >
+          <div>This review link is closed. No additional action is needed.</div>
+          {status === 'REJECTED' && !!savedFeedback && (
+            <div className="p-3 rounded-[8px] bg-input border border-fifth text-inputText space-y-1">
+              <div className="text-[12px] uppercase tracking-wide text-gray-400">
+                Feedback
+              </div>
+              <div>{savedFeedback}</div>
+            </div>
+          )}
         </div>
       ) : (
         <>
+          <input
+            className="w-full p-3 rounded-[8px] bg-input border border-fifth outline-none text-inputText placeholder-inputText"
+            placeholder="Your name (required)"
+            value={reviewerName}
+            onChange={(e) => setReviewerName(e.target.value)}
+          />
+          <input
+            className="w-full p-3 rounded-[8px] bg-input border border-fifth outline-none text-inputText placeholder-inputText"
+            placeholder="Email (optional)"
+            value={reviewerEmail}
+            onChange={(e) => setReviewerEmail(e.target.value)}
+          />
           <textarea
             className="w-full min-h-[120px] p-3 rounded-[8px] bg-input border border-fifth outline-none text-inputText placeholder-inputText"
-            placeholder="Optional feedback for rejection..."
+            placeholder="Feedback is required for rejection..."
             value={feedback}
             onChange={(e) => setFeedback(e.target.value)}
           />

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -38,6 +38,7 @@ export async function middleware(request: NextRequest) {
   if (
     nextUrl.pathname.startsWith('/uploads/') ||
     nextUrl.pathname.startsWith('/p/') ||
+    nextUrl.pathname.startsWith('/share/') ||
     nextUrl.pathname.startsWith('/icons/')
   ) {
     return topResponse;

--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -17,6 +17,7 @@ import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integration
 import { timer } from '@gitroom/helpers/utils/timer';
 import { IntegrationService } from '@gitroom/nestjs-libraries/database/prisma/integrations/integration.service';
 import { WebhooksService } from '@gitroom/nestjs-libraries/database/prisma/webhooks/webhooks.service';
+import { ReviewService } from '@gitroom/nestjs-libraries/review/review.service';
 import { TypedSearchAttributes } from '@temporalio/common';
 import {
   organizationId,
@@ -33,7 +34,8 @@ export class PostActivity {
     private _integrationService: IntegrationService,
     private _refreshIntegrationService: RefreshIntegrationService,
     private _webhookService: WebhooksService,
-    private _temporalService: TemporalService
+    private _temporalService: TemporalService,
+    private _reviewService: ReviewService
   ) {}
 
   @ActivityMethod()
@@ -322,5 +324,15 @@ export class PostActivity {
       await this._refreshIntegrationService.setBetweenSteps(integration);
       return false;
     }
+  }
+
+  @ActivityMethod()
+  async sendExternalReviewReminder(token: string) {
+    return this._reviewService.sendReminderIfPending(token);
+  }
+
+  @ActivityMethod()
+  async expireExternalReview(token: string) {
+    return this._reviewService.expireIfPending(token);
   }
 }

--- a/apps/orchestrator/src/app.module.ts
+++ b/apps/orchestrator/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { PostActivity } from '@gitroom/orchestrator/activities/post.activity';
 import { getTemporalModule } from '@gitroom/nestjs-libraries/temporal/temporal.module';
+import { TemporalFallbackModule } from '@gitroom/nestjs-libraries/temporal/temporal.fallback.module';
 import { DatabaseModule } from '@gitroom/nestjs-libraries/database/prisma/database.module';
 import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
 import { EmailActivity } from '@gitroom/orchestrator/activities/email.activity';
@@ -12,11 +13,12 @@ const activities = [
   EmailActivity,
   IntegrationsActivity,
 ];
+const temporalImports =
+  process.env.DISABLE_TEMPORAL === 'true'
+    ? [TemporalFallbackModule]
+    : [getTemporalModule(true, require.resolve('./workflows'), activities)];
 @Module({
-  imports: [
-    DatabaseModule,
-    getTemporalModule(true, require.resolve('./workflows'), activities),
-  ],
+  imports: [DatabaseModule, ...temporalImports],
   controllers: [],
   providers: [...activities],
   get exports() {

--- a/apps/orchestrator/src/signals/external.review.signal.ts
+++ b/apps/orchestrator/src/signals/external.review.signal.ts
@@ -1,0 +1,6 @@
+import { defineSignal } from '@temporalio/workflow';
+
+export const externalReviewResolvedSignal = defineSignal<
+  [{ status: 'APPROVED' | 'REJECTED' | 'EXPIRED' | 'REVOKED' }]
+>('externalReviewResolved');
+

--- a/apps/orchestrator/src/workflows/external.review.workflow.spec.ts
+++ b/apps/orchestrator/src/workflows/external.review.workflow.spec.ts
@@ -1,0 +1,61 @@
+const reminder = jest.fn(async () => undefined);
+const expire = jest.fn(async () => undefined);
+let resolvedHandler: ((payload: {
+  status: 'APPROVED' | 'REJECTED' | 'EXPIRED' | 'REVOKED';
+}) => void) | null = null;
+let autoResolve = false;
+
+jest.mock('@temporalio/workflow', () => ({
+  proxyActivities: jest.fn(() => ({
+    sendExternalReviewReminder: reminder,
+    expireExternalReview: expire,
+  })),
+  sleep: jest.fn(async () => undefined),
+  condition: jest.fn(async (fn: () => boolean) => {
+    if (fn()) return;
+    await new Promise(() => undefined);
+  }),
+  setHandler: jest.fn((_signal: any, handler: any) => {
+    resolvedHandler = handler;
+    if (autoResolve) {
+      handler({ status: 'APPROVED' });
+    }
+  }),
+}));
+
+jest.mock('@gitroom/orchestrator/signals/external.review.signal', () => ({
+  externalReviewResolvedSignal: 'externalReviewResolved',
+}));
+
+import { externalReviewWorkflow } from './external.review.workflow';
+
+describe('externalReviewWorkflow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolvedHandler = null;
+    autoResolve = false;
+  });
+
+  it('sends reminder then expires when not resolved', async () => {
+    await externalReviewWorkflow({
+      token: 't1',
+      reminderDelayMs: 0,
+      expiryDelayMs: 0,
+    });
+
+    expect(reminder).toHaveBeenCalledWith('t1');
+    expect(expire).toHaveBeenCalledWith('t1');
+  });
+
+  it('skips reminder/expiry when resolved signal arrives first', async () => {
+    autoResolve = true;
+    await externalReviewWorkflow({
+      token: 't2',
+      reminderDelayMs: 0,
+      expiryDelayMs: 0,
+    });
+
+    expect(reminder).not.toHaveBeenCalled();
+    expect(expire).not.toHaveBeenCalled();
+  });
+});

--- a/apps/orchestrator/src/workflows/external.review.workflow.ts
+++ b/apps/orchestrator/src/workflows/external.review.workflow.ts
@@ -1,0 +1,55 @@
+import {
+  condition,
+  proxyActivities,
+  setHandler,
+  sleep,
+} from '@temporalio/workflow';
+import { PostActivity } from '@gitroom/orchestrator/activities/post.activity';
+import { externalReviewResolvedSignal } from '@gitroom/orchestrator/signals/external.review.signal';
+
+const { sendExternalReviewReminder, expireExternalReview } =
+  proxyActivities<PostActivity>({
+    startToCloseTimeout: '10 minute',
+    taskQueue: 'main',
+    cancellationType: 'ABANDON',
+    retry: {
+      maximumAttempts: 3,
+      backoffCoefficient: 1,
+      initialInterval: '2 minutes',
+    },
+  });
+
+export async function externalReviewWorkflow({
+  token,
+  reminderDelayMs = 0,
+  expiryDelayMs = 0,
+}: {
+  token: string;
+  reminderDelayMs?: number;
+  expiryDelayMs?: number;
+}) {
+  const safeReminderDelay = Math.max(0, Number(reminderDelayMs || 0));
+  const safeExpiryDelay = Math.max(0, Number(expiryDelayMs || 0));
+  let resolved = false;
+
+  setHandler(externalReviewResolvedSignal, () => {
+    resolved = true;
+  });
+
+  if (safeReminderDelay > 0) {
+    await Promise.race([sleep(safeReminderDelay), condition(() => resolved)]);
+  }
+
+  if (!resolved) {
+    await sendExternalReviewReminder(token);
+  }
+
+  const remainingToExpiry = Math.max(0, safeExpiryDelay - safeReminderDelay);
+  if (remainingToExpiry > 0) {
+    await Promise.race([sleep(remainingToExpiry), condition(() => resolved)]);
+  }
+
+  if (!resolved) {
+    await expireExternalReview(token);
+  }
+}

--- a/apps/orchestrator/src/workflows/index.ts
+++ b/apps/orchestrator/src/workflows/index.ts
@@ -5,3 +5,4 @@ export * from './missing.post.workflow';
 export * from './send.email.workflow';
 export * from './refresh.token.workflow';
 export * from './streak.workflow';
+export * from './external.review.workflow';

--- a/jest.review.config.cjs
+++ b/jest.review.config.cjs
@@ -1,0 +1,30 @@
+const path = require('path');
+
+module.exports = {
+  rootDir: __dirname,
+  testEnvironment: 'node',
+  testMatch: ['**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.(t|j)s$': [
+      'ts-jest',
+      {
+        tsconfig: path.join(__dirname, 'tsconfig.base.json'),
+        isolatedModules: true,
+        diagnostics: false,
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^@gitroom/backend/(.*)$': '<rootDir>/apps/backend/src/$1',
+    '^@gitroom/frontend/(.*)$': '<rootDir>/apps/frontend/src/$1',
+    '^@gitroom/helpers/(.*)$': '<rootDir>/libraries/helpers/src/$1',
+    '^@gitroom/nestjs-libraries/(.*)$':
+      '<rootDir>/libraries/nestjs-libraries/src/$1',
+    '^@gitroom/react/(.*)$': '<rootDir>/libraries/react-shared-libraries/src/$1',
+    '^@gitroom/plugins/(.*)$': '<rootDir>/libraries/plugins/src/$1',
+    '^@gitroom/orchestrator/(.*)$': '<rootDir>/apps/orchestrator/src/$1',
+    '^@gitroom/extension/(.*)$': '<rootDir>/apps/extension/src/$1',
+  },
+};
+

--- a/libraries/nestjs-libraries/src/database/prisma/database.module.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/database.module.ts
@@ -36,6 +36,7 @@ import { ThirdPartyService } from '@gitroom/nestjs-libraries/database/prisma/thi
 import { VideoManager } from '@gitroom/nestjs-libraries/videos/video.manager';
 import { FalService } from '@gitroom/nestjs-libraries/openai/fal.service';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
+import { ReviewService } from '@gitroom/nestjs-libraries/review/review.service';
 
 @Global()
 @Module({
@@ -81,6 +82,7 @@ import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integration
     ThirdPartyRepository,
     ThirdPartyService,
     VideoManager,
+    ReviewService,
   ],
   get exports() {
     return this.providers;

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -753,9 +753,42 @@ export class PostsRepository {
   }
 
   async getComments(postId: string) {
+    const post = await this._post.model.post.findUnique({
+      where: {
+        id: postId,
+      },
+      select: {
+        group: true,
+        organizationId: true,
+      },
+    });
+
+    if (!post) {
+      return [];
+    }
+
     return this._comments.model.comments.findMany({
       where: {
-        postId,
+        deletedAt: null,
+        organizationId: post.organizationId,
+        post: {
+          group: post.group,
+          deletedAt: null,
+        },
+      },
+      select: {
+        id: true,
+        content: true,
+        userId: true,
+        createdAt: true,
+        user: {
+          select: {
+            id: true,
+            name: true,
+            lastName: true,
+            email: true,
+          },
+        },
       },
       orderBy: {
         createdAt: 'asc',

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Organization {
   media             Media[]
   buyerOrganization MessagesGroup[]
   notifications     Notifications[]
+  reviewTokens      ReviewToken[]
   plugs             Plugs[]
   post              Post[]              @relation("organization")
   submittedPost     Post[]              @relation("submittedForOrg")
@@ -414,6 +415,7 @@ model Post {
   comments                   Comments[]
   errors                     Errors[]
   payoutProblems             PayoutProblems[]
+  reviewTokens               ReviewToken[]
   integration                Integration               @relation(fields: [integrationId], references: [id])
   lastMessage                Messages?                 @relation(fields: [lastMessageId], references: [id])
   organization               Organization              @relation("organization", fields: [organizationId], references: [id])
@@ -452,6 +454,40 @@ model Notifications {
   @@index([createdAt])
   @@index([organizationId])
   @@index([deletedAt])
+}
+
+model ReviewToken {
+  id             String        @id @default(uuid())
+  organizationId String
+  postId         String
+  tokenHash      String        @unique
+  status         ReviewStatus  @default(PENDING)
+  expiresAt      DateTime
+  decidedAt      DateTime?
+  feedback       String?
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+  organization   Organization  @relation(fields: [organizationId], references: [id])
+  post           Post          @relation(fields: [postId], references: [id])
+  events         ReviewEvent[]
+
+  @@index([organizationId])
+  @@index([postId])
+  @@index([status])
+  @@index([expiresAt])
+}
+
+model ReviewEvent {
+  id            String      @id @default(uuid())
+  reviewTokenId String
+  type          String
+  actor         Json?
+  details       String?
+  createdAt     DateTime    @default(now())
+  reviewToken   ReviewToken @relation(fields: [reviewTokenId], references: [id], onDelete: Cascade)
+
+  @@index([reviewTokenId])
+  @@index([createdAt])
 }
 
 model MessagesGroup {
@@ -892,4 +928,12 @@ enum ShortLinkPreference {
   ASK
   YES
   NO
+}
+
+enum ReviewStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  EXPIRED
+  REVOKED
 }

--- a/libraries/nestjs-libraries/src/review/review.flow.spec.ts
+++ b/libraries/nestjs-libraries/src/review/review.flow.spec.ts
@@ -1,0 +1,227 @@
+const redisStore = new Map<string, string>();
+let redisMock: any;
+
+jest.mock('@gitroom/nestjs-libraries/redis/redis.service', () => ({
+  ioRedis: (redisMock = {
+    get: jest.fn(async (key: string) => redisStore.get(key) || null),
+    set: jest.fn(async (key: string, value: string) => {
+      redisStore.set(key, value);
+      return 'OK';
+    }),
+    del: jest.fn(async (key: string) => {
+      redisStore.delete(key);
+      return 1;
+    }),
+    incr: jest.fn(async (key: string) => {
+      const current = Number(redisStore.get(key) || 0);
+      const next = current + 1;
+      redisStore.set(key, String(next));
+      return next;
+    }),
+    expire: jest.fn(async () => 1),
+  }),
+}));
+
+import { ReviewService } from './review.service';
+
+describe('ReviewService end-to-end flow tests', () => {
+  const tokenRows: any[] = [];
+  const eventRows: any[] = [];
+  const postsService = {
+    getPostsRecursively: jest.fn(),
+  } as any;
+  const prisma = {
+    post: {
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    userOrganization: {
+      findFirst: jest.fn(),
+    },
+    comments: {
+      create: jest.fn(),
+    },
+    reviewToken: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    reviewEvent: {
+      create: jest.fn(),
+    },
+  } as any;
+  const notificationService = {
+    inAppNotification: jest.fn(),
+  } as any;
+  const temporalService = {
+    client: {
+      getRawClient: jest.fn(() => ({
+        workflow: {
+          start: jest.fn(async () => undefined),
+        },
+      })),
+      getWorkflowHandle: jest.fn(async () => ({
+        signal: jest.fn(async () => undefined),
+      })),
+    },
+  } as any;
+
+  let service: ReviewService;
+
+  beforeEach(() => {
+    redisStore.clear();
+    tokenRows.length = 0;
+    eventRows.length = 0;
+    jest.clearAllMocks();
+    process.env.FRONTEND_URL = 'http://localhost:4200';
+    service = new ReviewService(
+      postsService,
+      prisma,
+      notificationService,
+      temporalService
+    );
+
+    postsService.getPostsRecursively.mockResolvedValue([
+      {
+        id: 'p1',
+        publishDate: '2026-03-01T12:00:00.000Z',
+        content: 'content',
+        image: '[]',
+        integration: {
+          id: 'i1',
+          name: 'LinkedIn',
+          picture: 'pic',
+          providerIdentifier: 'linkedin',
+          profile: 'acme',
+        },
+      },
+    ]);
+    prisma.post.findUnique.mockResolvedValue({ id: 'p1', group: 'g1' });
+    prisma.post.updateMany.mockResolvedValue({ count: 1 });
+    prisma.userOrganization.findFirst.mockResolvedValue({ userId: 'owner-1' });
+    prisma.comments.create.mockResolvedValue({ id: 'c1' });
+    notificationService.inAppNotification.mockResolvedValue(undefined);
+
+    prisma.reviewToken.findUnique.mockImplementation(
+      async ({ where, include }: any) => {
+        const row = tokenRows.find((t) => t.tokenHash === where.tokenHash);
+        if (!row) return null;
+        if (include?.events) {
+          return {
+            ...row,
+            events: eventRows.filter((e) => e.reviewTokenId === row.id),
+          };
+        }
+        return row;
+      }
+    );
+    prisma.reviewToken.findFirst.mockImplementation(async ({ where }: any) => {
+      return (
+        tokenRows
+          .filter(
+            (t) =>
+              t.organizationId === where.organizationId &&
+              t.postId === where.postId &&
+              t.status === where.status
+          )
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ||
+        null
+      );
+    });
+    prisma.reviewToken.create.mockImplementation(async ({ data }: any) => {
+      const row = {
+        id: `rt_${tokenRows.length + 1}`,
+        ...data,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      tokenRows.push(row);
+      return row;
+    });
+    prisma.reviewToken.update.mockImplementation(async ({ where, data }: any) => {
+      const idx = tokenRows.findIndex((t) => t.id === where.id);
+      tokenRows[idx] = { ...tokenRows[idx], ...data, updatedAt: new Date() };
+      return tokenRows[idx];
+    });
+    prisma.reviewToken.updateMany.mockImplementation(
+      async ({ where, data }: any) => {
+        let count = 0;
+        tokenRows.forEach((row, idx) => {
+          const match =
+            (where.tokenHash ? row.tokenHash === where.tokenHash : true) &&
+            (where.status ? row.status === where.status : true);
+          if (match) {
+            tokenRows[idx] = { ...row, ...data, updatedAt: new Date() };
+            count++;
+          }
+        });
+        return { count };
+      }
+    );
+    prisma.reviewEvent.create.mockImplementation(async ({ data }: any) => {
+      const row = {
+        id: `re_${eventRows.length + 1}`,
+        ...data,
+        createdAt: new Date(),
+      };
+      eventRows.push(row);
+      return row;
+    });
+  });
+
+  it('create link -> get review -> approve -> replay blocked', async () => {
+    const link = await service.createReviewLink('org-1', 'post-1');
+    const review = await service.getReviewByToken(link!.token);
+    const approve = await service.decide(link!.token, 'approve');
+    const replay = await service.decide(link!.token, 'approve');
+
+    expect(review?.status).toBe('PENDING');
+    expect(approve.ok).toBe(true);
+    expect(approve.status).toBe('APPROVED');
+    expect(replay.ok).toBe(false);
+    expect(replay.code).toBe(409);
+  });
+
+  it('create link -> reject with feedback', async () => {
+    const link = await service.createReviewLink('org-1', 'post-1');
+    const reject = await service.decide(link!.token, 'reject', 'Need edits');
+
+    expect(reject.ok).toBe(true);
+    expect(reject.status).toBe('REJECTED');
+    expect(reject.feedback).toBe('Need edits');
+  });
+
+  it('pending until expiry -> expires and decision blocked', async () => {
+    postsService.getPostsRecursively.mockResolvedValue([
+      {
+        id: 'p1',
+        publishDate: '2020-01-01T00:00:00.000Z',
+        content: 'content',
+        image: '[]',
+        integration: {
+          id: 'i1',
+          name: 'LinkedIn',
+          picture: 'pic',
+          providerIdentifier: 'linkedin',
+          profile: 'acme',
+        },
+      },
+    ]);
+
+    const link = await service.createReviewLink('org-1', 'post-1');
+    const decision = await service.decide(link!.token, 'approve');
+
+    expect(decision.ok).toBe(false);
+    expect(decision.status).toBe('EXPIRED');
+    expect(prisma.post.updateMany).toHaveBeenCalled();
+  });
+
+  it('tampered token is rejected', async () => {
+    const decision = await service.decide('tampered-token', 'approve');
+    expect(decision.ok).toBe(false);
+    expect(decision.code).toBe(404);
+  });
+});
+

--- a/libraries/nestjs-libraries/src/review/review.service.spec.ts
+++ b/libraries/nestjs-libraries/src/review/review.service.spec.ts
@@ -1,0 +1,334 @@
+const redisStore = new Map<string, string>();
+let redisMock: any;
+
+jest.mock('@gitroom/nestjs-libraries/redis/redis.service', () => ({
+  ioRedis: (redisMock = {
+    get: jest.fn(async (key: string) => redisStore.get(key) || null),
+    set: jest.fn(async (key: string, value: string) => {
+      redisStore.set(key, value);
+      return 'OK';
+    }),
+    del: jest.fn(async (key: string) => {
+      redisStore.delete(key);
+      return 1;
+    }),
+    incr: jest.fn(async (key: string) => {
+      const current = Number(redisStore.get(key) || 0);
+      const next = current + 1;
+      redisStore.set(key, String(next));
+      return next;
+    }),
+    expire: jest.fn(async () => 1),
+  }),
+}));
+
+import { ReviewService } from './review.service';
+
+describe('ReviewService', () => {
+  const tokenRows: any[] = [];
+  const eventRows: any[] = [];
+  const postsService = {
+    getPostsRecursively: jest.fn(),
+  } as any;
+  const prisma = {
+    post: {
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    userOrganization: {
+      findFirst: jest.fn(),
+    },
+    comments: {
+      create: jest.fn(),
+    },
+    reviewToken: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    reviewEvent: {
+      create: jest.fn(),
+    },
+  } as any;
+  const notificationService = {
+    inAppNotification: jest.fn(),
+  } as any;
+  const temporalStart = jest.fn(async () => undefined);
+  const temporalSignal = jest.fn(async () => undefined);
+  const temporalService = {
+    client: {
+      getRawClient: jest.fn(() => ({
+        workflow: {
+          start: temporalStart,
+        },
+      })),
+      getWorkflowHandle: jest.fn(async () => ({
+        signal: temporalSignal,
+      })),
+    },
+  } as any;
+
+  let service: ReviewService;
+
+  beforeEach(() => {
+    redisStore.clear();
+    jest.clearAllMocks();
+    tokenRows.length = 0;
+    eventRows.length = 0;
+    temporalStart.mockClear();
+    temporalSignal.mockClear();
+    service = new ReviewService(
+      postsService,
+      prisma,
+      notificationService,
+      temporalService
+    );
+    process.env.FRONTEND_URL = 'http://localhost:4200';
+
+    postsService.getPostsRecursively.mockResolvedValue([
+      { id: 'p1', publishDate: '2026-02-26T10:00:00.000Z' },
+    ]);
+    prisma.post.findUnique.mockResolvedValue({ id: 'p1', group: 'g1' });
+    prisma.post.updateMany.mockResolvedValue({ count: 1 });
+    prisma.userOrganization.findFirst.mockResolvedValue({ userId: 'owner-1' });
+    prisma.comments.create.mockResolvedValue({ id: 'c1' });
+    notificationService.inAppNotification.mockResolvedValue(undefined);
+
+    prisma.reviewToken.findUnique.mockImplementation(
+      async ({ where, include }: any) => {
+        const row = tokenRows.find((t) => t.tokenHash === where.tokenHash);
+        if (!row) return null;
+        if (include?.events) {
+          return {
+            ...row,
+            events: eventRows.filter((e) => e.reviewTokenId === row.id),
+          };
+        }
+        return row;
+      }
+    );
+    prisma.reviewToken.findFirst.mockImplementation(async ({ where }: any) => {
+      return (
+        tokenRows
+          .filter(
+            (t) =>
+              t.organizationId === where.organizationId &&
+              t.postId === where.postId &&
+              t.status === where.status
+          )
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ||
+        null
+      );
+    });
+    prisma.reviewToken.create.mockImplementation(async ({ data }: any) => {
+      const row = {
+        id: `rt_${tokenRows.length + 1}`,
+        ...data,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      tokenRows.push(row);
+      return row;
+    });
+    prisma.reviewToken.update.mockImplementation(async ({ where, data }: any) => {
+      const idx = tokenRows.findIndex((t) => t.id === where.id);
+      if (idx === -1) throw new Error('not found');
+      tokenRows[idx] = { ...tokenRows[idx], ...data, updatedAt: new Date() };
+      return tokenRows[idx];
+    });
+    prisma.reviewToken.updateMany.mockImplementation(
+      async ({ where, data }: any) => {
+        let count = 0;
+        tokenRows.forEach((row, idx) => {
+          const match =
+            (where.tokenHash ? row.tokenHash === where.tokenHash : true) &&
+            (where.status ? row.status === where.status : true);
+          if (match) {
+            tokenRows[idx] = { ...row, ...data, updatedAt: new Date() };
+            count++;
+          }
+        });
+        return { count };
+      }
+    );
+    prisma.reviewEvent.create.mockImplementation(async ({ data }: any) => {
+      const row = {
+        id: `re_${eventRows.length + 1}`,
+        ...data,
+        createdAt: new Date(),
+      };
+      eventRows.push(row);
+      return row;
+    });
+  });
+
+  it('creates review link with raw token url and hashed storage key', async () => {
+    const result = await service.createReviewLink('org-1', 'post-1');
+
+    expect(result?.token).toBeDefined();
+    expect(result?.url).toContain(`/share/${result?.token}`);
+    expect(result?.status).toBe('PENDING');
+    expect(redisMock.set).toHaveBeenCalled();
+    expect(temporalStart).toHaveBeenCalledWith(
+      'externalReviewWorkflow',
+      expect.objectContaining({
+        args: [
+          expect.objectContaining({
+            token: result?.token,
+          }),
+        ],
+      })
+    );
+  });
+
+  it('approves with reviewer identity and creates review comment', async () => {
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const decision = await service.decide(created!.token, 'approve', undefined, {
+      reviewerName: 'Alice',
+      reviewerEmail: 'alice@example.com',
+      ip: '127.0.0.1',
+      userAgent: 'jest',
+    });
+
+    expect(decision.ok).toBe(true);
+    expect(decision.status).toBe('APPROVED');
+    expect(prisma.comments.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: expect.stringContaining(
+            'Post approved by Alice <alice@example.com>'
+          ),
+        }),
+      })
+    );
+    expect(notificationService.inAppNotification).toHaveBeenCalled();
+    expect(temporalService.client.getWorkflowHandle).toHaveBeenCalled();
+    expect(temporalSignal).toHaveBeenCalledWith('externalReviewResolved', {
+      status: 'APPROVED',
+    });
+  });
+
+  it('rejects and stores feedback', async () => {
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const decision = await service.decide(
+      created!.token,
+      'reject',
+      'Please change copy',
+      {
+        reviewerName: 'Bob',
+      }
+    );
+
+    expect(decision.ok).toBe(true);
+    expect(decision.status).toBe('REJECTED');
+    expect(decision.feedback).toBe('Please change copy');
+    expect(prisma.comments.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: expect.stringContaining('Please change copy'),
+        }),
+      })
+    );
+  });
+
+  it('returns not found for invalid token decision', async () => {
+    const decision = await service.decide('not-a-token', 'approve');
+
+    expect(decision.ok).toBe(false);
+    expect(decision.code).toBe(404);
+  });
+
+  it('is idempotent on replayed decisions', async () => {
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const first = await service.decide(created!.token, 'approve', undefined, {
+      reviewerName: 'Alice',
+    });
+    const second = await service.decide(created!.token, 'approve');
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(false);
+    expect(second.code).toBe(409);
+    expect(second.status).toBe('APPROVED');
+  });
+
+  it('signals workflow resolution on revoke', async () => {
+    await service.createReviewLink('org-1', 'post-1');
+    const revoked = await service.revokeActiveReview('org-1', 'post-1');
+
+    expect(revoked.ok).toBe(true);
+    expect(temporalSignal).toHaveBeenCalledWith('externalReviewResolved', {
+      status: 'REVOKED',
+    });
+  });
+
+  it('expires old pending links and blocks approve', async () => {
+    postsService.getPostsRecursively.mockResolvedValue([
+      { id: 'p1', publishDate: '2020-01-01T00:00:00.000Z' },
+    ]);
+
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const decision = await service.decide(created!.token, 'approve');
+
+    expect(decision.ok).toBe(false);
+    expect(decision.code).toBe(409);
+    expect(decision.status).toBe('EXPIRED');
+  });
+
+  it('sanitizes public review payload fields', async () => {
+    postsService.getPostsRecursively.mockResolvedValue([
+      {
+        id: 'p1',
+        publishDate: '2026-02-26T10:00:00.000Z',
+        content: 'Post content',
+        image: '[]',
+        childrenPost: [{ id: 'child' }],
+        integration: {
+          id: 'i1',
+          name: 'LinkedIn',
+          picture: 'pic',
+          providerIdentifier: 'linkedin',
+          profile: 'acme',
+          token: 'secret-token',
+          accessToken: 'secret-access',
+        },
+      },
+    ]);
+
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const review = await service.getReviewByToken(created!.token);
+
+    expect(review?.posts?.[0]?.childrenPost).toBeUndefined();
+    expect(review?.posts?.[0]?.integration?.id).toBe('i1');
+    expect(review?.posts?.[0]?.integration?.name).toBe('LinkedIn');
+    expect(review?.posts?.[0]?.integration?.token).toBeUndefined();
+    expect(review?.posts?.[0]?.integration?.accessToken).toBeUndefined();
+  });
+
+  it('sends reminder only for pending tokens', async () => {
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const reminder = await service.sendReminderIfPending(created!.token);
+
+    expect(reminder.ok).toBe(true);
+    expect(reminder.skipped).toBe(false);
+    expect(notificationService.inAppNotification).toHaveBeenCalledWith(
+      'org-1',
+      'External review reminder',
+      expect.any(String),
+      false,
+      false,
+      'info'
+    );
+  });
+
+  it('expires pending token from workflow activity path', async () => {
+    const created = await service.createReviewLink('org-1', 'post-1');
+    const expired = await service.expireIfPending(created!.token);
+    const readBack = await service.getTokenPayload(created!.token);
+
+    expect(expired.ok).toBe(true);
+    expect(expired.skipped).toBe(false);
+    expect(readBack?.status).toBe('EXPIRED');
+  });
+});

--- a/libraries/nestjs-libraries/src/review/review.service.ts
+++ b/libraries/nestjs-libraries/src/review/review.service.ts
@@ -1,0 +1,689 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
+import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import { PrismaService } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
+import { NotificationService } from '@gitroom/nestjs-libraries/database/prisma/notifications/notification.service';
+import { TemporalService } from 'nestjs-temporal-core';
+
+type ReviewStatus =
+  | 'PENDING'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'EXPIRED'
+  | 'REVOKED';
+type ReviewEventType =
+  | 'CREATED'
+  | 'VIEWED'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'EXPIRED'
+  | 'REVOKED'
+  | 'INVALID_ATTEMPT'
+  | 'REMINDER_SENT';
+
+type ReviewActor = {
+  ip?: string;
+  userAgent?: string;
+  reviewerName?: string;
+  reviewerEmail?: string;
+};
+
+type ReviewEvent = {
+  type: ReviewEventType;
+  at: string;
+  actor?: ReviewActor;
+  details?: string;
+};
+
+type ReviewTokenPayload = {
+  id: string;
+  postId: string;
+  organizationId: string;
+  status: ReviewStatus;
+  expiresAt: string;
+  createdAt: string;
+  decidedAt?: string;
+  feedback?: string;
+  events?: ReviewEvent[];
+};
+
+const REVIEW_KEY = 'review:token:';
+const REVIEW_POST_ACTIVE_KEY = 'review:post:';
+
+@Injectable()
+export class ReviewService {
+  constructor(
+    private _postsService: PostsService,
+    private _prisma: PrismaService,
+    private _notificationService: NotificationService,
+    @Optional()
+    private _temporalService?: TemporalService
+  ) {}
+
+  private hashToken(token: string): string {
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private getKeyFromToken(token: string): string {
+    return `${REVIEW_KEY}${this.hashToken(token)}`;
+  }
+
+  private getStorageKeyFromHash(hash: string): string {
+    return `${REVIEW_KEY}${hash}`;
+  }
+
+  private getActivePostKey(orgId: string, postId: string): string {
+    return `${REVIEW_POST_ACTIVE_KEY}${orgId}:${postId}`;
+  }
+
+  private isExpired(expiresAt: string) {
+    return new Date(expiresAt).getTime() <= Date.now();
+  }
+
+  private pushEvent(
+    payload: ReviewTokenPayload,
+    type: ReviewEventType,
+    actor?: ReviewActor,
+    details?: string
+  ) {
+    return {
+      ...payload,
+      events: [
+        ...(payload.events || []),
+        {
+          type,
+          at: new Date().toISOString(),
+          ...(actor ? { actor } : {}),
+          ...(details ? { details } : {}),
+        },
+      ],
+    };
+  }
+
+  private async incrementWithTtl(key: string, ttlSeconds: number) {
+    const redisAny = ioRedis as any;
+    if (typeof redisAny.incr === 'function') {
+      const count = await redisAny.incr(key);
+      if (count === 1 && typeof redisAny.expire === 'function') {
+        await redisAny.expire(key, ttlSeconds);
+      }
+      return count;
+    }
+    const current = Number((await ioRedis.get(key)) || 0) || 0;
+    const next = current + 1;
+    await ioRedis.set(key, String(next), 'EX', ttlSeconds);
+    return next;
+  }
+
+  private async checkRateLimit(
+    namespace: string,
+    id: string,
+    actor?: ReviewActor,
+    max = 30,
+    ttlSeconds = 60 * 15
+  ) {
+    const ip = actor?.ip || 'unknown';
+    const key = `review:rate:${namespace}:${id}:${ip}`;
+    const count = await this.incrementWithTtl(key, ttlSeconds);
+    return count <= max;
+  }
+
+  private async applyDecisionEffects(
+    payload: ReviewTokenPayload,
+    status: ReviewStatus,
+    feedback?: string,
+    actor?: ReviewActor
+  ) {
+    const rootPost = await this._prisma.post.findUnique({
+      where: {
+        id: payload.postId,
+        organizationId: payload.organizationId,
+      },
+      select: {
+        id: true,
+        group: true,
+      },
+    });
+
+    if (!rootPost) {
+      return;
+    }
+
+    if (status === 'REJECTED' || status === 'EXPIRED') {
+      await this._prisma.post.updateMany({
+        where: {
+          organizationId: payload.organizationId,
+          group: rootPost.group,
+          deletedAt: null,
+        },
+        data: {
+          state: 'DRAFT',
+        },
+      });
+    }
+
+    const orgUser = await this._prisma.userOrganization.findFirst({
+      where: {
+        organizationId: payload.organizationId,
+        disabled: false,
+      },
+      select: {
+        userId: true,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+
+    const reviewerIdentity = actor?.reviewerName?.trim()
+      ? `${actor.reviewerName.trim()}${
+          actor?.reviewerEmail?.trim() ? ` <${actor.reviewerEmail.trim()}>` : ''
+        }`
+      : '';
+
+    if (orgUser) {
+      const content =
+        status === 'APPROVED'
+          ? `[External Review] Post approved${
+              reviewerIdentity ? ` by ${reviewerIdentity}` : ''
+            }`
+          : status === 'REJECTED'
+          ? `[External Review] Post rejected${
+              reviewerIdentity ? ` by ${reviewerIdentity}` : ''
+            }${
+              feedback?.trim() ? `: ${feedback.trim()}` : ''
+            }`
+          : '[External Review] Link expired before approval';
+      await this._prisma.comments.create({
+        data: {
+          organizationId: payload.organizationId,
+          userId: orgUser.userId,
+          postId: payload.postId,
+          content,
+        },
+      });
+    }
+
+    const subject =
+      status === 'APPROVED'
+        ? 'External review approved'
+        : status === 'REJECTED'
+        ? 'External review rejected'
+        : 'External review expired';
+    const message =
+      status === 'REJECTED'
+        ? `Post review was rejected${
+            reviewerIdentity ? ` by ${reviewerIdentity}` : ''
+          }.${feedback?.trim() ? ` Feedback: ${feedback.trim()}` : ''}`
+        : status === 'APPROVED'
+        ? `Post review was approved${
+            reviewerIdentity ? ` by ${reviewerIdentity}` : ''
+          }.`
+        : 'Post review expired before a decision.';
+
+    await this._notificationService.inAppNotification(
+      payload.organizationId,
+      subject,
+      message,
+      false,
+      false,
+      'info'
+    );
+  }
+
+  private sanitizePosts(posts: any[]) {
+    return posts.map(({ childrenPost, ...post }) => ({
+      ...post,
+      ...(post.integration
+        ? {
+            integration: {
+              id: post.integration.id,
+              name: post.integration.name,
+              picture: post.integration.picture,
+              providerIdentifier: post.integration.providerIdentifier,
+              profile: post.integration.profile,
+            },
+          }
+        : {}),
+    }));
+  }
+
+  private mapDbToken(dbToken: any): ReviewTokenPayload {
+    return {
+      id: dbToken.tokenHash,
+      postId: dbToken.postId,
+      organizationId: dbToken.organizationId,
+      status: dbToken.status as ReviewStatus,
+      expiresAt: new Date(dbToken.expiresAt).toISOString(),
+      createdAt: new Date(dbToken.createdAt).toISOString(),
+      ...(dbToken.decidedAt
+        ? { decidedAt: new Date(dbToken.decidedAt).toISOString() }
+        : {}),
+      ...(dbToken.feedback ? { feedback: dbToken.feedback } : {}),
+      events: (dbToken.events || []).map((event: any) => ({
+        type: event.type as ReviewEventType,
+        at: new Date(event.createdAt).toISOString(),
+        ...(event.actor ? { actor: event.actor as ReviewActor } : {}),
+        ...(event.details ? { details: event.details } : {}),
+      })),
+    };
+  }
+
+  private async getDbTokenByHash(tokenHash: string) {
+    return this._prisma.reviewToken.findUnique({
+      where: {
+        tokenHash,
+      },
+      include: {
+        events: {
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    });
+  }
+
+  private async appendEvent(
+    reviewTokenId: string,
+    type: ReviewEventType,
+    actor?: ReviewActor,
+    details?: string
+  ) {
+    await this._prisma.reviewEvent.create({
+      data: {
+        reviewTokenId,
+        type,
+        ...(actor ? { actor: actor as any } : {}),
+        ...(details ? { details } : {}),
+      },
+    });
+  }
+
+  private async signalWorkflowResolved(
+    tokenHash: string,
+    status: 'APPROVED' | 'REJECTED' | 'EXPIRED' | 'REVOKED'
+  ) {
+    try {
+      const handle = await this._temporalService?.client?.getWorkflowHandle(
+        `external_review_${tokenHash}`
+      );
+      await (handle as any)?.signal?.('externalReviewResolved', { status });
+    } catch (e) {
+      // Signaling should not fail the API operation.
+    }
+  }
+
+  async createReviewLink(orgId: string, postId: string) {
+    const posts = await this._postsService.getPostsRecursively(
+      postId,
+      true,
+      orgId,
+      true
+    );
+
+    if (!posts.length) {
+      return null;
+    }
+
+    const token = randomBytes(32).toString('hex');
+    const tokenHash = this.hashToken(token);
+    const activePostKey = this.getActivePostKey(orgId, postId);
+
+    const previousPending = await this._prisma.reviewToken.findFirst({
+      where: {
+        organizationId: orgId,
+        postId,
+        status: 'PENDING',
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    if (previousPending) {
+      await this._prisma.reviewToken.update({
+        where: {
+          id: previousPending.id,
+        },
+        data: {
+          status: 'REVOKED',
+          decidedAt: new Date(),
+        },
+      });
+      await this.appendEvent(previousPending.id, 'REVOKED');
+      await this.signalWorkflowResolved(previousPending.tokenHash, 'REVOKED');
+    }
+
+    const firstPost = posts[0];
+    const scheduledAt = firstPost?.publishDate
+      ? new Date(firstPost.publishDate)
+      : new Date();
+    const expiresAt = new Date(scheduledAt.getTime() + 1000 * 60 * 60 * 24 * 7);
+
+    const created = await this._prisma.reviewToken.create({
+      data: {
+        organizationId: orgId,
+        postId,
+        tokenHash,
+        status: 'PENDING',
+        expiresAt,
+      },
+    });
+    await this.appendEvent(created.id, 'CREATED');
+
+    const payload: ReviewTokenPayload = {
+      id: tokenHash,
+      postId,
+      organizationId: orgId,
+      status: 'PENDING',
+      createdAt: new Date(created.createdAt).toISOString(),
+      expiresAt: new Date(created.expiresAt).toISOString(),
+      events: [{ type: 'CREATED', at: new Date().toISOString() }],
+    };
+
+    await ioRedis.set(
+      this.getStorageKeyFromHash(tokenHash),
+      JSON.stringify(payload),
+      'EX',
+      60 * 60 * 24 * 14
+    );
+    await ioRedis.set(activePostKey, tokenHash, 'EX', 60 * 60 * 24 * 14);
+
+    const scheduledAtDate = firstPost?.publishDate
+      ? new Date(firstPost.publishDate)
+      : null;
+    const reminderAt = scheduledAtDate
+      ? new Date(scheduledAtDate.getTime() - 2 * 60 * 60 * 1000)
+      : null;
+    const reminderDelayMs = reminderAt
+      ? Math.max(0, reminderAt.getTime() - Date.now())
+      : 0;
+    const expiryDelayMs = Math.max(
+      0,
+      new Date(payload.expiresAt).getTime() - Date.now()
+    );
+
+    try {
+      await this._temporalService?.client
+        ?.getRawClient()
+        ?.workflow.start('externalReviewWorkflow', {
+          args: [
+            {
+              token,
+              reminderDelayMs,
+              expiryDelayMs,
+            },
+          ],
+          workflowId: `external_review_${tokenHash}`,
+          taskQueue: 'main',
+          workflowIdConflictPolicy: 'TERMINATE_EXISTING',
+        });
+    } catch (e) {
+      // Link generation must not fail if Temporal is unavailable.
+    }
+
+    return {
+      token,
+      expiresAt: payload.expiresAt,
+      status: payload.status,
+      scheduledAt: firstPost?.publishDate || null,
+      url: `${process.env.FRONTEND_URL}/share/${token}`,
+    };
+  }
+
+  async getTokenPayload(token: string): Promise<ReviewTokenPayload | null> {
+    const tokenHash = this.hashToken(token);
+    const dbToken = await this.getDbTokenByHash(tokenHash);
+    if (!dbToken) {
+      return null;
+    }
+
+    const parsed = this.mapDbToken(dbToken);
+    if (parsed.status !== 'PENDING') {
+      return parsed;
+    }
+
+    if (parsed.status === 'PENDING' && this.isExpired(parsed.expiresAt)) {
+      await this._prisma.reviewToken.update({
+        where: {
+          id: dbToken.id,
+        },
+        data: {
+          status: 'EXPIRED',
+          decidedAt: new Date(),
+        },
+      });
+      await this.appendEvent(dbToken.id, 'EXPIRED');
+      const updated = await this.getDbTokenByHash(tokenHash);
+      if (!updated) {
+        return null;
+      }
+      const expired = this.mapDbToken(updated);
+      await this.applyDecisionEffects(expired, 'EXPIRED');
+      await this.signalWorkflowResolved(tokenHash, 'EXPIRED');
+      return expired;
+    }
+
+    return parsed;
+  }
+
+  async getReviewByToken(token: string, actor?: ReviewActor) {
+    const payload = await this.getTokenPayload(token);
+    if (!payload) {
+      return null;
+    }
+
+    if (!(await this.checkRateLimit('view', payload.id, actor, 120, 60 * 15))) {
+      return null;
+    }
+
+    const posts = await this._postsService.getPostsRecursively(
+      payload.postId,
+      true,
+      payload.organizationId,
+      true
+    );
+
+    if (!posts.length) {
+      return null;
+    }
+
+    const sanitized = this.sanitizePosts(posts);
+    const dbToken = await this.getDbTokenByHash(payload.id);
+    if (dbToken) {
+      await this.appendEvent(dbToken.id, 'VIEWED', actor);
+    }
+
+    return {
+      status: payload.status,
+      expiresAt: payload.expiresAt,
+      scheduledAt: sanitized[0]?.publishDate || null,
+      feedback: payload.feedback,
+      posts: sanitized,
+    };
+  }
+
+  async revokeActiveReview(orgId: string, postId: string) {
+    const pending = await this._prisma.reviewToken.findFirst({
+      where: {
+        organizationId: orgId,
+        postId,
+        status: 'PENDING',
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+
+    if (!pending) {
+      return {
+        ok: false as const,
+        code: 404,
+        message: 'No active review link found',
+      };
+    }
+
+    await this._prisma.reviewToken.update({
+      where: {
+        id: pending.id,
+      },
+      data: {
+        status: 'REVOKED',
+        decidedAt: new Date(),
+      },
+    });
+    await this.appendEvent(pending.id, 'REVOKED');
+    await this.signalWorkflowResolved(pending.tokenHash, 'REVOKED');
+    await ioRedis.del(this.getActivePostKey(orgId, postId));
+    return { ok: true as const, code: 200, status: 'REVOKED' as const };
+  }
+
+  async sendReminderIfPending(token: string) {
+    const payload = await this.getTokenPayload(token);
+    if (!payload || payload.status !== 'PENDING') {
+      return { ok: false as const, skipped: true as const };
+    }
+
+    const dbToken = await this.getDbTokenByHash(payload.id);
+    if (dbToken) {
+      await this.appendEvent(dbToken.id, 'REMINDER_SENT');
+    }
+
+    await this._notificationService.inAppNotification(
+      payload.organizationId,
+      'External review reminder',
+      'A shared post is still pending external approval.',
+      false,
+      false,
+      'info'
+    );
+
+    return { ok: true as const, skipped: false as const };
+  }
+
+  async expireIfPending(token: string) {
+    const payload = await this.getTokenPayload(token);
+    if (!payload || payload.status !== 'PENDING') {
+      return { ok: false as const, skipped: true as const };
+    }
+
+    const dbToken = await this.getDbTokenByHash(payload.id);
+    if (!dbToken) {
+      return { ok: false as const, skipped: true as const };
+    }
+
+    await this._prisma.reviewToken.update({
+      where: {
+        id: dbToken.id,
+      },
+      data: {
+        status: 'EXPIRED',
+        decidedAt: new Date(),
+      },
+    });
+    await this.appendEvent(dbToken.id, 'EXPIRED');
+    const updated = await this.getDbTokenByHash(payload.id);
+    if (updated) {
+      await this.applyDecisionEffects(this.mapDbToken(updated), 'EXPIRED');
+      await this.signalWorkflowResolved(updated.tokenHash, 'EXPIRED');
+      await ioRedis.del(
+        this.getActivePostKey(updated.organizationId, updated.postId)
+      );
+    }
+    return { ok: true as const, skipped: false as const };
+  }
+
+  async decide(
+    token: string,
+    decision: 'approve' | 'reject',
+    feedback?: string,
+    actor?: ReviewActor
+  ) {
+    const payload = await this.getTokenPayload(token);
+
+    const tokenHash = this.hashToken(token);
+    const withinLimit = await this.checkRateLimit('decide', tokenHash, actor, 20, 60 * 10);
+    if (!withinLimit) {
+      return {
+        ok: false as const,
+        code: 429,
+        message: 'Too many attempts. Please try again shortly.',
+      };
+    }
+
+    if (!payload) {
+      await this.incrementWithTtl(
+        `review:invalid:${actor?.ip || 'unknown'}`,
+        60 * 15
+      );
+      return { ok: false as const, code: 404, message: 'Review token not found' };
+    }
+
+    if (payload.status !== 'PENDING') {
+      return {
+        ok: false as const,
+        code: 409,
+        message: `Review is already ${payload.status.toLowerCase()}`,
+        status: payload.status,
+      };
+    }
+
+    const status: ReviewStatus = decision === 'approve' ? 'APPROVED' : 'REJECTED';
+    const updated = await this._prisma.reviewToken.updateMany({
+      where: {
+        tokenHash,
+        status: 'PENDING',
+      },
+      data: {
+        status,
+        feedback: decision === 'reject' ? feedback || '' : null,
+        decidedAt: new Date(),
+      },
+    });
+    if (!updated.count) {
+      const latest = await this.getTokenPayload(token);
+      return {
+        ok: false as const,
+        code: 409,
+        message: `Review is already ${latest?.status?.toLowerCase?.() || 'closed'}`,
+        status: latest?.status,
+      };
+    }
+
+    const dbToken = await this.getDbTokenByHash(tokenHash);
+    if (!dbToken) {
+      return { ok: false as const, code: 404, message: 'Review token not found' };
+    }
+    await this.appendEvent(
+      dbToken.id,
+      decision === 'approve' ? 'APPROVED' : 'REJECTED',
+      actor
+    );
+    const updatedToken = await this.getDbTokenByHash(tokenHash);
+    if (!updatedToken) {
+      return { ok: false as const, code: 404, message: 'Review token not found' };
+    }
+    const nextPayload = this.mapDbToken(updatedToken);
+
+    await this.applyDecisionEffects(
+      nextPayload,
+      status,
+      nextPayload.feedback,
+      actor
+    );
+    await this.signalWorkflowResolved(
+      tokenHash,
+      status === 'APPROVED' ? 'APPROVED' : 'REJECTED'
+    );
+    await ioRedis.del(this.getActivePostKey(payload.organizationId, payload.postId));
+
+    return {
+      ok: true as const,
+      code: 200,
+      status: nextPayload.status,
+      feedback: nextPayload.feedback,
+    };
+  }
+}

--- a/libraries/nestjs-libraries/src/temporal/temporal.fallback.module.ts
+++ b/libraries/nestjs-libraries/src/temporal/temporal.fallback.module.ts
@@ -1,0 +1,56 @@
+import { Global, Module } from '@nestjs/common';
+import { TemporalService } from 'nestjs-temporal-core';
+
+function emptyAsyncIterable<T>(): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          return { done: true, value: undefined as T };
+        },
+      };
+    },
+  };
+}
+
+const temporalServiceFallback = {
+  terminateWorkflow: async (): Promise<boolean> => false,
+  client: {
+    getRawClient: (): {
+      workflow: {
+        start: () => Promise<undefined>;
+        signalWithStart: () => Promise<undefined>;
+        list: () => AsyncIterable<unknown>;
+      };
+    } => ({
+      workflow: {
+        start: async (): Promise<undefined> => undefined,
+        signalWithStart: async (): Promise<undefined> => undefined,
+        list: (): AsyncIterable<unknown> => emptyAsyncIterable(),
+      },
+    }),
+    getWorkflowHandle: async (): Promise<{
+      describe: () => Promise<{ status: { name: string } }>;
+      terminate: () => Promise<undefined>;
+      signal: () => Promise<undefined>;
+    }> => ({
+      describe: async (): Promise<{ status: { name: string } }> => ({
+        status: { name: 'TERMINATED' },
+      }),
+      terminate: async (): Promise<undefined> => undefined,
+      signal: async (): Promise<undefined> => undefined,
+    }),
+  },
+};
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: TemporalService,
+      useValue: temporalServiceFallback as unknown as TemporalService,
+    },
+  ],
+  exports: [TemporalService],
+})
+export class TemporalFallbackModule {}

--- a/libraries/react-shared-libraries/src/form/input.tsx
+++ b/libraries/react-shared-libraries/src/form/input.tsx
@@ -2,17 +2,18 @@
 
 import {
   DetailedHTMLProps,
-  FC,
+  ForwardedRef,
   InputHTMLAttributes,
   ReactNode,
+  forwardRef,
   useEffect,
   useMemo,
 } from 'react';
 import { clsx } from 'clsx';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { TranslatedLabel } from '../translation/translated-label';
 
-export const Input: FC<
+type InputProps =
   DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> & {
     removeError?: boolean;
     error?: any;
@@ -23,8 +24,25 @@ export const Input: FC<
     icon?: ReactNode;
     translationKey?: string;
     translationParams?: Record<string, string | number>;
+  };
+
+function setMergedRef(
+  ref: ForwardedRef<HTMLInputElement>,
+  registerRef: any,
+  node: HTMLInputElement | null
+) {
+  if (typeof registerRef === 'function') {
+    registerRef(node);
   }
-> = (props) => {
+
+  if (typeof ref === 'function') {
+    ref(node);
+  } else if (ref) {
+    ref.current = node;
+  }
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const {
     label,
     icon,
@@ -38,6 +56,7 @@ export const Input: FC<
     ...rest
   } = props;
   const form = useFormContext();
+  const registerProps = !disableForm && form ? form.register(props.name) : {};
   const err = useMemo(() => {
     if (error) return error;
     if (!form || !form.formState.errors[props?.name!]) return;
@@ -72,8 +91,9 @@ export const Input: FC<
             'h-full bg-transparent outline-none flex-1 text-[14px] text-textColor',
             icon ? 'pl-[8px] pe-[16px]' : 'px-[16px]'
           )}
-          {...(disableForm ? {} : form.register(props.name))}
+          {...registerProps}
           {...rest}
+          ref={(node) => setMergedRef(ref, (registerProps as any).ref, node)}
         />
       </div>
       {!removeError && (
@@ -81,4 +101,6 @@ export const Input: FC<
       )}
     </div>
   );
-};
+});
+
+Input.displayName = 'Input';

--- a/libraries/react-shared-libraries/src/helpers/variable.context.tsx
+++ b/libraries/react-shared-libraries/src/helpers/variable.context.tsx
@@ -26,6 +26,7 @@ interface VariableContextInterface {
   transloadit: string[];
   sentryDsn: string;
   extensionId: string;
+  externalReviewEnabled: boolean;
 }
 const VariableContext = createContext({
   stripeClient: '',
@@ -51,6 +52,7 @@ const VariableContext = createContext({
   transloadit: [],
   sentryDsn: '',
   extensionId: '',
+  externalReviewEnabled: true,
 } as VariableContextInterface);
 export const VariableContextComponent: FC<
   VariableContextInterface & {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prisma-db-push": "pnpm dlx prisma@6.5.0 db push --accept-data-loss --schema ./libraries/nestjs-libraries/src/database/prisma/schema.prisma",
     "prisma-db-pull": "pnpm dlx prisma@6.5.0 db pull --schema ./libraries/nestjs-libraries/src/database/prisma/schema.prisma",
     "prisma-reset": "cd ./libraries/nestjs-libraries/src/database/prisma && pnpm dlx prisma@6.5.0 db push --force-reset && pnpx prisma@6.5.0 db push",
+    "test:review": "jest --config jest.review.config.cjs libraries/nestjs-libraries/src/review/review.service.spec.ts libraries/nestjs-libraries/src/review/review.flow.spec.ts apps/backend/src/api/routes/public.controller.spec.ts apps/backend/src/api/routes/posts.controller.spec.ts apps/orchestrator/src/workflows/external.review.workflow.spec.ts --runInBand --forceExit",
     "docker-build": "./var/docker/docker-build.sh",
     "docker-create": "./var/docker/docker-create.sh",
     "postinstall": "pnpm run prisma-generate",


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature + tests + docs update.

This PR introduces a new External Review workflow that allows public approve/reject flows for scheduled posts, with auditability and workflow automation.

# Why was this change needed?

Post approval in client/manager workflows currently requires friction (internal access or manual back-and-forth), which slows scheduling and increases operational risk for teams handling external stakeholders.

This change enables secure, token-based public review links so non-Postiz users can approve/reject quickly, while still preserving internal controls (audit trail, replay protection, expiry handling, reminders, and DRAFT fallback on rejection/expiry).

No specific issue link was referenced for this branch; this was implemented as a high-priority workflow enhancement discussed during feature planning/testing.

# Other information:

- Discussed implementation strategy iteratively during development/testing sessions (backend, frontend, workflow, and security behavior).
- Feature flags were added for safe rollout:
  - `EXTERNAL_REVIEW_ENABLED`
  - `NEXT_PUBLIC_EXTERNAL_REVIEW_ENABLED`
- Follow-up items (separate PR candidates):
  - Browser UI E2E harness (Playwright/Cypress)
  - Metrics dashboard + alerting
  - Confirm/resolve schema drift around `OrganizationProviderCredential`

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
