### PR TITLE
feat: add provider testing framework (782 tests)

### DIFF
--- a/__mocks__/@temporalio/activity.js
+++ b/__mocks__/@temporalio/activity.js
@@ -1,0 +1,11 @@
+class ApplicationFailure extends Error {
+  constructor(message, type, nonRetryable, details = []) {
+    super(message);
+    this.name = 'ApplicationFailure';
+    this.type = type;
+    this.nonRetryable = nonRetryable;
+    this.details = details;
+  }
+}
+
+module.exports = { ApplicationFailure };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,33 @@
-import { getJestProjects } from '@nx/jest';
-
 export default {
-  projects: getJestProjects(),
+  roots: ['<rootDir>/libraries/nestjs-libraries/src'],
+  testMatch: ['**/__tests__/**/*.spec.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.base.json',
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^@gitroom/backend/(.*)$': '<rootDir>/apps/backend/src/$1',
+    '^@gitroom/frontend/(.*)$': '<rootDir>/apps/frontend/src/$1',
+    '^@gitroom/helpers/(.*)$': '<rootDir>/libraries/helpers/src/$1',
+    '^@gitroom/nestjs-libraries/(.*)$':
+      '<rootDir>/libraries/nestjs-libraries/src/$1',
+    '^@gitroom/react/(.*)$':
+      '<rootDir>/libraries/react-shared-libraries/src/$1',
+    '^@gitroom/plugins/(.*)$': '<rootDir>/libraries/plugins/src/$1',
+    '^@gitroom/orchestrator/(.*)$': '<rootDir>/apps/orchestrator/src/$1',
+    '^@gitroom/extension/(.*)$': '<rootDir>/apps/extension/src/$1',
+  },
+  testTimeout: 15000,
+  detectOpenHandles: true,
+  maxWorkers: 1,
+  collectCoverageFrom: [
+    'libraries/nestjs-libraries/src/integrations/**/*.ts',
+    '!libraries/nestjs-libraries/src/integrations/__tests__/**',
+    '!libraries/nestjs-libraries/src/integrations/social/mastodon.custom.provider.ts',
+  ],
+  coverageDirectory: '<rootDir>/coverage',
 };

--- a/libraries/nestjs-libraries/src/integrations/__tests__/factories.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/factories.ts
@@ -1,0 +1,121 @@
+import type {
+  PostDetails,
+  PostResponse,
+  MediaContent,
+  AuthTokenDetails,
+} from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import type { Integration } from '@prisma/client';
+
+export function createPostDetails<T = any>(
+  overrides: Partial<PostDetails<T>> = {}
+): PostDetails<T> {
+  return {
+    id: 'test-post-id',
+    message: 'Test post message',
+    settings: {} as T,
+    media: [],
+    ...overrides,
+  };
+}
+
+export function createMediaContent(
+  overrides: Partial<MediaContent> = {}
+): MediaContent {
+  return {
+    type: 'image',
+    path: 'https://example.com/test-image.jpg',
+    ...overrides,
+  };
+}
+
+export function createIntegration(
+  overrides: Partial<Integration> = {}
+): Integration {
+  return {
+    id: 'test-integration-id',
+    internalId: 'test-internal-id',
+    organizationId: 'test-org-id',
+    name: 'Test Integration',
+    picture: 'https://example.com/pic.jpg',
+    providerIdentifier: 'test-provider',
+    type: 'social',
+    token: 'test-access-token',
+    refreshToken: 'test-refresh-token',
+    expiresIn: 3600,
+    profile: 'test-profile',
+    deletedAt: null,
+    refreshNeeded: false,
+    inBetweenSteps: false,
+    disabled: false,
+    tokenExpireDate: new Date(),
+    order: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    customInstanceDetails: null,
+    additionalSettings: null,
+    ...overrides,
+  } as Integration;
+}
+
+export function createAuthTokenDetails(
+  overrides: Partial<AuthTokenDetails> = {}
+): AuthTokenDetails {
+  return {
+    id: 'test-auth-id',
+    name: 'Test User',
+    accessToken: 'test-access-token',
+    refreshToken: 'test-refresh-token',
+    expiresIn: 3600,
+    picture: 'https://example.com/avatar.jpg',
+    username: 'testuser',
+    ...overrides,
+  };
+}
+
+export function createPostResponse(
+  overrides: Partial<PostResponse> = {}
+): PostResponse {
+  return {
+    id: 'test-post-id',
+    postId: 'platform-post-id',
+    releaseURL: 'https://example.com/post/123',
+    status: 'posted',
+    ...overrides,
+  };
+}
+
+export function createMockResponse(
+  body: any = {},
+  status = 200,
+  headers: Record<string, string> = {}
+): Response {
+  const headersObj = new Headers(headers);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: headersObj,
+    json: jest.fn().mockResolvedValue(body),
+    text: jest.fn().mockResolvedValue(
+      typeof body === 'string' ? body : JSON.stringify(body)
+    ),
+    blob: jest.fn().mockResolvedValue(new Blob()),
+    clone: jest.fn(),
+    arrayBuffer: jest.fn(),
+    formData: jest.fn(),
+    body: null,
+    bodyUsed: false,
+    redirected: false,
+    type: 'basic' as ResponseType,
+    url: '',
+    bytes: jest.fn(),
+  } as unknown as Response;
+}
+
+export function mockFetchSequence(responses: Response[]): jest.Mock {
+  const mock = jest.fn();
+  responses.forEach((response, index) => {
+    mock.mockResolvedValueOnce(response);
+  });
+  return mock;
+}

