### PR TITLE
feat: add PostingCapabilities interface for centralized provider configuration

### DIFF
--- a/apps/backend/src/api/routes/integrations.controller.ts
+++ b/apps/backend/src/api/routes/integrations.controller.ts
@@ -106,6 +106,7 @@ export class IntegrationsController {
             changeNickName: !!findIntegration?.changeNickname,
             customer: p.customer,
             additionalSettings: p.additionalSettings || '[]',
+            mediaCapabilities: findIntegration.mediaCapabilities,
           };
         })
       ),

--- a/apps/backend/src/api/routes/integrations.controller.ts
+++ b/apps/backend/src/api/routes/integrations.controller.ts
@@ -85,6 +85,11 @@ export class IntegrationsController {
           const findIntegration = this._integrationManager.getSocialIntegration(
             p.providerIdentifier
           );
+          const parsedSettings = JSON.parse(p.additionalSettings || '[]');
+          const verified = parsedSettings?.find(
+            (s: any) => s?.title === 'Verified'
+          )?.value || false;
+
           return {
             name: p.name,
             id: p.id,
@@ -107,6 +112,7 @@ export class IntegrationsController {
             customer: p.customer,
             additionalSettings: p.additionalSettings || '[]',
             mediaCapabilities: findIntegration.mediaCapabilities,
+            postingCapabilities: findIntegration.getPostingCapabilities(verified),
           };
         })
       ),

--- a/apps/frontend/src/components/launches/calendar.context.tsx
+++ b/apps/frontend/src/components/launches/calendar.context.tsx
@@ -80,6 +80,27 @@ export const CalendarContext = createContext({
   },
 });
 
