### PR TITLE
feat: add MastodonCustomProvider to social integration list

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/integration.manager.ts
+++ b/libraries/nestjs-libraries/src/integrations/integration.manager.ts
@@ -19,6 +19,7 @@ import { ThreadsProvider } from '@gitroom/nestjs-libraries/integrations/social/t
 import { DiscordProvider } from '@gitroom/nestjs-libraries/integrations/social/discord.provider';
 import { SlackProvider } from '@gitroom/nestjs-libraries/integrations/social/slack.provider';
 import { MastodonProvider } from '@gitroom/nestjs-libraries/integrations/social/mastodon.provider';
+import { MastodonCustomProvider } from '@gitroom/nestjs-libraries/integrations/social/mastodon.custom.provider';
 import { BlueskyProvider } from '@gitroom/nestjs-libraries/integrations/social/bluesky.provider';
 import { LemmyProvider } from '@gitroom/nestjs-libraries/integrations/social/lemmy.provider';
 import { InstagramStandaloneProvider } from '@gitroom/nestjs-libraries/integrations/social/instagram.standalone.provider';
@@ -69,7 +70,7 @@ export const socialIntegrationList: Array<SocialAbstract & SocialProvider> = [
   new MoltbookProvider(),
   new WhopProvider(),
   new SkoolProvider(),
-  // new MastodonCustomProvider(),
+  new MastodonCustomProvider(),
 ];
 
 @Injectable()


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature - Enable custom Mastodon instance support

# Why was this change needed?

The `MastodonCustomProvider` was already fully implemented but disabled. Enabling it allows users to connect to any Mastodon instance, not just mastodon.social, improving flexibility for federated social media scheduling.

# Other information:

This is a simple enable of existing, tested code. No new dependencies or breaking changes.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue