### PR TITLE
feat: add repeat timezone support and adjust post scheduling

### DIFF
--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -28,6 +28,7 @@ import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+import { getTimezone } from '@gitroom/frontend/components/layout/set.timezone';
 import { capitalize } from 'lodash';
 import { SelectCustomer } from '@gitroom/frontend/components/launches/select.customer';
 import { CopilotPopup } from '@copilotkit/react-ui';
@@ -368,7 +369,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
       const group = existingData.group || makeId(10);
       const data = {
         type,
-        ...(repeater ? { inter: repeater } : {}),
+        ...(repeater ? { inter: repeater, timezone: getTimezone() } : {}),
         tags,
         shortLink,
         date: date.utc().format('YYYY-MM-DDTHH:mm:ss'),

--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -22,6 +22,7 @@ import {
   organizationId,
   postId as postIdSearchParam,
 } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
+import { getNextRecurringOccurrenceDate } from '@gitroom/helpers/utils/recurrence';
 
 @Injectable()
 @Activity()
@@ -273,6 +274,25 @@ export class PostActivity {
       })
     );
   }
+
+  @ActivityMethod()
+  async getRepeatDelay(
+    publishDate: Date,
+    intervalInDays: number,
+    repeatTimezone?: string | null,
+    fromDate?: string
+  ) {
+    const from = fromDate ? new Date(fromDate) : new Date();
+    const nextOccurrence = getNextRecurringOccurrenceDate({
+      anchorDate: publishDate,
+      intervalInDays,
+      timezone: repeatTimezone,
+      fromDate: from,
+    });
+
+    return Math.max(0, nextOccurrence.getTime() - from.getTime());
+  }
+
   @ActivityMethod()
   async processPlug(data: {
     plugId: string;

--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.1.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.1.ts
@@ -35,6 +35,7 @@ const {
   updatePost,
   sendWebhooks,
   isCommentable,
+  getRepeatDelay,
 } = proxyActivities<PostActivity>({
   startToCloseTimeout: '10 minute',
   retry: {
@@ -76,7 +77,6 @@ export async function postWorkflowV101({
     poked = true;
   });
 
-  const startTime = new Date();
   // get all the posts and comments to post
   const postsListBefore = await getPostsList(organizationId, postId);
   const [post] = postsListBefore;
@@ -271,9 +271,11 @@ export async function postWorkflowV101({
     : [
         {
           type: 'repeat-post',
-          delay:
-            post.intervalInDays * 24 * 60 * 60 * 1000 -
-            (new Date().getTime() - startTime.getTime()),
+          delay: await getRepeatDelay(
+            post.publishDate,
+            post.intervalInDays,
+            post.repeatTimezone
+          ),
         },
       ];
 

--- a/libraries/helpers/src/utils/recurrence.spec.ts
+++ b/libraries/helpers/src/utils/recurrence.spec.ts
@@ -1,0 +1,54 @@
+import {
+  getNextRecurringOccurrenceDate,
+  listRecurringOccurrencesInRange,
+} from '@gitroom/helpers/utils/recurrence';
+
+describe('recurrence utils', () => {
+  it('keeps local wall clock time across DST spring-forward', () => {
+    const next = getNextRecurringOccurrenceDate({
+      anchorDate: '2026-03-07T14:30:00.000Z',
+      intervalInDays: 1,
+      timezone: 'America/New_York',
+      fromDate: '2026-03-08T14:00:00.000Z',
+    });
+
+    expect(next.toISOString()).toBe('2026-03-09T13:30:00.000Z');
+  });
+
+  it('keeps local wall clock time across DST fall-back', () => {
+    const next = getNextRecurringOccurrenceDate({
+      anchorDate: '2026-10-31T13:30:00.000Z',
+      intervalInDays: 1,
+      timezone: 'America/New_York',
+      fromDate: '2026-11-01T15:00:00.000Z',
+    });
+
+    expect(next.toISOString()).toBe('2026-11-02T14:30:00.000Z');
+  });
+
+  it('falls back to legacy fixed-day behavior when timezone is missing', () => {
+    const next = getNextRecurringOccurrenceDate({
+      anchorDate: '2026-03-07T14:30:00.000Z',
+      intervalInDays: 1,
+      fromDate: '2026-03-08T14:00:00.000Z',
+    });
+
+    expect(next.toISOString()).toBe('2026-03-08T14:30:00.000Z');
+  });
+
+  it('expands occurrences in range using timezone-aware recurrence', () => {
+    const dates = listRecurringOccurrencesInRange({
+      anchorDate: '2026-03-07T14:30:00.000Z',
+      intervalInDays: 1,
+      timezone: 'America/New_York',
+      rangeStart: '2026-03-07T00:00:00.000Z',
+      rangeEnd: '2026-03-09T23:59:59.000Z',
+    });
+
+    expect(dates.map((d) => d.toISOString())).toEqual([
+      '2026-03-07T14:30:00.000Z',
+      '2026-03-08T13:30:00.000Z',
+      '2026-03-09T13:30:00.000Z',
+    ]);
+  });
+});

--- a/libraries/helpers/src/utils/recurrence.ts
+++ b/libraries/helpers/src/utils/recurrence.ts
@@ -1,0 +1,159 @@
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+type RecurrenceInput = {
+  anchorDate: Date | string;
+  intervalInDays: number;
+  fromDate: Date | string;
+  timezone?: string | null;
+};
+
+type RecurrenceRangeInput = {
+  anchorDate: Date | string;
+  intervalInDays: number;
+  rangeStart: Date | string;
+  rangeEnd: Date | string;
+  timezone?: string | null;
+};
+
+export const isValidIanaTimezone = (
+  timezoneValue?: string | null
+): timezoneValue is string => {
+  if (!timezoneValue) {
+    return false;
+  }
+
+  try {
+    Intl.DateTimeFormat('en-US', {
+      timeZone: timezoneValue,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const getNextLegacyOccurrenceDate = ({
+  anchorDate,
+  intervalInDays,
+  fromDate,
+}: Omit<RecurrenceInput, 'timezone'>) => {
+  const anchorUtc = dayjs.utc(anchorDate);
+  const fromUtc = dayjs.utc(fromDate);
+
+  if (anchorUtc.isAfter(fromUtc)) {
+    return anchorUtc.toDate();
+  }
+
+  const stepInMilliseconds = intervalInDays * DAY_IN_MS;
+  const passed = fromUtc.diff(anchorUtc, 'millisecond');
+  const steps = Math.floor(passed / stepInMilliseconds) + 1;
+
+  return anchorUtc.add(intervalInDays * steps, 'day').toDate();
+};
+
+export const getNextRecurringOccurrenceDate = ({
+  anchorDate,
+  intervalInDays,
+  fromDate,
+  timezone: timezoneValue,
+}: RecurrenceInput): Date => {
+  if (!intervalInDays || intervalInDays < 1) {
+    return dayjs.utc(anchorDate).toDate();
+  }
+
+  if (!isValidIanaTimezone(timezoneValue)) {
+    return getNextLegacyOccurrenceDate({
+      anchorDate,
+      intervalInDays,
+      fromDate,
+    });
+  }
+
+  const anchorLocal = dayjs.utc(anchorDate).tz(timezoneValue);
+  const fromLocal = dayjs.utc(fromDate).tz(timezoneValue);
+
+  let candidateLocal = anchorLocal;
+
+  if (!candidateLocal.isAfter(fromLocal)) {
+    const diffInDays = fromLocal
+      .startOf('day')
+      .diff(anchorLocal.startOf('day'), 'day');
+    const jumps = Math.max(0, Math.floor(diffInDays / intervalInDays));
+
+    candidateLocal = anchorLocal.add(jumps * intervalInDays, 'day');
+
+    while (!candidateLocal.isAfter(fromLocal)) {
+      candidateLocal = candidateLocal.add(intervalInDays, 'day');
+    }
+  }
+
+  return candidateLocal.utc().toDate();
+};
+
+export const listRecurringOccurrencesInRange = ({
+  anchorDate,
+  intervalInDays,
+  rangeStart,
+  rangeEnd,
+  timezone: timezoneValue,
+}: RecurrenceRangeInput): Date[] => {
+  if (!intervalInDays || intervalInDays < 1) {
+    return [];
+  }
+
+  const startUtc = dayjs.utc(rangeStart);
+  const endUtc = dayjs.utc(rangeEnd);
+  if (endUtc.isBefore(startUtc)) {
+    return [];
+  }
+
+  if (!isValidIanaTimezone(timezoneValue)) {
+    let current = dayjs.utc(anchorDate);
+    const output: Date[] = [];
+
+    while (current.isBefore(startUtc)) {
+      current = current.add(intervalInDays, 'day');
+    }
+
+    while (!current.isAfter(endUtc)) {
+      output.push(current.toDate());
+      current = current.add(intervalInDays, 'day');
+    }
+
+    return output;
+  }
+
+  const anchorLocal = dayjs.utc(anchorDate).tz(timezoneValue);
+  let currentLocal = anchorLocal;
+
+  const startUtcMs = startUtc.valueOf();
+  const endUtcMs = endUtc.valueOf();
+
+  const startLocal = dayjs.utc(rangeStart).tz(timezoneValue);
+  if (currentLocal.utc().valueOf() < startUtcMs) {
+    const diffInDays = startLocal
+      .startOf('day')
+      .diff(anchorLocal.startOf('day'), 'day');
+    const jumps = Math.max(0, Math.floor(diffInDays / intervalInDays));
+    currentLocal = anchorLocal.add(jumps * intervalInDays, 'day');
+
+    while (currentLocal.utc().valueOf() < startUtcMs) {
+      currentLocal = currentLocal.add(intervalInDays, 'day');
+    }
+  }
+
+  const output: Date[] = [];
+  while (currentLocal.utc().valueOf() <= endUtcMs) {
+    output.push(currentLocal.utc().toDate());
+    currentLocal = currentLocal.add(intervalInDays, 'day');
+  }
+
+  return output;
+};

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -11,6 +11,7 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import utc from 'dayjs/plugin/utc';
 import { v4 as uuidv4 } from 'uuid';
 import { CreateTagDto } from '@gitroom/nestjs-libraries/dtos/posts/create.tag.dto';
+import { listRecurringOccurrencesInRange } from '@gitroom/helpers/utils/recurrence';
 
 dayjs.extend(isoWeek);
 dayjs.extend(weekOfYear);
@@ -172,6 +173,7 @@ export class PostsRepository {
         releaseId: true,
         state: true,
         intervalInDays: true,
+        repeatTimezone: true,
         group: true,
         tags: {
           select: {
@@ -190,23 +192,23 @@ export class PostsRepository {
     });
 
     return list.reduce((all, post) => {
+      const { repeatTimezone, ...postWithoutTimezone } = post;
+
       if (!post.intervalInDays) {
-        return [...all, post];
+        return [...all, postWithoutTimezone];
       }
 
-      const addMorePosts = [];
-      let startingDate = dayjs.utc(post.publishDate);
-      while (dayjs.utc(endDate).isSameOrAfter(startingDate)) {
-        if (dayjs(startingDate).isSameOrAfter(dayjs.utc(post.publishDate))) {
-          addMorePosts.push({
-            ...post,
-            publishDate: startingDate.toDate(),
-            actualDate: post.publishDate,
-          });
-        }
-
-        startingDate = startingDate.add(post.intervalInDays, 'days');
-      }
+      const addMorePosts = listRecurringOccurrencesInRange({
+        anchorDate: post.publishDate,
+        intervalInDays: post.intervalInDays,
+        rangeStart: startDate,
+        rangeEnd: endDate,
+        timezone: repeatTimezone,
+      }).map((occurrence) => ({
+        ...postWithoutTimezone,
+        publishDate: occurrence,
+        actualDate: post.publishDate,
+      }));
 
       return [...all, ...addMorePosts];
     }, [] as any[]);
@@ -474,7 +476,8 @@ export class PostsRepository {
     date: string,
     body: PostBody,
     tags: { value: string; label: string }[],
-    inter?: number
+    inter?: number,
+    timezone?: string
   ) {
     const posts: Post[] = [];
     const uuid = uuidv4();
@@ -507,6 +510,11 @@ export class PostsRepository {
         delay: value.delay || 0,
         group: uuid,
         intervalInDays: inter ? +inter : null,
+        ...(inter
+          ? timezone
+            ? { repeatTimezone: timezone }
+            : {}
+          : { repeatTimezone: null }),
         approvedSubmitForOrder: APPROVED_SUBMIT_FOR_ORDER.NO,
         ...(state === 'update'
           ? {}

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -37,6 +37,7 @@ import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
 import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
+import { isValidIanaTimezone } from '@gitroom/helpers/utils/recurrence';
 
 type PostWithConditionals = Post & {
   integration?: Integration;
@@ -231,6 +232,10 @@ export class PostsService {
   ): Promise<CreatePostDto> {
     if (!body?.posts?.every((p) => p?.integration?.id)) {
       throw new BadRequestException('All posts must have an integration id');
+    }
+
+    if (body.inter && body.timezone && !isValidIanaTimezone(body.timezone)) {
+      throw new BadRequestException('Invalid timezone value');
     }
 
     const mappedValues = {
@@ -703,7 +708,8 @@ export class PostsService {
         body.type === 'now' ? dayjs().format('YYYY-MM-DDTHH:mm:00') : body.date,
         post,
         body.tags,
-        body.inter
+        body.inter,
+        body.timezone
       );
 
       if (!posts?.length) {

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -407,6 +407,7 @@ model Post {
   approvedSubmitForOrder     APPROVED_SUBMIT_FOR_ORDER @default(NO)
   lastMessageId              String?
   intervalInDays             Int?
+  repeatTimezone             String?
   error                      String?
   createdAt                  DateTime                  @default(now())
   updatedAt                  DateTime                  @updatedAt

--- a/libraries/nestjs-libraries/src/dtos/posts/create.post.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/create.post.dto.ts
@@ -105,6 +105,10 @@ export class CreatePostDto {
   @IsNumber()
   inter?: number;
 
+  @IsOptional()
+  @IsString()
+  timezone?: string;
+
   @IsDefined()
   @IsDateString()
   date: string;


### PR DESCRIPTION
 # What kind of change does this PR introduce?

  Bug fix (core scheduling behavior) + architecture improvement for recurring posts.

  # Why was this change needed?

  Closes #1145.

  Recurring posts were scheduled with fixed UTC intervals (intervalInDays * 24h), which causes local publish time to
  drift by 1 hour across DST transitions.

  This PR makes recurrence timezone-aware by storing an IANA timezone per recurring post and calculating next
  occurrences using local wall-clock time semantics. It also aligns calendar/list recurrence expansion with the same
  logic so UI and execution are consistent.

  Additionally, repeat delay is now computed from current scheduling time (not workflow start), preventing delayed
  repeats when posting/comments/retries consume time before repeat scheduling.

  # Other information:

  I checked open issues/PRs before implementing. At implementation time, there was no open PR fixing #1145.

  Manual verification performed:

  - POST /posts payload includes inter + timezone when repeat is enabled.
  - Persisted post row includes intervalInDays and repeatTimezone.
  - Workflow repeat delay path no longer uses workflow start timestamp.

  # Checklist:

  - [x] I have read the CONTRIBUTING (https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
  - [x] I checked that there were not similar issues or PRs already open for this.
  - [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example,
    don't try and fix a UI issue and include new dependencies in the same PR.