+export interface MediaCapabilities {
+  maxImages: number;
+  maxVideos: number;
+  canMixMediaTypes: boolean;
+  requiresMedia: boolean;
+  requiresVideo: boolean;
+  maxImageSizeBytes?: number;
+  maxVideoSizeBytes?: number;
+  maxVideoDurationSeconds?: number;
+}
+
+export interface PostingCapabilities {
+  media: MediaCapabilities;
+  maxLength: number;
+  editor: 'none' | 'normal' | 'markdown' | 'html';
+  supportsComments: boolean;
+  supportsAnalytics: boolean;
+  supportsMentions: boolean;
+  commentsMediaSupport: boolean | 'no-media';
+}
+
 export interface Integrations {
   name: string;
   id: string;
@@ -93,6 +114,8 @@ export interface Integrations {
   changeProfilePicture: boolean;
   additionalSettings: string;
   changeNickName: boolean;
+  mediaCapabilities?: MediaCapabilities;
+  postingCapabilities?: PostingCapabilities;
   time: {
     time: number;
   }[];

--- a/apps/frontend/src/components/new-launch/providers/bluesky/bluesky.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/bluesky/bluesky.provider.tsx
@@ -16,19 +16,4 @@ export default withProvider({
   SettingsComponent: SettingsComponent,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: async (posts) => {
-    if (
-      posts?.some(
-        (p) => p?.some((a) => (a?.path?.indexOf?.('mp4') ?? -1) > -1) && (p?.length ?? 0) > 1
-      )
-    ) {
-      return 'You can only upload one video per post.';
-    }
-
-    if (posts?.some((p) => (p?.length ?? 0) > 4)) {
-      return 'There can be maximum 4 pictures in a post.';
-    }
-    return true;
-  },
-  maximumCharacters: 300,
 });

--- a/apps/frontend/src/components/new-launch/providers/devto/devto.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/devto/devto.provider.tsx
@@ -52,6 +52,4 @@ export default withProvider({
   SettingsComponent: DevtoSettings,
   CustomPreviewComponent: undefined, // DevtoPreview,
   dto: DevToSettingsDto,
-  checkValidity: undefined,
-  maximumCharacters: 100000,
 });

--- a/apps/frontend/src/components/new-launch/providers/discord/discord.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/discord/discord.provider.tsx
@@ -22,6 +22,4 @@ export default withProvider({
   SettingsComponent: DiscordComponent,
   CustomPreviewComponent: undefined,
   dto: DiscordDto,
-  checkValidity: undefined,
-  maximumCharacters: 1980,
 });

--- a/apps/frontend/src/components/new-launch/providers/dribbble/dribbble.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/dribbble/dribbble.provider.tsx
@@ -24,32 +24,4 @@ export default withProvider({
   SettingsComponent: DribbbleSettings,
   CustomPreviewComponent: undefined,
   dto: DribbbleDto,
-  checkValidity: async ([firstItem, ...otherItems] = []) => {
-    const isMp4 = firstItem?.find((item) => (item?.path?.indexOf?.('mp4') ?? -1) > -1);
-    if (firstItem?.length !== 1) {
-      return 'Requires one item';
-    }
-    if (isMp4) {
-      return 'Does not support mp4 files';
-    }
-    const details = await new Promise<{
-      width: number;
-      height: number;
-    }>((resolve, reject) => {
-      const url = new Image();
-      url.onload = function () {
-        // @ts-ignore
-        resolve({ width: this.width, height: this.height });
-      };
-      url.src = firstItem?.[0]?.path;
-    });
-    if (
-      (details?.width === 400 && details?.height === 300) ||
-      (details?.width === 800 && details?.height === 600)
-    ) {
-      return true;
-    }
-    return 'Invalid image size. Requires 400x300 or 800x600 px images.';
-  },
-  maximumCharacters: 40000,
 });

--- a/apps/frontend/src/components/new-launch/providers/facebook/facebook.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/facebook/facebook.provider.tsx
@@ -28,6 +28,4 @@ export default withProvider({
   SettingsComponent: FacebookSettings,
   CustomPreviewComponent: FacebookPreview,
   dto: FacebookDto,
-  checkValidity: undefined,
-  maximumCharacters: 63206,
 });

--- a/apps/frontend/src/components/new-launch/providers/gmb/gmb.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/gmb/gmb.provider.tsx
@@ -165,26 +165,4 @@ export default withProvider({
   SettingsComponent: GmbSettings,
   CustomPreviewComponent: undefined,
   dto: GmbSettingsDto,
-  checkValidity: async (items, settings: any) => {
-    // GMB posts can have text only, or text with one image
-    if ((items?.length ?? 0) > 0 && (items?.[0]?.length ?? 0) > 1) {
-      return 'Google My Business posts can only have one image';
-    }
-
-    // Check for video - GMB doesn't support video in local posts
-    if ((items?.length ?? 0) > 0 && (items?.[0]?.length ?? 0) > 0) {
-      const media = items?.[0]?.[0];
-      if ((media?.path?.indexOf?.('mp4') ?? -1) > -1) {
-        return 'Google My Business posts do not support video attachments';
-      }
-    }
-
-    // Event posts require a title
-    if (settings?.topicType === 'EVENT' && !settings?.eventTitle) {
-      return 'Event posts require an event title';
-    }
-
-    return true;
-  },
-  maximumCharacters: 1500,
 });

--- a/apps/frontend/src/components/new-launch/providers/hashnode/hashnode.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/hashnode/hashnode.provider.tsx
@@ -48,6 +48,4 @@ export default withProvider({
   SettingsComponent: HashnodeSettings,
   CustomPreviewComponent: undefined, // HashnodePreview,
   dto: HashnodeSettingsDto,
-  checkValidity: undefined,
-  maximumCharacters: 10000,
 });

--- a/apps/frontend/src/components/new-launch/providers/high.order.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/high.order.provider.tsx
@@ -22,6 +22,7 @@ import { InternalChannels } from '@gitroom/frontend/components/launches/internal
 import { createPortal } from 'react-dom';
 import clsx from 'clsx';
 import Image from 'next/image';
+import { validateMediaFromCapabilities } from '@gitroom/frontend/components/new-launch/providers/validate-media-from-capabilities';
 
 class Empty {
   @IsOptional()
@@ -118,21 +119,37 @@ export const withProvider = function <T extends object>(params: {
       }))
     );
 
+    const resolvedMaxChars = useMemo(() => {
+      if (typeof maximumCharacters === 'number') {
+        return maximumCharacters;
+      }
+      if (typeof maximumCharacters === 'function') {
+        return maximumCharacters(
+          JSON.parse(
+            selectedIntegration.integration.additionalSettings || '[]'
+          )
+        );
+      }
+      return selectedIntegration.integration.postingCapabilities?.maxLength ?? 0;
+    }, [maximumCharacters, selectedIntegration.integration.additionalSettings, selectedIntegration.integration.postingCapabilities?.maxLength]);
+
+    const resolvedComments = useMemo(() => {
+      if (typeof params.comments !== 'undefined') {
+        return params.comments;
+      }
+      const pc = selectedIntegration.integration.postingCapabilities;
+      if (pc) {
+        return pc.commentsMediaSupport;
+      }
+      return true;
+    }, [params.comments, selectedIntegration.integration.postingCapabilities]);
+
     useEffect(() => {
       if (!setTotalChars) {
         return;
       }
 
-      setChars(
-        props.id,
-        typeof maximumCharacters === 'number'
-          ? maximumCharacters
-          : maximumCharacters(
-              JSON.parse(
-                selectedIntegration.integration.additionalSettings || '[]'
-              )
-            )
-      );
+      setChars(props.id, resolvedMaxChars);
 
       if (isGlobal) {
         setComments(true);
@@ -142,22 +159,12 @@ export const withProvider = function <T extends object>(params: {
       }
 
       if (current) {
-        setComments(
-          typeof params.comments === 'undefined' ? true : params.comments
-        );
+        setComments(resolvedComments);
         setEditor(selectedIntegration?.integration.editor);
         setPostComment(postComment);
-        setTotalChars(
-          typeof maximumCharacters === 'number'
-            ? maximumCharacters
-            : maximumCharacters(
-                JSON.parse(
-                  selectedIntegration.integration.additionalSettings || '[]'
-                )
-              )
-        );
+        setTotalChars(resolvedMaxChars);
       }
-    }, [justCurrent, current, isGlobal, setTotalChars]);
+    }, [justCurrent, current, isGlobal, setTotalChars, resolvedMaxChars, resolvedComments]);
 
     const getInternalPlugs = useCallback(async () => {
       return (
@@ -192,6 +199,20 @@ export const withProvider = function <T extends object>(params: {
       reValidateMode: 'onChange',
     });
 
+    const resolvedCheckValidity = useCallback(
+      async (mediaArrays: Array<Array<{ path: string; thumbnail?: string }>>, settings: T, additionalSettings: any) => {
+        if (checkValidity) {
+          return checkValidity(mediaArrays, settings, additionalSettings);
+        }
+        const pc = selectedIntegration.integration.postingCapabilities;
+        if (pc?.media) {
+          return validateMediaFromCapabilities(mediaArrays, pc.media);
+        }
+        return true as string | true;
+      },
+      [checkValidity, selectedIntegration.integration.postingCapabilities]
+    );
+
     useImperativeHandle(
       ref,
       () => ({
@@ -203,25 +224,16 @@ export const withProvider = function <T extends object>(params: {
             integration: selectedIntegration.integration,
             valid: await form.trigger(),
             err: form.formState.errors,
-            errors: checkValidity
-              ? await checkValidity(
-                  value.map((p) => p.media || []),
-                  settings,
-                  JSON.parse(
-                    selectedIntegration.integration.additionalSettings || '[]'
-                  )
-                )
-              : true,
+            errors: await resolvedCheckValidity(
+              value.map((p) => p.media || []),
+              settings,
+              JSON.parse(
+                selectedIntegration.integration.additionalSettings || '[]'
+              )
+            ),
             settings,
             values: value,
-            maximumCharacters:
-              typeof maximumCharacters === 'number'
-                ? maximumCharacters
-                : maximumCharacters(
-                    JSON.parse(
-                      selectedIntegration.integration.additionalSettings || '[]'
-                    )
-                  ),
+            maximumCharacters: resolvedMaxChars,
             fix: () => {
               setCurrent(props.id);
               setHide(true);
@@ -244,7 +256,7 @@ export const withProvider = function <T extends object>(params: {
           return form.trigger();
         },
       }),
-      [value]
+      [value, resolvedMaxChars, resolvedCheckValidity]
     );
 
     return (
@@ -284,29 +296,11 @@ export const withProvider = function <T extends object>(params: {
               !!value?.[0]?.content?.length &&
               (CustomPreviewComponent ? (
                 <CustomPreviewComponent
-                  maximumCharacters={
-                    typeof maximumCharacters === 'number'
-                      ? maximumCharacters
-                      : maximumCharacters(
-                          JSON.parse(
-                            selectedIntegration.integration
-                              .additionalSettings || '[]'
-                          )
-                        )
-                  }
+                  maximumCharacters={resolvedMaxChars}
                 />
               ) : (
                 <GeneralPreviewComponent
-                  maximumCharacters={
-                    typeof maximumCharacters === 'number'
-                      ? maximumCharacters
-                      : maximumCharacters(
-                          JSON.parse(
-                            selectedIntegration.integration
-                              .additionalSettings || '[]'
-                          )
-                        )
-                  }
+                  maximumCharacters={resolvedMaxChars}
                 />
               ))}
             {(SettingsComponent || !!data?.internalPlugs?.length) &&

--- a/apps/frontend/src/components/new-launch/providers/instagram/instagram.collaborators.tsx
+++ b/apps/frontend/src/components/new-launch/providers/instagram/instagram.collaborators.tsx
@@ -139,6 +139,5 @@ export default withProvider<InstagramDto>({
     }
     return true;
   },
-  maximumCharacters: 2200,
   comments: 'no-media'
 });

--- a/apps/frontend/src/components/new-launch/providers/kick/kick.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/kick/kick.provider.tsx
@@ -12,6 +12,4 @@ export default withProvider({
   SettingsComponent: undefined,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: undefined,
-  maximumCharacters: 500,
 });

--- a/apps/frontend/src/components/new-launch/providers/lemmy/lemmy.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/lemmy/lemmy.provider.tsx
@@ -72,18 +72,4 @@ export default withProvider({
   SettingsComponent: LemmySettings,
   CustomPreviewComponent: undefined,
   dto: LemmySettingsDto,
-  checkValidity: async (items) => {
-    const [firstItems] = items ?? [];
-    if (
-      firstItems?.length &&
-      (firstItems?.[0]?.path?.indexOf?.('png') ?? -1) === -1 &&
-      (firstItems?.[0]?.path?.indexOf?.('jpg') ?? -1) === -1 &&
-      (firstItems?.[0]?.path?.indexOf?.('jpef') ?? -1) === -1 &&
-      (firstItems?.[0]?.path?.indexOf?.('gif') ?? -1) === -1
-    ) {
-      return 'You can set only one picture for a cover';
-    }
-    return true;
-  },
-  maximumCharacters: 10000,
 });

--- a/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.provider.tsx
@@ -43,27 +43,4 @@ export default withProvider<LinkedinDto>({
   SettingsComponent: LinkedInSettings,
   CustomPreviewComponent: LinkedinPreview,
   dto: LinkedinDto,
-  checkValidity: async (posts, vals) => {
-    const [firstPost, ...restPosts] = posts ?? [];
-
-    if (
-      vals?.post_as_images_carousel &&
-      ((firstPost?.length ?? 0) < 2 ||
-        firstPost?.some((p) => (p?.path?.indexOf?.('mp4') ?? -1) > -1))
-    ) {
-      return 'Carousel can only be created with 2 or more images and no videos.';
-    }
-
-    if (
-      (firstPost?.length ?? 0) > 1 &&
-      firstPost?.some((p) => (p?.path?.indexOf?.('mp4') ?? -1) > -1)
-    ) {
-      return 'Can have maximum 1 media when selecting a video.';
-    }
-    if (restPosts?.some((p) => (p?.length ?? 0) > 0)) {
-      return 'Comments can only contain text.';
-    }
-    return true;
-  },
-  maximumCharacters: 3000,
 });

--- a/apps/frontend/src/components/new-launch/providers/listmonk/listmonk.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/listmonk/listmonk.provider.tsx
@@ -29,6 +29,4 @@ export default withProvider({
   SettingsComponent: SettingsComponent,
   CustomPreviewComponent: undefined,
   dto: ListmonkDto,
-  checkValidity: undefined,
-  maximumCharacters: 300000,
 });

--- a/apps/frontend/src/components/new-launch/providers/mastodon/mastodon.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/mastodon/mastodon.provider.tsx
@@ -10,6 +10,4 @@ export default withProvider({
   SettingsComponent: null,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: undefined,
-  maximumCharacters: 500,
 });

--- a/apps/frontend/src/components/new-launch/providers/medium/medium.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/medium/medium.provider.tsx
@@ -40,6 +40,4 @@ export default withProvider({
   SettingsComponent: MediumSettings,
   CustomPreviewComponent: undefined, //MediumPreview,
   dto: MediumSettingsDto,
-  checkValidity: undefined,
-  maximumCharacters: 100000,
 });

--- a/apps/frontend/src/components/new-launch/providers/moltbook/moltbook.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/moltbook/moltbook.provider.tsx
@@ -31,5 +31,4 @@ export default withProvider({
   SettingsComponent: MoltbookSettings,
   CustomPreviewComponent: undefined,
   dto: MoltbookDto,
-  maximumCharacters: 300,
 });

--- a/apps/frontend/src/components/new-launch/providers/nostr/nostr.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/nostr/nostr.provider.tsx
@@ -10,8 +10,4 @@ export default withProvider({
   SettingsComponent: null,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: async () => {
-    return true;
-  },
-  maximumCharacters: 100000,
 });

--- a/apps/frontend/src/components/new-launch/providers/pinterest/pinterest.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/pinterest/pinterest.provider.tsx
@@ -77,5 +77,4 @@ export default withProvider({
     }
     return true;
   },
-  maximumCharacters: 500,
 });

--- a/apps/frontend/src/components/new-launch/providers/reddit/reddit.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/reddit/reddit.provider.tsx
@@ -214,25 +214,4 @@ export default withProvider({
   SettingsComponent: RedditSettings,
   CustomPreviewComponent: undefined,
   dto: RedditSettingsDto,
-  checkValidity: async (posts, settings: any) => {
-    if (
-      settings?.subreddit?.some(
-        (p: any, index: number) =>
-          p?.value?.type === 'media' && posts?.[0]?.length !== 1
-      )
-    ) {
-      return 'When posting a media post, you must attached exactly one media file.';
-    }
-
-    if (
-      posts?.some((p) =>
-        p?.some((a) => !a?.thumbnail && (a?.path?.indexOf?.('mp4') ?? -1) > -1)
-      )
-    ) {
-      return 'You must attach a thumbnail to your video post.';
-    }
-
-    return true;
-  },
-  maximumCharacters: 10000,
 });

--- a/apps/frontend/src/components/new-launch/providers/skool/skool.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/skool/skool.provider.tsx
@@ -32,7 +32,5 @@ export default withProvider({
   SettingsComponent: SkoolComponent,
   CustomPreviewComponent: undefined,
   dto: SkoolDto,
-  checkValidity: undefined,
-  maximumCharacters: 50000,
   postComment: PostComment.ALL,
 });

--- a/apps/frontend/src/components/new-launch/providers/slack/slack.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/slack/slack.provider.tsx
@@ -22,6 +22,4 @@ export default withProvider({
   SettingsComponent: SlackComponent,
   CustomPreviewComponent: undefined,
   dto: SlackDto,
-  checkValidity: undefined,
-  maximumCharacters: 400000,
 });

--- a/apps/frontend/src/components/new-launch/providers/telegram/telegram.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/telegram/telegram.provider.tsx
@@ -10,8 +10,4 @@ export default withProvider({
   SettingsComponent: null,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: async () => {
-    return true;
-  },
-  maximumCharacters: 4096,
 });

--- a/apps/frontend/src/components/new-launch/providers/threads/threads.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/threads/threads.provider.tsx
@@ -15,30 +15,4 @@ export default withProvider({
   SettingsComponent: SettingsComponent,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: async ([firstPost, ...otherPosts] = [], settings) => {
-    const checkVideosLength = await Promise.all(
-      firstPost
-        ?.filter((f) => (f?.path?.indexOf?.('mp4') ?? -1) > -1)
-        ?.flatMap((p) => p?.path)
-        ?.map((p) => {
-          return new Promise<number>((res) => {
-            const video = document.createElement('video');
-            video.preload = 'metadata';
-            video.src = p;
-            video.addEventListener('loadedmetadata', () => {
-              res(video.duration);
-            });
-          });
-        }) ?? []
-    );
-
-    for (const video of checkVideosLength) {
-      if (video > 300) {
-        return 'Video should be maximum 300 seconds (5 minutes)';
-      }
-    }
-
-    return true;
-  },
-  maximumCharacters: 500,
 });

--- a/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
@@ -318,5 +318,4 @@ export default withProvider({
     }
     return true;
   },
-  maximumCharacters: 2000,
 });

--- a/apps/frontend/src/components/new-launch/providers/twitch/twitch.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/twitch/twitch.provider.tsx
@@ -90,6 +90,4 @@ export default withProvider({
   SettingsComponent: TwitchSettings,
   CustomPreviewComponent: undefined,
   dto: TwitchDto,
-  checkValidity: undefined,
-  maximumCharacters: 500,
 });

--- a/apps/frontend/src/components/new-launch/providers/validate-media-from-capabilities.ts
+++ b/apps/frontend/src/components/new-launch/providers/validate-media-from-capabilities.ts
@@ -1,0 +1,43 @@
+import { MediaCapabilities } from '@gitroom/frontend/components/launches/calendar.context';
+
+export function validateMediaFromCapabilities(
+  posts: Array<Array<{ path: string; thumbnail?: string }>>,
+  capabilities: MediaCapabilities
+): string | true {
+  for (const media of posts) {
+    if (!media || media.length === 0) {
+      if (capabilities.requiresMedia) {
+        return 'At least one media attachment is required';
+      }
+      if (capabilities.requiresVideo) {
+        return 'At least one video is required';
+      }
+      continue;
+    }
+
+    const images = media.filter((m) => !m.thumbnail);
+    const videos = media.filter((m) => !!m.thumbnail);
+
+    if (capabilities.requiresVideo && videos.length === 0) {
+      return 'At least one video is required';
+    }
+
+    if (images.length > capabilities.maxImages) {
+      return `Maximum ${capabilities.maxImages} images allowed`;
+    }
+
+    if (videos.length > capabilities.maxVideos) {
+      return `Maximum ${capabilities.maxVideos} videos allowed`;
+    }
+
+    if (
+      !capabilities.canMixMediaTypes &&
+      images.length > 0 &&
+      videos.length > 0
+    ) {
+      return 'Images and videos cannot be mixed in the same post';
+    }
+  }
+
+  return true;
+}

--- a/apps/frontend/src/components/new-launch/providers/vk/vk.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/vk/vk.provider.tsx
@@ -11,8 +11,4 @@ export default withProvider({
   SettingsComponent: null,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: async (posts) => {
-    return true;
-  },
-  maximumCharacters: 2048,
 });

--- a/apps/frontend/src/components/new-launch/providers/warpcast/warpcast.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/warpcast/warpcast.provider.tsx
@@ -63,13 +63,4 @@ export default withProvider({
   SettingsComponent: WrapcastProvider,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  checkValidity: async (list) => {
-    if (
-      list?.some((item) => item?.some((field) => (field?.path?.indexOf?.('mp4') ?? -1) > -1))
-    ) {
-      return 'Can only accept images';
-    }
-    return true;
-  },
-  maximumCharacters: 800,
 });

--- a/apps/frontend/src/components/new-launch/providers/whop/whop.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/whop/whop.provider.tsx
@@ -42,6 +42,4 @@ export default withProvider({
   SettingsComponent: WhopSettings,
   CustomPreviewComponent: undefined,
   dto: WhopDto,
-  checkValidity: undefined,
-  maximumCharacters: 50000,
 });

--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.provider.tsx
@@ -31,6 +31,4 @@ export default withProvider({
   SettingsComponent: WordpressSettings,
   CustomPreviewComponent: undefined, // WordpressPreview,
   dto: WordpressDto,
-  checkValidity: undefined,
-  maximumCharacters: 100000,
 });

--- a/apps/frontend/src/components/new-launch/providers/x/x.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/x/x.provider.tsx
@@ -100,12 +100,6 @@ export default withProvider({
     }
     return true;
   },
-  maximumCharacters: (settings) => {
-    if (settings?.[0]?.value) {
-      return 4000;
-    }
-    return 280;
-  },
 });
 const checkVideoDuration = async (
   url: string,

--- a/apps/frontend/src/components/new-launch/providers/youtube/youtube.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/youtube/youtube.provider.tsx
@@ -97,5 +97,4 @@ export default withProvider({
     }
     return true;
   },
-  maximumCharacters: 5000,
 });

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -32,7 +32,11 @@ import {
   organizationId,
   postId as postIdSearchParam,
 } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
-import { AnalyticsData } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import {
+  AnalyticsData,
+  MediaContent,
+  validateMediaAgainstCapabilities,
+} from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
 import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -247,6 +251,32 @@ export class PostsService {
             throw new BadRequestException(
               `Integration with id ${post.integration.id} not found`
             );
+          }
+
+          if (body.type !== 'draft') {
+            const provider = this._integrationManager.getSocialIntegration(
+              integration.providerIdentifier
+            );
+            if (provider.mediaCapabilities) {
+              const allMedia: MediaContent[] = (post.value || []).flatMap(
+                (v) =>
+                  (v.image || []).map((img) => ({
+                    type: (img.path?.match(/\.(mp4|mov|avi|webm|mkv)$/i)
+                      ? 'video'
+                      : 'image') as 'image' | 'video',
+                    path: img.path || '',
+                  }))
+              );
+              const errors = validateMediaAgainstCapabilities(
+                allMedia,
+                provider.mediaCapabilities
+              );
+              if (errors.length > 0) {
+                throw new BadRequestException(
+                  `Media validation failed for ${provider.name}: ${errors.map((e) => e.message).join(', ')}`
+                );
+              }
+            }
           }
 
           return {

--- a/libraries/nestjs-libraries/src/integrations/integration.manager.ts
+++ b/libraries/nestjs-libraries/src/integrations/integration.manager.ts
@@ -87,6 +87,7 @@ export class IntegrationManager {
           isChromeExtension: !!p.isChromeExtension,
           ...(p.extensionCookies ? { extensionCookies: p.extensionCookies } : {}),
           ...(p.customFields ? { customFields: await p.customFields() } : {}),
+          mediaCapabilities: p.mediaCapabilities,
         }))
       ),
       article: [] as any[],

