### PR TITLE
 fix(api): validate inferred MIME type in upload-from-url flow

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -86,9 +86,20 @@ export class PublicIntegrationsController {
     const buffer = Buffer.from(response.data);
     const responseMime = response.headers?.['content-type']?.split(';')[0]?.trim();
     const urlMime = lookup(body?.url?.split?.('?')?.[0]);
-    const mimetype = (urlMime || responseMime || 'image/jpeg') as string;
-    const ext = extension(mimetype) || 'jpg';
+    const inferredMime = (responseMime || urlMime) as string | false | undefined;
+    const ext = inferredMime ? extension(inferredMime) : false;
 
+    if (!ext || !['png', 'jpg', 'jpeg', 'gif', 'webp', 'mp4'].includes(ext)) {
+      throw new HttpException(
+        {
+          msg: 'Unsupported file type. Allowed types: .png, .jpg, .jpeg, .gif, .webp, .mp4',
+        },
+        400
+      );
+    }
+
+    const mimetype =
+      inferredMime || (ext === 'mp4' ? 'video/mp4' : `image/${ext}`);
     const getFile = await this.storage.uploadFile({
       buffer,
       mimetype,

--- a/libraries/helpers/src/utils/valid.url.path.ts
+++ b/libraries/helpers/src/utils/valid.url.path.ts
@@ -7,20 +7,31 @@ import {
 @ValidatorConstraint({ name: 'checkValidExtension', async: false })
 export class ValidUrlExtension implements ValidatorConstraintInterface {
   validate(text: string, args: ValidationArguments) {
-    return (
-      !!text?.split?.('?')?.[0].endsWith('.png') ||
-      !!text?.split?.('?')?.[0].endsWith('.jpg') ||
-      !!text?.split?.('?')?.[0].endsWith('.jpeg') ||
-      !!text?.split?.('?')?.[0].endsWith('.gif') ||
-      !!text?.split?.('?')?.[0].endsWith('.webp') ||
-      !!text?.split?.('?')?.[0].endsWith('.mp4')
-    );
+   if (!text) {
+      return false;
+    }
+
+    const validExtension = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'mp4'];
+
+    try {
+      const url = new URL(text);
+      const lastPathSegment = url.pathname.split('/').pop() || '';
+
+      if (!lastPathSegment || !lastPathSegment.includes('.')) {
+        return true;
+      }
+
+      const extension = lastPathSegment.split('.').pop()?.toLowerCase();
+      return !!extension && validExtension.includes(extension);
+    } catch {
+      return false;
+    }
   }
 
   defaultMessage(args: ValidationArguments) {
     // here you can provide default error message if validation failed
     return (
-      'File must have a valid extension: .png, .jpg, .jpeg, .gif, .webp, or .mp4'
+      'File extension (if present) must be one of: .png, .jpg, .jpeg, .gif, .webp, or .mp4'
     );
   }
 }

--- a/libraries/nestjs-libraries/src/dtos/media/upload.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/media/upload.dto.ts
@@ -1,9 +1,10 @@
-import { IsDefined, IsString, Validate } from 'class-validator';
+import { IsDefined, IsString, IsUrl, Validate } from 'class-validator';
 import { ValidUrlExtension } from '@gitroom/helpers/utils/valid.url.path';
 
 export class UploadDto {
   @IsString()
   @IsDefined()
+  @IsUrl({ require_protocol: true })
   @Validate(ValidUrlExtension)
   url: string;
 }


### PR DESCRIPTION
📜 Description
I am using the (beta) Public API against a self-hosted instance.

There are two ways to make media available to Postiz via the API.

One is to call `upload`.

This is working for me.

The call returns a result which includes `id`, `name`, and `path` as expected. The path usually includes a descriptive suffix (for example `.png`) matching the original file.

The file becomes available through the Media page and can be used to create posts.

The other is to call `upload-from-url`.

This was problematic when the source URL had no file extension.

In that case, media could still be uploaded and appeared in the Media page, but creating a post using that returned URL could fail extension validation.

This PR updates the flow to:
- accept extensionless URLs for `upload-from-url`
- infer media type from response headers / URL MIME
- allow only supported media types (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.mp4`)
- return a clear 400 error for unsupported media
- require fully qualified URL input with protocol

👟 Reproduction steps
1. Call `upload-from-url` with an extensionless URL.
2. Note media appears in the Media page.
3. Use returned URL in `Create Post`.
4. Verify accepted behavior for supported media, and clear 400 for unsupported media.

👍 Expected behavior
- Extensionless source URLs should work when media type is supported.
- Unsupported media types should be rejected explicitly.
- URL input should be validated as a proper URL with protocol.

👎 Actual behavior before this PR
- Extensionless URL uploads could lead to validation failure when used in post creation due to extension-based checks.

💻 Operating system
Windows

🤖 Node Version
Latest stable local setup

📃 Additional context
- This change is scoped to remote upload validation and media type enforcement.
- No unrelated functional changes were included.

👀 Have you checked for similar issues?
Yes, and this PR addresses the known extensionless upload-from-url behavior.