--- a/libraries/nestjs-libraries/src/integrations/__tests__/integration.manager.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/integration.manager.spec.ts
@@ -1,0 +1,182 @@
+import './setup';
+import 'reflect-metadata';
+import {
+  IntegrationManager,
+  socialIntegrationList,
+} from '@gitroom/nestjs-libraries/integrations/integration.manager';
+
+const PROVIDER_COUNT = socialIntegrationList.length;
+
+describe('IntegrationManager', () => {
+  let manager: IntegrationManager;
+
+  beforeAll(() => {
+    manager = new IntegrationManager();
+  });
+
+  describe('Provider registry', () => {
+    it('should have all providers registered (at least 30)', () => {
+      expect(PROVIDER_COUNT).toBeGreaterThanOrEqual(30);
+    });
+
+    it('should have no duplicate identifiers', () => {
+      const identifiers = socialIntegrationList.map((p) => p.identifier);
+      const uniqueIdentifiers = new Set(identifiers);
+      expect(uniqueIdentifiers.size).toBe(identifiers.length);
+    });
+
+    it('should have no duplicate names', () => {
+      const names = socialIntegrationList.map((p) => p.name);
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(names.length);
+    });
+  });
+
+  describe('getSocialIntegration()', () => {
+    it('should return correct provider for known identifier', () => {
+      const provider = manager.getSocialIntegration('linkedin');
+      expect(provider).toBeDefined();
+      expect(provider.identifier).toBe('linkedin');
+    });
+
+    it('should return correct provider for x', () => {
+      const provider = manager.getSocialIntegration('x');
+      expect(provider).toBeDefined();
+      expect(provider.identifier).toBe('x');
+    });
+
+    it('should return correct provider for discord', () => {
+      const provider = manager.getSocialIntegration('discord');
+      expect(provider).toBeDefined();
+      expect(provider.identifier).toBe('discord');
+    });
+
+    it('should return undefined for unknown identifier', () => {
+      const provider = manager.getSocialIntegration('nonexistent');
+      expect(provider).toBeUndefined();
+    });
+  });
+
+  describe('getAllIntegrations()', () => {
+    it('should return social array with name, identifier, and editor', async () => {
+      const integrations = await manager.getAllIntegrations();
+      expect(integrations.social).toBeDefined();
+      expect(Array.isArray(integrations.social)).toBe(true);
+      expect(integrations.social.length).toBe(PROVIDER_COUNT);
+
+      integrations.social.forEach((item) => {
+        expect(item.name).toBeDefined();
+        expect(typeof item.name).toBe('string');
+        expect(item.identifier).toBeDefined();
+        expect(typeof item.identifier).toBe('string');
+        expect(item.editor).toBeDefined();
+      });
+    });
+
+    it('should return empty article array', async () => {
+      const integrations = await manager.getAllIntegrations();
+      expect(integrations.article).toEqual([]);
+    });
+  });
+
+  describe('getAllowedSocialsIntegrations()', () => {
+    it('should return 31 identifier strings', () => {
+      const allowed = manager.getAllowedSocialsIntegrations();
+      expect(allowed.length).toBe(PROVIDER_COUNT);
+      allowed.forEach((id) => {
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should include known providers', () => {
+      const allowed = manager.getAllowedSocialsIntegrations();
+      expect(allowed).toContain('x');
+      expect(allowed).toContain('linkedin');
+      expect(allowed).toContain('discord');
+      expect(allowed).toContain('tiktok');
+      expect(allowed).toContain('facebook');
+      expect(allowed).toContain('instagram');
+    });
+  });
+
+  describe('getAllTools()', () => {
+    it('should return an object with provider identifiers as keys', () => {
+      const tools = manager.getAllTools();
+      expect(typeof tools).toBe('object');
+      expect(Object.keys(tools).length).toBe(PROVIDER_COUNT);
+    });
+
+    it('should include discord channels tool', () => {
+      const tools = manager.getAllTools();
+      expect(tools['discord']).toBeDefined();
+      expect(Array.isArray(tools['discord'])).toBe(true);
+      const channelsTool = tools['discord'].find(
+        (t) => t.methodName === 'channels'
+      );
+      expect(channelsTool).toBeDefined();
+      expect(channelsTool!.description).toBe('Channels');
+    });
+
+    it('should return empty array for providers without tools', () => {
+      const tools = manager.getAllTools();
+      // LinkedIn doesn't have @Tool decorators
+      expect(tools['linkedin']).toEqual([]);
+    });
+  });
+
+  describe('getAllRulesDescription()', () => {
+    it('should return an object with provider identifiers as keys', () => {
+      const rules = manager.getAllRulesDescription();
+      expect(typeof rules).toBe('object');
+    });
+
+    it('should include X rules description', () => {
+      const rules = manager.getAllRulesDescription();
+      expect(rules['x']).toBeDefined();
+      expect(rules['x'].length).toBeGreaterThan(0);
+      expect(rules['x']).toContain('X can have maximum 4 pictures');
+    });
+
+    it('should include LinkedIn rules description', () => {
+      const rules = manager.getAllRulesDescription();
+      expect(rules['linkedin']).toBeDefined();
+      expect(rules['linkedin']).toContain('LinkedIn');
+    });
+
+    it('should return empty string for providers without @Rules', () => {
+      const rules = manager.getAllRulesDescription();
+      // Discord has no @Rules decorator
+      expect(rules['discord']).toBe('');
+    });
+  });
+
+  describe('getAllPlugs()', () => {
+    it('should return array of providers with @Plug decorators', () => {
+      const plugs = manager.getAllPlugs();
+      expect(Array.isArray(plugs)).toBe(true);
+      expect(plugs.length).toBeGreaterThan(0);
+    });
+
+    it('should have correct structure for each plug entry', () => {
+      const plugs = manager.getAllPlugs();
+      plugs.forEach((entry) => {
+        expect(entry.name).toBeDefined();
+        expect(entry.identifier).toBeDefined();
+        expect(Array.isArray(entry.plugs)).toBe(true);
+        entry.plugs.forEach((plug: any) => {
+          expect(plug.identifier).toBeDefined();
+          expect(plug.title).toBeDefined();
+          expect(plug.description).toBeDefined();
+        });
+      });
+    });
+
+    it('should include X provider plugs', () => {
+      const plugs = manager.getAllPlugs();
+      const xPlugs = plugs.find((p) => p.identifier === 'x');
+      expect(xPlugs).toBeDefined();
+      expect(xPlugs!.plugs.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/__tests__/provider.conformance.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/provider.conformance.spec.ts
@@ -1,0 +1,168 @@
+import './setup';
+import { socialIntegrationList } from '@gitroom/nestjs-libraries/integrations/integration.manager';
+import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import type { SocialProvider } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+
+type ProviderInstance = SocialAbstract & SocialProvider;
+
+// Build test table: [identifier, provider instance]
+const providerTable: [string, ProviderInstance][] = socialIntegrationList.map(
+  (p) => [p.identifier, p]
+);
+
+describe('Provider Conformance Tests', () => {
+  describe.each(providerTable)('%s', (identifier, provider) => {
+    describe('Identity', () => {
+      it('should have a non-empty string identifier', () => {
+        expect(typeof provider.identifier).toBe('string');
+        expect(provider.identifier.length).toBeGreaterThan(0);
+      });
+
+      it('should have a non-empty string name', () => {
+        expect(typeof provider.name).toBe('string');
+        expect(provider.name.length).toBeGreaterThan(0);
+      });
+
+      it('should have identifier matching the registered key', () => {
+        expect(provider.identifier).toBe(identifier);
+      });
+    });
+
+    describe('Editor', () => {
+      it('should have a valid editor type', () => {
+        expect(['none', 'normal', 'markdown', 'html']).toContain(
+          provider.editor
+        );
+      });
+    });
+
+    describe('Scopes', () => {
+      it('should have scopes as an array of strings', () => {
+        expect(Array.isArray(provider.scopes)).toBe(true);
+        provider.scopes.forEach((scope) => {
+          expect(typeof scope).toBe('string');
+        });
+      });
+    });
+
+    describe('maxLength()', () => {
+      it('should return a positive number', () => {
+        const length = provider.maxLength();
+        expect(typeof length).toBe('number');
+        expect(length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('isBetweenSteps', () => {
+      it('should be a boolean', () => {
+        expect(typeof provider.isBetweenSteps).toBe('boolean');
+      });
+    });
+
+    describe('Required methods', () => {
+      it('should have authenticate method', () => {
+        expect(typeof provider.authenticate).toBe('function');
+      });
+
+      it('should have refreshToken method', () => {
+        expect(typeof provider.refreshToken).toBe('function');
+      });
+
+      it('should have generateAuthUrl method', () => {
+        expect(typeof provider.generateAuthUrl).toBe('function');
+      });
+
+      it('should have post method', () => {
+        expect(typeof provider.post).toBe('function');
+      });
+    });
+
+    describe('SocialAbstract inheritance', () => {
+      it('should be an instance of SocialAbstract', () => {
+        expect(provider).toBeInstanceOf(SocialAbstract);
+      });
+
+      it('should inherit fetch method', () => {
+        expect(typeof provider.fetch).toBe('function');
+      });
+
+      it('should inherit checkScopes method', () => {
+        expect(typeof provider.checkScopes).toBe('function');
+      });
+
+      it('should inherit runInConcurrent method', () => {
+        expect(typeof provider.runInConcurrent).toBe('function');
+      });
+
+      it('should inherit handleErrors method', () => {
+        expect(typeof provider.handleErrors).toBe('function');
+      });
+
+      it('should have maxConcurrentJob > 0', () => {
+        expect(provider.maxConcurrentJob).toBeGreaterThan(0);
+      });
+    });
+
+    describe('Optional methods and properties', () => {
+      if (provider.customFields) {
+        it('should have customFields return a promise', () => {
+          expect(typeof provider.customFields).toBe('function');
+        });
+      }
+
+      if (provider.mentionFormat) {
+        it('should have mentionFormat as a function', () => {
+          expect(typeof provider.mentionFormat).toBe('function');
+        });
+
+        it('should have mentionFormat return a non-empty string', () => {
+          const result = provider.mentionFormat!('test-id', 'Test Name');
+          expect(typeof result).toBe('string');
+          expect(result.length).toBeGreaterThan(0);
+        });
+      }
+
+      if (provider.comment) {
+        it('should have comment as a function', () => {
+          expect(typeof provider.comment).toBe('function');
+        });
+      }
+
+      if (provider.analytics) {
+        it('should have analytics as a function', () => {
+          expect(typeof provider.analytics).toBe('function');
+        });
+      }
+
+      if (provider.mention) {
+        it('should have mention as a function', () => {
+          expect(typeof provider.mention).toBe('function');
+        });
+      }
+
+      if (provider.refreshWait !== undefined) {
+        it('should have refreshWait as a boolean', () => {
+          expect(typeof provider.refreshWait).toBe('boolean');
+        });
+      }
+
+      if (provider.convertToJPEG !== undefined) {
+        it('should have convertToJPEG as a boolean', () => {
+          expect(typeof provider.convertToJPEG).toBe('boolean');
+        });
+      }
+
+      if (provider.oneTimeToken !== undefined) {
+        it('should have oneTimeToken as a boolean', () => {
+          expect(typeof provider.oneTimeToken).toBe('boolean');
+        });
+      }
+
+      if (provider.dto) {
+        it('should have dto defined', () => {
+          expect(provider.dto).toBeDefined();
+        });
+      }
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/__tests__/providers/discord.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/providers/discord.provider.spec.ts
@@ -1,0 +1,179 @@
+import '../setup';
+import { DiscordProvider } from '@gitroom/nestjs-libraries/integrations/social/discord.provider';
+import { createMockResponse, createPostDetails } from '../factories';
+
+describe('DiscordProvider', () => {
+  let provider: DiscordProvider;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    provider = new DiscordProvider();
+    originalFetch = global.fetch;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('Metadata', () => {
+    it('should have identifier "discord"', () => {
+      expect(provider.identifier).toBe('discord');
+    });
+
+    it('should have name "Discord"', () => {
+      expect(provider.name).toBe('Discord');
+    });
+
+    it('should have markdown editor', () => {
+      expect(provider.editor).toBe('markdown');
+    });
+
+    it('should have maxLength of 1980', () => {
+      expect(provider.maxLength()).toBe(1980);
+    });
+
+    it('should have maxConcurrentJob of 5', () => {
+      expect(provider.maxConcurrentJob).toBe(5);
+    });
+
+    it('should have identify and guilds scopes', () => {
+      expect(provider.scopes).toEqual(['identify', 'guilds']);
+    });
+  });
+
+  describe('authenticate()', () => {
+    it('should call token endpoint and @me endpoint', async () => {
+      // First call: this.fetch for token (needs 200/201 to pass through SocialAbstract.fetch)
+      const tokenResponse = createMockResponse({
+        access_token: 'discord-token',
+        expires_in: 604800,
+        refresh_token: 'discord-refresh',
+        scope: 'identify guilds bot',
+        guild: { id: 'guild-123' },
+      });
+
+      // Second call: direct fetch for @me
+      const meResponse = createMockResponse({
+        application: {
+          name: 'TestBot',
+          bot: {
+            id: 'bot-123',
+            avatar: 'abc123',
+            username: 'TestBot#1234',
+          },
+        },
+      });
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(tokenResponse)
+        .mockResolvedValueOnce(meResponse);
+
+      const result = await provider.authenticate({
+        code: 'auth-code',
+        codeVerifier: 'verifier',
+      });
+
+      expect(result.id).toBe('guild-123');
+      expect(result.name).toBe('TestBot');
+      expect(result.accessToken).toBe('discord-token');
+      expect(result.refreshToken).toBe('discord-refresh');
+      expect(result.picture).toContain('cdn.discordapp.com');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('post()', () => {
+    it('should post message to Discord channel', async () => {
+      const messageResponse = createMockResponse({
+        id: 'message-123',
+      });
+
+      global.fetch = jest.fn().mockResolvedValue(messageResponse);
+
+      const postDetails = [
+        createPostDetails({
+          id: 'post-1',
+          message: 'Hello Discord!',
+          settings: { channel: 'channel-456' },
+          media: [],
+        }),
+      ];
+
+      const result = await provider.post(
+        'guild-123',
+        'bot-token',
+        postDetails
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].postId).toBe('message-123');
+      expect(result[0].status).toBe('success');
+      expect(result[0].releaseURL).toContain(
+        'discord.com/channels/guild-123/channel-456/message-123'
+      );
+    });
+
+    it('should replace mention format in message', async () => {
+      const messageResponse = createMockResponse({ id: 'msg-1' });
+      global.fetch = jest.fn().mockResolvedValue(messageResponse);
+
+      await provider.post('guild-123', 'token', [
+        createPostDetails({
+          message: 'Hello [[[@user123]]]!',
+          settings: { channel: 'ch-1' },
+        }),
+      ]);
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+      // The body is FormData, let's verify fetch was called
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('mentionFormat()', () => {
+    it('should return [[[@id]]] format for regular users', () => {
+      const result = provider.mentionFormat('user-123', 'Test User');
+      expect(result).toBe('[[[@user-123]]]');
+    });
+
+    it('should passthrough @here', () => {
+      const result = provider.mentionFormat('here', '@here');
+      expect(result).toBe('@here');
+    });
+
+    it('should passthrough @everyone', () => {
+      const result = provider.mentionFormat('everyone', '@everyone');
+      expect(result).toBe('@everyone');
+    });
+
+    it('should strip @ from id', () => {
+      const result = provider.mentionFormat('@user-123', 'Test User');
+      expect(result).toBe('[[[@user-123]]]');
+    });
+  });
+
+  describe('channels()', () => {
+    it('should fetch and filter guild channels', async () => {
+      const channelsResponse = createMockResponse([
+        { id: '1', name: 'general', type: 0 },
+        { id: '2', name: 'announcements', type: 5 },
+        { id: '3', name: 'voice', type: 2 },
+        { id: '4', name: 'forum', type: 15 },
+      ]);
+
+      global.fetch = jest.fn().mockResolvedValue(channelsResponse);
+
+      const result = await provider.channels('token', {}, 'guild-123');
+
+      // Should filter to type 0, 5, and 15 only
+      expect(result).toHaveLength(3);
+      expect(result.map((c: any) => c.name)).toEqual([
+        'general',
+        'announcements',
+        'forum',
+      ]);
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/__tests__/providers/linkedin.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/providers/linkedin.provider.spec.ts
@@ -1,0 +1,189 @@
+import '../setup';
+import { LinkedinProvider } from '@gitroom/nestjs-libraries/integrations/social/linkedin.provider';
+import { createMockResponse, createPostDetails, createIntegration } from '../factories';
+
+jest.mock('sharp', () => jest.fn().mockReturnValue({
+  toFormat: jest.fn().mockReturnThis(),
+  resize: jest.fn().mockReturnThis(),
+  metadata: jest.fn().mockResolvedValue({ width: 1000, height: 1000 }),
+  toBuffer: jest.fn().mockResolvedValue(Buffer.from('test')),
+  gif: jest.fn().mockReturnThis(),
+}));
+
+jest.mock('@gitroom/helpers/utils/read.or.fetch', () => ({
+  readOrFetch: jest.fn().mockResolvedValue(Buffer.from('test-image')),
+}));
+
+jest.mock('image-to-pdf', () =>
+  jest.fn().mockReturnValue({
+    on: jest.fn((event, callback) => {
+      if (event === 'data') callback(Buffer.from('pdf'));
+      if (event === 'end') callback();
+    }),
+  })
+);
+
+describe('LinkedinProvider', () => {
+  let provider: LinkedinProvider;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    provider = new LinkedinProvider();
+    originalFetch = global.fetch;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('Metadata', () => {
+    it('should have identifier "linkedin"', () => {
+      expect(provider.identifier).toBe('linkedin');
+    });
+
+    it('should have name "LinkedIn"', () => {
+      expect(provider.name).toBe('LinkedIn');
+    });
+
+    it('should have maxLength of 3000', () => {
+      expect(provider.maxLength()).toBe(3000);
+    });
+
+    it('should have oneTimeToken enabled', () => {
+      expect(provider.oneTimeToken).toBe(true);
+    });
+
+    it('should have refreshWait enabled', () => {
+      expect(provider.refreshWait).toBe(true);
+    });
+
+    it('should have 7 scopes', () => {
+      expect(provider.scopes).toHaveLength(7);
+      expect(provider.scopes).toContain('openid');
+      expect(provider.scopes).toContain('profile');
+      expect(provider.scopes).toContain('w_member_social');
+    });
+
+    it('should have normal editor', () => {
+      expect(provider.editor).toBe('normal');
+    });
+
+    it('should have maxConcurrentJob of 2', () => {
+      expect(provider.maxConcurrentJob).toBe(2);
+    });
+  });
+
+  describe('handleErrors()', () => {
+    it('should return retry for "Unable to obtain activity"', () => {
+      const result = provider.handleErrors('Unable to obtain activity for URN');
+      expect(result).toEqual({
+        type: 'retry',
+        value: 'Unable to obtain activity',
+      });
+    });
+
+    it('should return retry for "resource is forbidden"', () => {
+      const result = provider.handleErrors('The resource is forbidden');
+      expect(result).toEqual({
+        type: 'retry',
+        value: 'Resource is forbidden',
+      });
+    });
+
+    it('should return undefined for unknown errors', () => {
+      const result = provider.handleErrors('some random error');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('authenticate()', () => {
+    it('should call 3 fetch endpoints and return auth details', async () => {
+      const tokenResponse = createMockResponse({
+        access_token: 'li-access-token',
+        expires_in: 3600,
+        refresh_token: 'li-refresh-token',
+        scope: 'openid profile w_member_social r_basicprofile rw_organization_admin w_organization_social r_organization_social',
+      });
+
+      const userinfoResponse = createMockResponse({
+        name: 'Test User',
+        sub: 'user-123',
+        picture: 'https://pic.example.com/avatar.jpg',
+      });
+
+      const meResponse = createMockResponse({
+        vanityName: 'testuser',
+      });
+
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(tokenResponse)
+        .mockResolvedValueOnce(userinfoResponse)
+        .mockResolvedValueOnce(meResponse);
+
+      const result = await provider.authenticate({
+        code: 'auth-code',
+        codeVerifier: 'verifier',
+      });
+
+      expect(result.id).toBe('user-123');
+      expect(result.accessToken).toBe('li-access-token');
+      expect(result.refreshToken).toBe('li-refresh-token');
+      expect(result.name).toBe('Test User');
+      expect(result.username).toBe('testuser');
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('post()', () => {
+    it('should create a post and return PostResponse with releaseURL', async () => {
+      // Mock for processMediaForPosts (no media)
+      const postResponse = createMockResponse(
+        {},
+        201,
+        { 'x-restli-id': 'urn:li:share:12345' }
+      );
+      // Override provider.fetch to use our mock
+      global.fetch = jest.fn().mockResolvedValue(postResponse);
+
+      const postDetails = [
+        createPostDetails({
+          id: 'post-1',
+          message: 'Hello LinkedIn!',
+          settings: { post_as_images_carousel: false },
+          media: [],
+        }),
+      ];
+
+      const integration = createIntegration({
+        internalId: 'person-id',
+      });
+
+      const result = await provider.post(
+        'person-id',
+        'access-token',
+        postDetails,
+        integration,
+        'personal'
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe('posted');
+      expect(result[0].id).toBe('post-1');
+      expect(result[0].releaseURL).toContain('linkedin.com/feed/update/');
+    });
+  });
+
+  describe('mentionFormat()', () => {
+    it('should return correct LinkedIn mention format', () => {
+      const result = provider.mentionFormat('12345', 'Test Company');
+      expect(result).toBe('@[Test Company](urn:li:organization:12345)');
+    });
+
+    it('should strip @ from name', () => {
+      const result = provider.mentionFormat('12345', '@Test Company');
+      expect(result).toBe('@[Test Company](urn:li:organization:12345)');
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/__tests__/providers/tiktok.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/providers/tiktok.provider.spec.ts
@@ -1,0 +1,200 @@
+import '../setup';
+import { TiktokProvider } from '@gitroom/nestjs-libraries/integrations/social/tiktok.provider';
+
+describe('TiktokProvider', () => {
+  let provider: TiktokProvider;
+
+  beforeEach(() => {
+    provider = new TiktokProvider();
+  });
+
+  describe('Metadata', () => {
+    it('should have identifier "tiktok"', () => {
+      expect(provider.identifier).toBe('tiktok');
+    });
+
+    it('should have name "Tiktok"', () => {
+      expect(provider.name).toBe('Tiktok');
+    });
+
+    it('should have maxLength of 2000', () => {
+      expect(provider.maxLength()).toBe(2000);
+    });
+
+    it('should have convertToJPEG enabled', () => {
+      expect(provider.convertToJPEG).toBe(true);
+    });
+
+    it('should have maxConcurrentJob of 300', () => {
+      expect(provider.maxConcurrentJob).toBe(300);
+    });
+
+    it('should have normal editor', () => {
+      expect(provider.editor).toBe('normal');
+    });
+
+    it('should have 6 scopes', () => {
+      expect(provider.scopes).toHaveLength(6);
+      expect(provider.scopes).toContain('video.publish');
+      expect(provider.scopes).toContain('video.upload');
+    });
+  });
+
+  describe('handleErrors()', () => {
+    const authErrors = [
+      {
+        input: 'access_token_invalid',
+        expectedType: 'refresh-token',
+        expectedMsg:
+          'Access token invalid, please re-authenticate your TikTok account',
+      },
+    ];
+
+    const badBodyErrors = [
+      {
+        input: 'scope_not_authorized',
+        expectedMsg:
+          'Missing required permissions, please re-authenticate with all scopes',
+      },
+      {
+        input: 'scope_permission_missed',
+        expectedMsg:
+          'Additional permissions required, please re-authenticate',
+      },
+      {
+        input: 'rate_limit_exceeded',
+        expectedMsg: 'TikTok API rate limit exceeded, please try again later',
+      },
+      {
+        input: 'file_format_check_failed',
+        expectedMsg:
+          'File format is invalid, please check video specifications',
+      },
+      {
+        input: 'app_version_check_failed',
+        expectedMsg:
+          'In order to use the TikTok upload feature, you have to update your app to the latest version',
+      },
+      {
+        input: 'duration_check_failed',
+        expectedMsg:
+          'Video duration is invalid, please check video specifications',
+      },
+      {
+        input: 'frame_rate_check_failed',
+        expectedMsg:
+          'Video frame rate is invalid, please check video specifications',
+      },
+      {
+        input: 'video_pull_failed',
+        expectedMsg: 'Failed to pull video from URL, please check the URL',
+      },
+      {
+        input: 'photo_pull_failed',
+        expectedMsg: 'Failed to pull photo from URL, please check the URL',
+      },
+      {
+        input: 'spam_risk_user_banned_from_posting',
+        expectedMsg:
+          'Account banned from posting, please check TikTok account status',
+      },
+      {
+        input: 'spam_risk_text content detected',
+        expectedMsg: 'TikTok detected potential spam in the post text',
+      },
+      {
+        input: 'spam_risk_too_many_posts limit',
+        expectedMsg:
+          'TikTok says your daily post limit reached, please try again tomorrow',
+      },
+      {
+        input: 'spam_risk_too_many_pending_share limit',
+        expectedMsg:
+          'TikTok limit the maximum of pending posts to 5, please check your TikTok inbox at your TikTok mobile app',
+      },
+      {
+        input: 'spam_risk generic',
+        expectedMsg: 'TikTok detected potential spam',
+      },
+      {
+        input: 'reached_active_user_cap',
+        expectedMsg:
+          'Daily active user quota reached, please try again later',
+      },
+      {
+        input: 'unaudited_client_can_only_post_to_private_accounts',
+        expectedMsg: 'App not approved for public posting, contact support',
+      },
+      {
+        input: 'url_ownership_unverified',
+        expectedMsg:
+          'URL ownership not verified, please verify domain ownership',
+      },
+      {
+        input: 'privacy_level_option_mismatch',
+        expectedMsg:
+          'Privacy level mismatch, please check privacy settings',
+      },
+      {
+        input: 'invalid_file_upload',
+        expectedMsg: 'Invalid file format or specifications not met',
+      },
+      {
+        input: 'invalid_params',
+        expectedMsg:
+          'Invalid request parameters, please check content format',
+      },
+      {
+        input: 'internal server error',
+        expectedMsg:
+          'There is a problem with TikTok servers, please try again later',
+      },
+      {
+        input: 'picture_size_check_failed',
+        expectedMsg:
+          'Picture / Video size is invalid, must be at least 720p',
+      },
+      {
+        input: 'TikTok API error occurred',
+        expectedMsg: 'TikTok API error, please try again',
+      },
+    ];
+
+    it.each(authErrors)(
+      'should return refresh-token for "$input"',
+      ({ input, expectedType, expectedMsg }) => {
+        const result = provider.handleErrors(input);
+        expect(result).toBeDefined();
+        expect(result!.type).toBe(expectedType);
+        expect(result!.value).toBe(expectedMsg);
+      }
+    );
+
+    it.each(badBodyErrors)(
+      'should return bad-body for "$input"',
+      ({ input, expectedMsg }) => {
+        const result = provider.handleErrors(input);
+        expect(result).toBeDefined();
+        expect(result!.type).toBe('bad-body');
+        expect(result!.value).toBe(expectedMsg);
+      }
+    );
+
+    it('should return undefined for unknown errors', () => {
+      expect(
+        provider.handleErrors('completely unknown error string')
+      ).toBeUndefined();
+    });
+
+    // Test ordering: spam_risk_text should match before generic spam_risk
+    it('should match specific spam errors before generic spam_risk', () => {
+      const textResult = provider.handleErrors('spam_risk_text detected');
+      expect(textResult!.value).toContain('spam in the post text');
+
+      const genericResult = provider.handleErrors(
+        'spam_risk some other reason'
+      );
+      expect(genericResult!.value).toBe('TikTok detected potential spam');
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/__tests__/providers/x.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/providers/x.provider.spec.ts
@@ -1,0 +1,167 @@
+import '../setup';
+import { XProvider } from '@gitroom/nestjs-libraries/integrations/social/x.provider';
+
+jest.mock('sharp', () => jest.fn().mockReturnValue({
+  toFormat: jest.fn().mockReturnThis(),
+  resize: jest.fn().mockReturnThis(),
+  gif: jest.fn().mockReturnThis(),
+  toBuffer: jest.fn().mockResolvedValue(Buffer.from('test')),
+}));
+
+jest.mock('@gitroom/helpers/utils/read.or.fetch', () => ({
+  readOrFetch: jest.fn().mockResolvedValue(Buffer.from('test-image')),
+}));
+
+// Mock TwitterApi
+const mockTweet = jest.fn().mockResolvedValue({
+  data: { id: 'tweet-123' },
+});
+const mockMe = jest.fn().mockResolvedValue({
+  data: { username: 'testuser', verified: false, profile_image_url: 'pic.jpg', name: 'Test', id: '123' },
+});
+const mockUploadMedia = jest.fn().mockResolvedValue('media-id-123');
+const mockLogin = jest.fn().mockResolvedValue({
+  accessToken: 'at',
+  accessSecret: 'as',
+  client: { v2: { me: mockMe } },
+});
+const mockGenerateAuthLink = jest.fn().mockResolvedValue({
+  url: 'https://twitter.com/auth',
+  oauth_token: 'token',
+  oauth_token_secret: 'secret',
+});
+
+jest.mock('twitter-api-v2', () => ({
+  TwitterApi: jest.fn().mockImplementation(() => ({
+    v2: {
+      tweet: mockTweet,
+      me: mockMe,
+      uploadMedia: mockUploadMedia,
+    },
+    login: mockLogin,
+    generateAuthLink: mockGenerateAuthLink,
+  })),
+}));
+
+describe('XProvider', () => {
+  let provider: XProvider;
+
+  beforeEach(() => {
+    provider = new XProvider();
+    jest.clearAllMocks();
+  });
+
+  describe('Metadata', () => {
+    it('should have identifier "x"', () => {
+      expect(provider.identifier).toBe('x');
+    });
+
+    it('should have name "X"', () => {
+      expect(provider.name).toBe('X');
+    });
+
+    it('should have empty scopes for OAuth 1.0a', () => {
+      expect(provider.scopes).toEqual([]);
+    });
+
+    it('should have maxLength(false) = 200', () => {
+      expect(provider.maxLength(false)).toBe(200);
+    });
+
+    it('should have maxLength(true) = 4000 for premium', () => {
+      expect(provider.maxLength(true)).toBe(4000);
+    });
+
+    it('should have normal editor', () => {
+      expect(provider.editor).toBe('normal');
+    });
+
+    it('should have maxConcurrentJob of 1', () => {
+      expect(provider.maxConcurrentJob).toBe(1);
+    });
+  });
+
+  describe('handleErrors()', () => {
+    const errorCases = [
+      {
+        input: 'Unsupported Authentication',
+        expected: {
+          type: 'refresh-token',
+          value: 'X authentication has expired, please reconnect your account',
+        },
+      },
+      {
+        input: 'usage-capped',
+        expected: {
+          type: 'bad-body',
+          value: 'Posting failed - capped reached. Please try again later',
+        },
+      },
+      {
+        input: 'duplicate-rules',
+        expected: {
+          type: 'bad-body',
+          value:
+            'You have already posted this post, please wait before posting again',
+        },
+      },
+      {
+        input: 'The Tweet contains an invalid URL.',
+        expected: {
+          type: 'bad-body',
+          value: 'The Tweet contains a URL that is not allowed on X',
+        },
+      },
+      {
+        input:
+          'This user is not allowed to post a video longer than 2 minutes',
+        expected: {
+          type: 'bad-body',
+          value:
+            'The video you are trying to post is longer than 2 minutes, which is not allowed for this account',
+        },
+      },
+    ];
+
+    it.each(errorCases)(
+      'should handle "$input" error',
+      ({ input, expected }) => {
+        const result = provider.handleErrors(input);
+        expect(result).toEqual(expected);
+      }
+    );
+
+    it('should return undefined for unknown errors', () => {
+      expect(provider.handleErrors('some unknown error')).toBeUndefined();
+    });
+  });
+
+  describe('post()', () => {
+    it('should call TwitterApi v2.tweet and return PostResponse', async () => {
+      const result = await provider.post('user-123', 'access:secret', [
+        {
+          id: 'post-1',
+          message: 'Hello X!',
+          settings: {
+            active_thread_finisher: false,
+            thread_finisher: '',
+            who_can_reply_post: 'everyone' as const,
+          },
+          media: [],
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].postId).toBe('tweet-123');
+      expect(result[0].status).toBe('posted');
+      expect(result[0].releaseURL).toContain('twitter.com/testuser/status/tweet-123');
+    });
+  });
+
+  describe('mentionFormat()', () => {
+    it('should return @handle format', () => {
+      const result = provider.mentionFormat('johndoe', 'John Doe');
+      expect(result).toBe('@johndoe');
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/__tests__/setup.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/setup.ts
@@ -1,0 +1,133 @@
+// Global test setup - mocks that must be in place before provider imports
+
+// Mock @temporalio/activity (heavy native dependency via core-bridge)
+jest.mock('@temporalio/activity', () => {
+  class ApplicationFailure extends Error {
+    public readonly type: string;
+    public readonly nonRetryable: boolean;
+    public readonly details: any[];
+
+    constructor(
+      message: string,
+      type: string,
+      nonRetryable: boolean,
+      details: any[] = []
+    ) {
+      super(message);
+      this.name = 'ApplicationFailure';
+      this.type = type;
+      this.nonRetryable = nonRetryable;
+      this.details = details;
+    }
+  }
+
+  return { ApplicationFailure };
+});
+
+// Mock timer to resolve immediately (prevents 5s delays in retry logic)
+jest.mock('@gitroom/helpers/utils/timer', () => ({
+  timer: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Mock node-telegram-bot-api (Telegram creates bot instance at module scope)
+jest.mock('node-telegram-bot-api', () => {
+  return jest.fn().mockImplementation(() => ({
+    sendMessage: jest.fn(),
+    sendPhoto: jest.fn(),
+    sendVideo: jest.fn(),
+    sendDocument: jest.fn(),
+    sendMediaGroup: jest.fn(),
+  }));
+});
+
+// Mock sharp (native binary, heavy import)
+jest.mock('sharp', () => {
+  const sharpInstance = {
+    toFormat: jest.fn().mockReturnThis(),
+    resize: jest.fn().mockReturnThis(),
+    metadata: jest.fn().mockResolvedValue({ width: 1000, height: 1000 }),
+    toBuffer: jest.fn().mockResolvedValue(Buffer.from('test')),
+    gif: jest.fn().mockReturnThis(),
+    jpeg: jest.fn().mockReturnThis(),
+    png: jest.fn().mockReturnThis(),
+  };
+  return jest.fn().mockReturnValue(sharpInstance);
+});
+
+// Mock readOrFetch (prevents actual file/network reads)
+jest.mock('@gitroom/helpers/utils/read.or.fetch', () => ({
+  readOrFetch: jest.fn().mockResolvedValue(Buffer.from('test-content')),
+}));
+
+// Mock image-to-pdf (used by LinkedIn carousel)
+jest.mock('image-to-pdf', () =>
+  jest.fn().mockReturnValue({
+    on: jest.fn((event: string, callback: Function) => {
+      if (event === 'data') callback(Buffer.from('pdf'));
+      if (event === 'end') callback();
+    }),
+  })
+);
+
+// Mock nostr-tools (used by Nostr provider - creates SimplePool at module scope)
+jest.mock('nostr-tools', () => ({
+  getPublicKey: jest.fn().mockReturnValue('mock-pubkey'),
+  nip19: { npubEncode: jest.fn().mockReturnValue('npub-mock') },
+  finalizeEvent: jest.fn().mockReturnValue({ id: 'mock-event-id', sig: 'mock-sig' }),
+  verifyEvent: jest.fn().mockReturnValue(true),
+  SimplePool: jest.fn().mockImplementation(() => ({
+    querySync: jest.fn().mockResolvedValue([]),
+    publish: jest.fn().mockResolvedValue(undefined),
+    close: jest.fn(),
+  })),
+  Relay: {
+    connect: jest.fn().mockResolvedValue({
+      publish: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn(),
+    }),
+  },
+}));
+
+// Mock ws (WebSocket used by Reddit)
+jest.mock('ws', () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    send: jest.fn(),
+    close: jest.fn(),
+  }));
+});
+
+// Set required env vars that providers read at import time
+process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'https://test.example.com';
+process.env.DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID || 'test-discord-client-id';
+process.env.DISCORD_CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET || 'test-discord-secret';
+process.env.DISCORD_BOT_TOKEN_ID = process.env.DISCORD_BOT_TOKEN_ID || 'test-discord-bot-token';
+process.env.LINKEDIN_CLIENT_ID = process.env.LINKEDIN_CLIENT_ID || 'test-linkedin-id';
+process.env.LINKEDIN_CLIENT_SECRET = process.env.LINKEDIN_CLIENT_SECRET || 'test-linkedin-secret';
+process.env.X_API_KEY = process.env.X_API_KEY || 'test-x-key';
+process.env.X_API_SECRET = process.env.X_API_SECRET || 'test-x-secret';
+process.env.TIKTOK_CLIENT_ID = process.env.TIKTOK_CLIENT_ID || 'test-tiktok-id';
+process.env.TIKTOK_CLIENT_SECRET = process.env.TIKTOK_CLIENT_SECRET || 'test-tiktok-secret';
+process.env.TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN || 'test-telegram-token';
+process.env.REDDIT_CLIENT_ID = process.env.REDDIT_CLIENT_ID || 'test-reddit-id';
+process.env.REDDIT_CLIENT_SECRET = process.env.REDDIT_CLIENT_SECRET || 'test-reddit-secret';
+process.env.FACEBOOK_APP_ID = process.env.FACEBOOK_APP_ID || 'test-fb-id';
+process.env.FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET || 'test-fb-secret';
+process.env.YOUTUBE_CLIENT_ID = process.env.YOUTUBE_CLIENT_ID || 'test-yt-id';
+process.env.YOUTUBE_CLIENT_SECRET = process.env.YOUTUBE_CLIENT_SECRET || 'test-yt-secret';
+process.env.PINTEREST_CLIENT_ID = process.env.PINTEREST_CLIENT_ID || 'test-pin-id';
+process.env.PINTEREST_CLIENT_SECRET = process.env.PINTEREST_CLIENT_SECRET || 'test-pin-secret';
+process.env.DRIBBBLE_CLIENT_ID = process.env.DRIBBBLE_CLIENT_ID || 'test-dribbble-id';
+process.env.DRIBBBLE_CLIENT_SECRET = process.env.DRIBBBLE_CLIENT_SECRET || 'test-dribbble-secret';
+process.env.THREADS_APP_ID = process.env.THREADS_APP_ID || 'test-threads-id';
+process.env.THREADS_APP_SECRET = process.env.THREADS_APP_SECRET || 'test-threads-secret';
+process.env.SLACK_CLIENT_ID = process.env.SLACK_CLIENT_ID || 'test-slack-id';
+process.env.SLACK_CLIENT_SECRET = process.env.SLACK_CLIENT_SECRET || 'test-slack-secret';
+process.env.VK_CLIENT_ID = process.env.VK_CLIENT_ID || 'test-vk-id';
+process.env.VK_CLIENT_SECRET = process.env.VK_CLIENT_SECRET || 'test-vk-secret';
+process.env.GMB_CLIENT_ID = process.env.GMB_CLIENT_ID || 'test-gmb-id';
+process.env.GMB_CLIENT_SECRET = process.env.GMB_CLIENT_SECRET || 'test-gmb-secret';
+process.env.TWITCH_CLIENT_ID = process.env.TWITCH_CLIENT_ID || 'test-twitch-id';
+process.env.TWITCH_CLIENT_SECRET = process.env.TWITCH_CLIENT_SECRET || 'test-twitch-secret';
+process.env.KICK_PROVIDER_TOKEN = process.env.KICK_PROVIDER_TOKEN || 'test-kick-token';
+process.env.NOSTR_PRIVATE_KEY = process.env.NOSTR_PRIVATE_KEY || 'test-nostr-key';

--- a/libraries/nestjs-libraries/src/integrations/__tests__/social.abstract.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/__tests__/social.abstract.spec.ts
@@ -1,0 +1,324 @@
+import './setup';
+import {
+  SocialAbstract,
+  RefreshToken,
+  BadBody,
+  NotEnoughScopes,
+} from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import { createMockResponse } from './factories';
+import { timer } from '@gitroom/helpers/utils/timer';
+
+// Concrete subclass for testing the abstract class
+class TestableProvider extends SocialAbstract {
+  identifier = 'test-provider';
+}
+
+// Subclass with custom handleErrors
+class TestableProviderWithErrors extends SocialAbstract {
+  identifier = 'test-provider-errors';
+
+  override handleErrors(
+    body: string
+  ):
+    | { type: 'refresh-token' | 'bad-body' | 'retry'; value: string }
+    | undefined {
+    if (body.includes('please_retry')) {
+      return { type: 'retry', value: 'Retrying...' };
+    }
+    if (body.includes('token_expired')) {
+      return { type: 'refresh-token', value: 'Token expired' };
+    }
+    if (body.includes('invalid_content')) {
+      return { type: 'bad-body', value: 'Invalid content' };
+    }
+    return undefined;
+  }
+}
+
+describe('SocialAbstract', () => {
+  let provider: TestableProvider;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    provider = new TestableProvider();
+    originalFetch = global.fetch;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('fetch()', () => {
+    it('should return response on 200 status', async () => {
+      const mockResponse = createMockResponse({ data: 'ok' }, 200);
+      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+      const result = await provider.fetch('https://api.example.com/test');
+      expect(result).toBe(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.example.com/test',
+        {}
+      );
+    });
+
+    it('should return response on 201 status', async () => {
+      const mockResponse = createMockResponse({ data: 'created' }, 201);
+      global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+      const result = await provider.fetch('https://api.example.com/create');
+      expect(result.status).toBe(201);
+    });
+
+    it('should retry on 429 status and use timer', async () => {
+      const retryResponse = createMockResponse('rate limited', 429);
+      const successResponse = createMockResponse({ data: 'ok' }, 200);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(retryResponse)
+        .mockResolvedValueOnce(successResponse);
+
+      const result = await provider.fetch('https://api.example.com/test');
+      expect(result.status).toBe(200);
+      expect(timer).toHaveBeenCalledWith(5000);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on 500 status', async () => {
+      const errorResponse = createMockResponse('server error', 500);
+      const successResponse = createMockResponse({ data: 'ok' }, 200);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(errorResponse)
+        .mockResolvedValueOnce(successResponse);
+
+      const result = await provider.fetch('https://api.example.com/test');
+      expect(result.status).toBe(200);
+      expect(timer).toHaveBeenCalledWith(5000);
+    });
+
+    it('should retry when body contains rate_limit_exceeded', async () => {
+      const rateLimitResponse = createMockResponse(
+        'rate_limit_exceeded',
+        403
+      );
+      const successResponse = createMockResponse({ data: 'ok' }, 200);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(rateLimitResponse)
+        .mockResolvedValueOnce(successResponse);
+
+      const result = await provider.fetch('https://api.example.com/test');
+      expect(result.status).toBe(200);
+    });
+
+    it('should throw BadBody after max 3 retries', async () => {
+      const errorResponse = createMockResponse('server error', 500);
+      global.fetch = jest.fn().mockResolvedValue(errorResponse);
+
+      await expect(
+        provider.fetch('https://api.example.com/test')
+      ).rejects.toThrow();
+
+      // Initial call + 3 retries = should stop at totalRetries > 2
+      expect(global.fetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('should throw RefreshToken on 401 status without handleErrors', async () => {
+      const unauthorizedResponse = createMockResponse('unauthorized', 401);
+      global.fetch = jest.fn().mockResolvedValue(unauthorizedResponse);
+
+      await expect(
+        provider.fetch('https://api.example.com/test')
+      ).rejects.toThrow(RefreshToken);
+    });
+
+    it('should handle text() error by defaulting to {}', async () => {
+      const errorResponse = {
+        status: 403,
+        ok: false,
+        headers: new Headers(),
+        text: jest.fn().mockRejectedValue(new Error('text failed')),
+        json: jest.fn(),
+      } as unknown as Response;
+      global.fetch = jest.fn().mockResolvedValue(errorResponse);
+
+      await expect(
+        provider.fetch('https://api.example.com/test', {}, 'test')
+      ).rejects.toThrow(BadBody);
+    });
+
+    it('should retry when handleErrors returns retry type', async () => {
+      const providerWithErrors = new TestableProviderWithErrors();
+      const retryResponse = createMockResponse('please_retry', 400);
+      const successResponse = createMockResponse({ data: 'ok' }, 200);
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(retryResponse)
+        .mockResolvedValueOnce(successResponse);
+
+      const result = await providerWithErrors.fetch(
+        'https://api.example.com/test'
+      );
+      expect(result.status).toBe(200);
+      expect(timer).toHaveBeenCalledWith(5000);
+    });
+
+    it('should throw RefreshToken when handleErrors returns refresh-token on any status', async () => {
+      const providerWithErrors = new TestableProviderWithErrors();
+      const errorResponse = createMockResponse('token_expired', 403);
+      global.fetch = jest.fn().mockResolvedValue(errorResponse);
+
+      await expect(
+        providerWithErrors.fetch('https://api.example.com/test')
+      ).rejects.toThrow(RefreshToken);
+    });
+
+    it('should throw BadBody when handleErrors returns bad-body', async () => {
+      const providerWithErrors = new TestableProviderWithErrors();
+      const errorResponse = createMockResponse('invalid_content', 400);
+      global.fetch = jest.fn().mockResolvedValue(errorResponse);
+
+      await expect(
+        providerWithErrors.fetch('https://api.example.com/test')
+      ).rejects.toThrow(BadBody);
+    });
+  });
+
+  describe('checkScopes()', () => {
+    it('should return true when array scopes match', () => {
+      expect(
+        provider.checkScopes(['read', 'write'], ['read', 'write', 'admin'])
+      ).toBe(true);
+    });
+
+    it('should throw NotEnoughScopes when array scopes do not match', () => {
+      expect(() =>
+        provider.checkScopes(['read', 'write', 'admin'], ['read'])
+      ).toThrow(NotEnoughScopes);
+    });
+
+    it('should handle comma-separated string scopes', () => {
+      expect(provider.checkScopes(['read', 'write'], 'read,write,admin')).toBe(
+        true
+      );
+    });
+
+    it('should handle space-separated string scopes', () => {
+      expect(provider.checkScopes(['read', 'write'], 'read write admin')).toBe(
+        true
+      );
+    });
+
+    it('should handle URL-encoded string scopes', () => {
+      expect(
+        provider.checkScopes(
+          ['read', 'write'],
+          encodeURIComponent('read,write,admin')
+        )
+      ).toBe(true);
+    });
+
+    it('should throw NotEnoughScopes when string scopes are insufficient', () => {
+      expect(() =>
+        provider.checkScopes(['read', 'write', 'admin'], 'read,write')
+      ).toThrow(NotEnoughScopes);
+    });
+
+    it('should pass with empty required scopes', () => {
+      expect(provider.checkScopes([], 'anything')).toBe(true);
+    });
+  });
+
+  describe('runInConcurrent()', () => {
+    it('should pass through successful result', async () => {
+      const result = await provider.runInConcurrent(async () => ({
+        data: 'success',
+      }));
+      expect(result).toEqual({ data: 'success' });
+    });
+
+    it('should throw RefreshToken when handleErrors returns refresh-token', async () => {
+      const providerWithErrors = new TestableProviderWithErrors();
+
+      // Must throw an object that serializes to contain 'token_expired'
+      // since runInConcurrent uses safeStringify(err) which calls JSON.stringify
+      // (Error properties are not enumerable so new Error('x') stringifies to '{}')
+      await expect(
+        providerWithErrors.runInConcurrent(async () => {
+          throw { error: 'token_expired', statusCode: 401 };
+        })
+      ).rejects.toThrow(RefreshToken);
+    });
+
+    it('should throw BadBody for unknown errors', async () => {
+      await expect(
+        provider.runInConcurrent(async () => {
+          throw new Error('something went wrong');
+        })
+      ).rejects.toThrow(BadBody);
+    });
+
+    it('should throw BadBody when handleErrors returns bad-body', async () => {
+      const providerWithErrors = new TestableProviderWithErrors();
+
+      await expect(
+        providerWithErrors.runInConcurrent(async () => {
+          throw { error: 'invalid_content' };
+        })
+      ).rejects.toThrow(BadBody);
+    });
+  });
+
+  describe('handleErrors() default implementation', () => {
+    it('should return undefined by default', () => {
+      expect(provider.handleErrors('any error body')).toBeUndefined();
+    });
+  });
+
+  describe('Error classes', () => {
+    it('RefreshToken should be an instance of ApplicationFailure', () => {
+      const err = new RefreshToken('test-id', '{}', '{}' as any, 'test msg');
+      expect(err).toBeInstanceOf(RefreshToken);
+      expect(err.type).toBe('refresh_token');
+      expect(err.message).toBe('test msg');
+    });
+
+    it('BadBody should be an instance of ApplicationFailure', () => {
+      const err = new BadBody('test-id', '{}', '{}' as any, 'bad body msg');
+      expect(err).toBeInstanceOf(BadBody);
+      expect(err.type).toBe('bad_body');
+      expect(err.message).toBe('bad body msg');
+    });
+
+    it('NotEnoughScopes should have default message', () => {
+      const err = new NotEnoughScopes();
+      expect(err.message).toBe(
+        'Not enough scopes, when choosing a provider, please add all the scopes'
+      );
+    });
+
+    it('NotEnoughScopes should accept custom message', () => {
+      const err = new NotEnoughScopes('Custom message');
+      expect(err.message).toBe('Custom message');
+    });
+  });
+
+  describe('maxConcurrentJob', () => {
+    it('should default to 1', () => {
+      expect(provider.maxConcurrentJob).toBe(1);
+    });
+  });
+
+  describe('mention() default implementation', () => {
+    it('should return { none: true } by default', async () => {
+      const result = await provider.mention(
+        'token',
+        { query: 'test' },
+        'id',
+        {} as any
+      );
+      expect(result).toEqual({ none: true });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "docker-build": "./var/docker/docker-build.sh",
     "docker-create": "./var/docker/docker-create.sh",
     "postinstall": "pnpm run prisma-generate",
-    "test": "jest --coverage --detectOpenHandles --reporters=default --reporters=jest-junit"
+    "test": "NODE_OPTIONS='--max-old-space-size=8192' jest --coverage --detectOpenHandles --reporters=default --reporters=jest-junit"
   },
   "dependencies": {
     "@ag-ui/mastra": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -322,7 +322,22 @@
       "next": "14.2.35"
     },
     "onlyBuiltDependencies": [
-      "bcrypt"
+      "bcrypt",
+      "@prisma/client",
+      "@prisma/engines",
+      "@swc/core",
+      "sharp",
+      "canvas",
+      "bufferutil",
+      "utf-8-validate",
+      "prisma",
+      "esbuild",
+      "@sentry/cli",
+      "@sentry-internal/node-cpu-profiler",
+      "@temporalio/core-bridge",
+      "@parcel/watcher",
+      "protobufjs",
+      "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- **Fix Jest config**: replace broken `getJestProjects()` (Nx returns empty) with direct config — ts-jest transform, `@gitroom/*` path aliases, coverage targeting
- **Add global test setup**: mocks for heavy native deps (Temporal SDK, sharp, nostr-tools, node-telegram-bot-api, ws) and 25+ env vars so all 32 providers can be imported without side effects
- **Add reusable test data factories**: `createPostDetails`, `createIntegration`, `createMockResponse`, etc.
- **Add SocialAbstract unit tests** (29 tests): fetch retry logic (429/500/rate_limit), checkScopes (array/string/URL-encoded), runInConcurrent, error classes
- **Add provider conformance tests** (480+ tests): `describe.each` over all 32 providers validating identity, editor, scopes, maxLength, required methods, SocialAbstract inheritance, optional properties — new providers auto-inherit all tests
- **Add IntegrationManager tests** (21 tests): registry uniqueness, getSocialIntegration, getAllTools, getAllRulesDescription, getAllPlugs
- **Add provider-specific tests**: LinkedIn (this.fetch pattern, handleErrors retry), X (TwitterApi SDK mock, 5 error patterns), Discord (mixed fetch + @Tool decorator, mentionFormat), TikTok (24 handleErrors branches via it.each)

## Test plan

- [ ] Run `pnpm test` from root — all 782 tests pass
- [ ] Run `pnpm test -- --verbose` — shows all named test cases across 7 suites
- [ ] Run `pnpm test -- --coverage` — shows coverage for `integrations/` directory
- [ ] Verify conformance tests list all 32 provider identifiers in output