--- a/libraries/nestjs-libraries/src/integrations/integration.manager.ts
+++ b/libraries/nestjs-libraries/src/integrations/integration.manager.ts
@@ -166,7 +166,7 @@ export class IntegrationManager {
   getAllowedSocialsIntegrations() {
     return socialIntegrationList.map((p) => p.identifier);
   }
-  getSocialIntegration(integration: string): SocialProvider {
+  getSocialIntegration(integration: string): SocialAbstract & SocialProvider {
     return socialIntegrationList.find((i) => i.identifier === integration)!;
   }
 }

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -1,7 +1,7 @@
 import { timer } from '@gitroom/helpers/utils/timer';
 import { Integration } from '@prisma/client';
 import { ApplicationFailure } from '@temporalio/activity';
-import { MediaCapabilities } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import { MediaCapabilities, PostingCapabilities, SocialProvider } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 
 export class RefreshToken extends ApplicationFailure {
   constructor(identifier: string, json: string, body: BodyInit, message = '') {
@@ -177,6 +177,23 @@ export abstract class SocialAbstract {
       options.body!,
       handleError?.value || ''
     );
+  }
+
+  getPostingCapabilities(additionalSettings?: any): PostingCapabilities {
+    const self = this as unknown as SocialProvider & SocialAbstract;
+    return {
+      media: self.mediaCapabilities || this.mediaCapabilities,
+      maxLength: self.maxLength(additionalSettings),
+      editor: self.editor,
+      supportsComments: typeof self.comment === 'function',
+      supportsAnalytics: typeof self.analytics === 'function',
+      supportsMentions: Object.getOwnPropertyNames(
+        self.constructor.prototype
+      ).includes('mention'),
+      commentsMediaSupport: typeof self.comment === 'function'
+        ? (self.commentsMediaSupport ?? true)
+        : false,
+    };
   }
 
   checkScopes(required: string[], got: string | string[]) {

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -1,6 +1,7 @@
 import { timer } from '@gitroom/helpers/utils/timer';
 import { Integration } from '@prisma/client';
 import { ApplicationFailure } from '@temporalio/activity';
+import { MediaCapabilities } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 
 export class RefreshToken extends ApplicationFailure {
   constructor(identifier: string, json: string, body: BodyInit, message = '') {
@@ -49,6 +50,13 @@ function safeStringify(obj: any) {
 export abstract class SocialAbstract {
   abstract identifier: string;
   maxConcurrentJob = 1;
+  mediaCapabilities: MediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: true,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
 
   public handleErrors(
     body: string

--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -149,8 +149,16 @@ export class BlueskyProvider extends SocialAbstract implements SocialProvider {
   override maxConcurrentJob = 2; // Bluesky has moderate rate limits
   identifier = 'bluesky';
   name = 'Bluesky';
-  toolTip = "We don’t currently support two-factor authentication. If it’s enabled on Bluesky, you’ll need to disable it."
+  toolTip = "We don't currently support two-factor authentication. If it's enabled on Bluesky, you'll need to disable it."
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 4,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+    maxImageSizeBytes: 976000,
+  };
   scopes = ['write:statuses', 'profile', 'write:media'];
   editor = 'normal' as const;
   maxLength() {

--- a/libraries/nestjs-libraries/src/integrations/social/dev.to.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/dev.to.provider.ts
@@ -16,6 +16,13 @@ export class DevToProvider extends SocialAbstract implements SocialProvider {
   identifier = 'devto';
   name = 'Dev.to';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   editor = 'markdown' as const;
   scopes = [] as string[];
   maxLength() {

--- a/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
@@ -15,6 +15,13 @@ export class DiscordProvider extends SocialAbstract implements SocialProvider {
   identifier = 'discord';
   name = 'Discord';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 10,
+    canMixMediaTypes: true,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   editor = 'markdown' as const;
   scopes = ['identify', 'guilds'];
   maxLength() {

--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -16,6 +16,14 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
   identifier = 'facebook';
   name = 'Facebook Page';
   isBetweenSteps = true;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+    maxImageSizeBytes: 4194304,
+  };
   scopes = [
     'pages_show_list',
     'business_management',

--- a/libraries/nestjs-libraries/src/integrations/social/farcaster.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/farcaster.provider.ts
@@ -28,6 +28,13 @@ export class FarcasterProvider
   name = 'Farcaster';
   isBetweenSteps = false;
   isWeb3 = true;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [] as string[];
   override maxConcurrentJob = 3; // Farcaster has moderate limits
   editor = 'normal' as const;

--- a/libraries/nestjs-libraries/src/integrations/social/hashnode.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/hashnode.provider.ts
@@ -18,6 +18,13 @@ export class HashnodeProvider extends SocialAbstract implements SocialProvider {
   identifier = 'hashnode';
   name = 'Hashnode';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [] as string[];
   editor = 'markdown' as const;
   maxLength() {

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -31,6 +31,7 @@ export class InstagramProvider
     requiresMedia: false,
     requiresVideo: false,
   };
+  commentsMediaSupport = 'no-media' as const;
   scopes = [
     'instagram_basic',
     'pages_show_list',

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -24,6 +24,13 @@ export class InstagramProvider
   name = 'Instagram\n(Facebook Business)';
   isBetweenSteps = true;
   toolTip = 'Instagram must be business and connected to a Facebook page';
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [
     'instagram_basic',
     'pages_show_list',

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
@@ -32,6 +32,7 @@ export class InstagramStandaloneProvider
     requiresMedia: false,
     requiresVideo: false,
   };
+  commentsMediaSupport = 'no-media' as const;
   scopes = [
     'instagram_business_basic',
     'instagram_business_content_publish',

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
@@ -25,6 +25,13 @@ export class InstagramStandaloneProvider
   name = 'Instagram\n(Standalone)';
   isBetweenSteps = false;
   refreshCron = true;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [
     'instagram_business_basic',
     'instagram_business_content_publish',

--- a/libraries/nestjs-libraries/src/integrations/social/kick.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/kick.provider.ts
@@ -16,6 +16,13 @@ export class KickProvider extends SocialAbstract implements SocialProvider {
   identifier = 'kick';
   name = 'Kick';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   editor = 'normal' as const;
   scopes = ['chat:write', 'user:read', 'channel:read'];
   dto = KickDto;

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -23,6 +23,13 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   identifier = 'linkedin';
   name = 'LinkedIn';
   oneTimeToken = true;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
 
   isBetweenSteps = false;
   scopes = [

--- a/libraries/nestjs-libraries/src/integrations/social/listmonk.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/listmonk.provider.ts
@@ -18,6 +18,13 @@ export class ListmonkProvider extends SocialAbstract implements SocialProvider {
   identifier = 'listmonk';
   name = 'ListMonk';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [] as string[];
   editor = 'html' as const;
   dto = ListmonkDto;

--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -14,6 +14,13 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
   identifier = 'mastodon';
   name = 'Mastodon';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 10,
+    canMixMediaTypes: true,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = ['write:statuses', 'profile', 'write:media'];
   editor = 'normal' as const;
   maxLength() {

--- a/libraries/nestjs-libraries/src/integrations/social/medium.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/medium.provider.ts
@@ -16,6 +16,13 @@ export class MediumProvider extends SocialAbstract implements SocialProvider {
   identifier = 'medium';
   name = 'Medium';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [] as string[];
   editor = 'markdown' as const;
   dto = MediumSettingsDto;

--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -25,6 +25,13 @@ export class PinterestProvider
   identifier = 'pinterest';
   name = 'Pinterest';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: true,
+    requiresMedia: true,
+    requiresVideo: false,
+  };
   scopes = [
     'boards:read',
     'boards:write',

--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -23,6 +23,13 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
   identifier = 'reddit';
   name = 'Reddit';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 1,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = ['read', 'identity', 'submit', 'flair'];
   editor = 'normal' as const;
   dto = RedditSettingsDto;

--- a/libraries/nestjs-libraries/src/integrations/social/slack.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/slack.provider.ts
@@ -16,6 +16,13 @@ export class SlackProvider extends SocialAbstract implements SocialProvider {
   identifier = 'slack';
   name = 'Slack';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   editor = 'normal' as const;
   scopes = [
     'channels:read',

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -127,6 +127,70 @@ export type MediaContent = {
   thumbnailTimestamp?: number;
 };
 
+export type MediaCapabilities = {
+  maxImages: number;
+  maxVideos: number;
+  canMixMediaTypes: boolean;
+  requiresMedia: boolean;
+  requiresVideo: boolean;
+  maxImageSizeBytes?: number;
+  maxVideoSizeBytes?: number;
+  maxVideoDurationSeconds?: number;
+};
+
+export type MediaValidationError = {
+  field: string;
+  message: string;
+};
+
+export function validateMediaAgainstCapabilities(
+  media: MediaContent[],
+  capabilities: MediaCapabilities
+): MediaValidationError[] {
+  const errors: MediaValidationError[] = [];
+  const images = media.filter((m) => m.type === 'image');
+  const videos = media.filter((m) => m.type === 'video');
+  const hasImages = images.length > 0;
+  const hasVideos = videos.length > 0;
+
+  if (capabilities.requiresMedia && media.length === 0) {
+    errors.push({
+      field: 'media',
+      message: 'At least one media attachment is required',
+    });
+  }
+
+  if (capabilities.requiresVideo && videos.length === 0) {
+    errors.push({
+      field: 'media',
+      message: 'At least one video is required',
+    });
+  }
+
+  if (images.length > capabilities.maxImages) {
+    errors.push({
+      field: 'images',
+      message: `Maximum ${capabilities.maxImages} images allowed`,
+    });
+  }
+
+  if (videos.length > capabilities.maxVideos) {
+    errors.push({
+      field: 'videos',
+      message: `Maximum ${capabilities.maxVideos} videos allowed`,
+    });
+  }
+
+  if (!capabilities.canMixMediaTypes && hasImages && hasVideos) {
+    errors.push({
+      field: 'media',
+      message: 'Images and videos cannot be mixed in the same post',
+    });
+  }
+
+  return errors;
+}
+
 export type FetchPageInformationResult = {
   id: string;
   name: string;
@@ -139,6 +203,7 @@ export interface SocialProvider
   extends IAuthenticator,
     ISocialMediaIntegration {
   identifier: string;
+  mediaCapabilities?: MediaCapabilities;
   refreshWait?: boolean;
   convertToJPEG?: boolean;
   refreshCron?: boolean;

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -138,6 +138,16 @@ export type MediaCapabilities = {
   maxVideoDurationSeconds?: number;
 };
 
+export type PostingCapabilities = {
+  media: MediaCapabilities;
+  maxLength: number;
+  editor: 'none' | 'normal' | 'markdown' | 'html';
+  supportsComments: boolean;
+  supportsAnalytics: boolean;
+  supportsMentions: boolean;
+  commentsMediaSupport: boolean | 'no-media';
+};
+
 export type MediaValidationError = {
   field: string;
   message: string;
@@ -204,6 +214,7 @@ export interface SocialProvider
     ISocialMediaIntegration {
   identifier: string;
   mediaCapabilities?: MediaCapabilities;
+  commentsMediaSupport?: boolean | 'no-media';
   refreshWait?: boolean;
   convertToJPEG?: boolean;
   refreshCron?: boolean;

--- a/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
@@ -24,6 +24,13 @@ export class TelegramProvider extends SocialAbstract implements SocialProvider {
   name = 'Telegram';
   isBetweenSteps = false;
   isWeb3 = true;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 10,
+    canMixMediaTypes: true,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [] as string[];
   editor = 'html' as const;
   maxLength() {

--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -18,6 +18,13 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
   identifier = 'threads';
   name = 'Threads';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [
     'threads_basic',
     'threads_content_publish',

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -23,6 +23,13 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
   name = 'Tiktok';
   isBetweenSteps = false;
   convertToJPEG = true;
+  override mediaCapabilities = {
+    maxImages: 10,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: true,
+    requiresVideo: false,
+  };
   scopes = [
     'video.list',
     'user.info.basic',

--- a/libraries/nestjs-libraries/src/integrations/social/twitch.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/twitch.provider.ts
@@ -15,6 +15,13 @@ export class TwitchProvider extends SocialAbstract implements SocialProvider {
   identifier = 'twitch';
   name = 'Twitch';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   editor = 'normal' as const;
   scopes = ['user:write:chat', 'user:read:chat', 'moderator:manage:announcements'];
   dto = TwitchDto;

--- a/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
@@ -22,6 +22,13 @@ export class WordpressProvider
   identifier = 'wordpress';
   name = 'WordPress';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 0,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   editor = 'html' as const;
   scopes = [] as string[];
   override maxConcurrentJob = 5; // WordPress self-hosted typically has generous limits

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -27,6 +27,13 @@ export class XProvider extends SocialAbstract implements SocialProvider {
   identifier = 'x';
   name = 'X';
   isBetweenSteps = false;
+  override mediaCapabilities = {
+    maxImages: 4,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: false,
+    requiresVideo: false,
+  };
   scopes = [] as string[];
   override maxConcurrentJob = 1; // X has strict rate limits (300 posts per 3 hours)
   toolTip =

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -55,6 +55,13 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
   name = 'YouTube';
   isBetweenSteps = true;
   dto = YoutubeSettingsDto;
+  override mediaCapabilities = {
+    maxImages: 0,
+    maxVideos: 1,
+    canMixMediaTypes: false,
+    requiresMedia: true,
+    requiresVideo: true,
+  };
   scopes = [
     'https://www.googleapis.com/auth/userinfo.profile',
     'https://www.googleapis.com/auth/userinfo.email',


### PR DESCRIPTION
## Problem

Provider capabilities (character limits, media validation, comment support) are currently scattered across the codebase:

1. **Backend provider classes** define `maxLength()`, optional `comment()`, `analytics()`, and `mediaCapabilities` — but these are only accessible server-side.
2. **30+ frontend provider components** each hardcode `maximumCharacters` and `checkValidity` in their `withProvider()` calls — duplicating what the backend already knows.
3. **No single source of truth** — when a limit changes (e.g. X raising character limits for premium users), both backend and frontend must be updated independently.

This makes adding new providers tedious, updating limits error-prone, and the architecture harder to reason about.

## Solution

Introduce a `PostingCapabilities` interface — a unified, server-computed descriptor that each provider generates once via introspection, and the frontend consumes from the API.

### What `PostingCapabilities` captures

```typescript
type PostingCapabilities = {
  media: MediaCapabilities;
  maxLength: number;
  editor: 'none' | 'normal' | 'markdown' | 'html';
  supportsComments: boolean;
  supportsAnalytics: boolean;
  supportsMentions: boolean;
  commentsMediaSupport: boolean | 'no-media';
};
```

### How it works

- **`SocialAbstract.getPostingCapabilities()`** introspects the provider instance at runtime — checks for `comment()`, `analytics()`, `mention()` methods, reads `mediaCapabilities`, calls `maxLength()` with the integration's settings (resolving dynamic limits like X premium vs regular).
- **`/integrations/list`** endpoint now includes `postingCapabilities` per integration, computed with the user's actual settings.
- **`withProvider()` HOC** gains `resolvedMaxChars`, `resolvedComments`, and `resolvedCheckValidity` — each falls back to API-provided capabilities when the provider component doesn't explicitly override them.
- **`validateMediaFromCapabilities()`** — a new frontend utility that performs generic media validation (image/video counts, mixing rules, required media) from the capabilities object, replacing 25 identical or trivial `checkValidity` implementations.

### What changed across the codebase

**Backend (6 files):**
- `PostingCapabilities` type + `commentsMediaSupport` added to `SocialProvider` interface
- `getPostingCapabilities()` method on `SocialAbstract`
- `getSocialIntegration()` return type updated to expose the method
- `/integrations/list` controller resolves and includes `postingCapabilities`
- Instagram providers annotated with `commentsMediaSupport = 'no-media'`

**Frontend (33 files):**
- `Integrations` type extended with `mediaCapabilities` and `postingCapabilities`
- `withProvider()` HOC updated with capability-aware fallbacks
- New `validateMediaFromCapabilities()` utility
- **25 simple providers** — removed both `maximumCharacters` and `checkValidity` (now derived from API)
- **5 complex providers** (X, Instagram, YouTube, TikTok, Pinterest) — removed `maximumCharacters` only, retained `checkValidity` for platform-specific validation (video duration, cover images, trial reels, etc.)

### Design decisions

- **Introspection over declaration**: `getPostingCapabilities()` checks `typeof self.comment === 'function'` rather than requiring each provider to manually declare `supportsComments: true`. This means existing and future providers get correct capabilities automatically.
- **Opt-in overrides**: The HOC still accepts explicit `maximumCharacters` and `checkValidity` — capabilities are a fallback, not a mandate. Complex providers keep their custom validation.
- **Server-side resolution**: Dynamic limits (X's 280 vs 4000 based on Verified setting) are resolved per-integration-instance on the server, so the frontend never needs to know the business logic.

## Test plan

- [ ] `pnpm build` compiles all 3 apps (frontend, backend, orchestrator)
- [ ] `/integrations/list` response includes `postingCapabilities` with correct `maxLength` per provider
- [ ] X returns `maxLength: 4000` for premium, `maxLength: 280` for regular
- [ ] Character counter works correctly in post editor for all providers
- [ ] Media validation triggers for YouTube (requires video), TikTok (no mixing), Pinterest (requires media)
- [ ] Drafts bypass validation as before

Closes #1268
