### PR TITLE
feat: source composer limits from provider metadata

### DIFF
--- a/apps/backend/src/api/routes/integrations.controller.ts
+++ b/apps/backend/src/api/routes/integrations.controller.ts
@@ -82,15 +82,22 @@ export class IntegrationsController {
         (
           await this._integrationService.getIntegrationsList(org.id)
         ).map(async (p) => {
+          const additionalSettings = p.additionalSettings || '[]';
           const findIntegration = this._integrationManager.getSocialIntegration(
             p.providerIdentifier
           );
+          const composerMetadata = this._integrationManager.getComposerMetadata(
+            p.providerIdentifier,
+            additionalSettings
+          );
+
           return {
             name: p.name,
             id: p.id,
             internalId: p.internalId,
             disabled: p.disabled,
-            editor: findIntegration.editor,
+            editor: composerMetadata.editor,
+            maxCharacters: composerMetadata.maxCharacters,
             picture: p.picture || '/no-picture.jpg',
             identifier: p.providerIdentifier,
             inBetweenSteps: p.inBetweenSteps,
@@ -105,7 +112,7 @@ export class IntegrationsController {
             changeProfilePicture: !!findIntegration?.changeProfilePicture,
             changeNickName: !!findIntegration?.changeNickname,
             customer: p.customer,
-            additionalSettings: p.additionalSettings || '[]',
+            additionalSettings,
           };
         })
       ),
@@ -438,9 +445,7 @@ export class IntegrationsController {
   }
 
   @Post('/moltbook/register')
-  async moltbookRegister(
-    @Body() body: { name: string; description: string }
-  ) {
+  async moltbookRegister(@Body() body: { name: string; description: string }) {
     try {
       const provider = new MoltbookProvider();
       const result = await provider.registerAgent(body.name, body.description);

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -34,7 +34,10 @@ import axios from 'axios';
 import { Readable } from 'stream';
 import { lookup, extension } from 'mime-types';
 import * as Sentry from '@sentry/nestjs';
-import { socialIntegrationList, IntegrationManager } from '@gitroom/nestjs-libraries/integrations/integration.manager';
+import {
+  socialIntegrationList,
+  IntegrationManager,
+} from '@gitroom/nestjs-libraries/integrations/integration.manager';
 import { getValidationSchemas } from '@gitroom/nestjs-libraries/chat/validation.schemas.helper';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
 import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -85,7 +88,9 @@ export class PublicIntegrationsController {
     });
 
     const buffer = Buffer.from(response.data);
-    const responseMime = response.headers?.['content-type']?.split(';')[0]?.trim();
+    const responseMime = response.headers?.['content-type']
+      ?.split(';')[0]
+      ?.trim();
     const urlMime = lookup(body?.url?.split?.('?')?.[0]);
     const mimetype = (urlMime || responseMime || 'image/jpeg') as string;
     const ext = extension(mimetype) || 'jpg';
@@ -217,7 +222,9 @@ export class PublicIntegrationsController {
 
     if (integrationProvider.externalUrl) {
       throw new HttpException(
-        { msg: 'This integration requires an external URL and is not supported via the public API' },
+        {
+          msg: 'This integration requires an external URL and is not supported via the public API',
+        },
         400
       );
     }
@@ -300,11 +307,6 @@ export class PublicIntegrationsController {
       id
     );
 
-    const verified =
-      JSON.parse(loadIntegration.additionalSettings || '[]')?.find(
-        (p: any) => p?.title === 'Verified'
-      )?.value || false;
-
     const integration = socialIntegrationList.find(
       (p) => p.identifier === loadIntegration.providerIdentifier
     )!;
@@ -315,7 +317,10 @@ export class PublicIntegrationsController {
       };
     }
 
-    const maxLength = integration.maxLength(verified);
+    const { maxCharacters } = this._integrationManager.getComposerMetadata(
+      loadIntegration.providerIdentifier,
+      loadIntegration.additionalSettings
+    );
     const schemas = !integration.dto
       ? false
       : getValidationSchemas()[integration.dto.name];
@@ -325,7 +330,7 @@ export class PublicIntegrationsController {
     return {
       output: {
         rules: rules[integration.identifier],
-        maxLength,
+        maxLength: maxCharacters,
         settings: !schemas ? 'No additional settings required' : schemas,
         tools: tools[integration.identifier],
       },

--- a/apps/frontend/src/components/launches/calendar.context.tsx
+++ b/apps/frontend/src/components/launches/calendar.context.tsx
@@ -22,7 +22,10 @@ import { extend } from 'dayjs';
 import useCookie from 'react-use-cookie';
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { timer } from '@gitroom/helpers/utils/timer';
-import { expandPostsList, expandPosts } from '@gitroom/helpers/utils/posts.list.minify';
+import {
+  expandPostsList,
+  expandPosts,
+} from '@gitroom/helpers/utils/posts.list.minify';
 extend(isoWeek);
 extend(weekOfYear);
 
@@ -86,6 +89,7 @@ export interface Integrations {
   disabled?: boolean;
   inBetweenSteps: boolean;
   editor: 'none' | 'normal' | 'markdown' | 'html';
+  maxCharacters: number;
   display: string;
   identifier: string;
   type: string;
@@ -202,16 +206,12 @@ export const CalendarWeekProvider: FC<{
     data: calendarData,
     isLoading: calendarIsLoading,
     mutate: mutateCalendar,
-  } = useSWR(
-    filters.display !== 'list' ? `/posts-${params}` : null,
-    loadData,
-    {
-      refreshInterval: 3600000,
-      refreshWhenOffline: false,
-      refreshWhenHidden: false,
-      revalidateOnFocus: false,
-    }
-  );
+  } = useSWR(filters.display !== 'list' ? `/posts-${params}` : null, loadData, {
+    refreshInterval: 3600000,
+    refreshWhenOffline: false,
+    refreshWhenHidden: false,
+    revalidateOnFocus: false,
+  });
 
   // SWR for list view
   const {
@@ -282,7 +282,10 @@ export const CalendarWeekProvider: FC<{
   );
 
   const posts = useMemo(() => calendarData?.posts || [], [calendarData?.posts]);
-  const comments = useMemo(() => calendarData?.comments || [], [calendarData?.comments]);
+  const comments = useMemo(
+    () => calendarData?.comments || [],
+    [calendarData?.comments]
+  );
 
   // List view data
   const listPosts = useMemo(() => listData?.posts || [], [listData?.posts]);
@@ -319,7 +322,8 @@ export const CalendarWeekProvider: FC<{
   }, [mutateCalendar, mutateList]);
 
   // Determine loading state based on current view
-  const loading = filters.display === 'list' ? listIsLoading : calendarIsLoading;
+  const loading =
+    filters.display === 'list' ? listIsLoading : calendarIsLoading;
 
   return (
     <CalendarContext.Provider

--- a/apps/frontend/src/components/launches/continue.integration.tsx
+++ b/apps/frontend/src/components/launches/continue.integration.tsx
@@ -41,11 +41,7 @@ export const ContinueIntegration: FC<{
 
   // Helper to handle navigation - redirects if logged or returnURL exists, otherwise shows inline
   const navigateOrShow = useCallback(
-    (
-      path: string,
-      returnURL: string | undefined,
-      successMessage: string
-    ) => {
+    (path: string, returnURL: string | undefined, successMessage: string) => {
       if (returnURL) {
         // If returnURL exists, always redirect to it with the path params
         const params = path.includes('?') ? path.split('?')[1] : '';
@@ -79,9 +75,7 @@ export const ContinueIntegration: FC<{
 
     if (provider === 'mewe') {
       const hash =
-        typeof window !== 'undefined'
-          ? window.location.hash.substring(1)
-          : '';
+        typeof window !== 'undefined' ? window.location.hash.substring(1) : '';
       const hashParams = new URLSearchParams(hash);
       return {
         state: hashParams.get('state') || searchParams.state || '',
@@ -139,7 +133,9 @@ export const ContinueIntegration: FC<{
         data.status !== HttpStatusCode.Created
       ) {
         const errorData = await data.json().catch(() => ({}));
-        setErrorMessage(errorData.message || errorData.msg || 'Could not add provider');
+        setErrorMessage(
+          errorData.message || errorData.msg || 'Could not add provider'
+        );
         setError(true);
         return;
       }
@@ -329,6 +325,7 @@ export const ContinueIntegration: FC<{
                 allIntegrations: [],
                 integration: {
                   editor: 'normal',
+                  maxCharacters: 1000000,
                   additionalSettings: '',
                   display: '',
                   time: [{ time: 0 }],

--- a/apps/frontend/src/components/layout/continue.provider.tsx
+++ b/apps/frontend/src/components/layout/continue.provider.tsx
@@ -91,6 +91,7 @@ const ModalContent: FC<{
         allIntegrations: [],
         integration: {
           editor: 'normal',
+          maxCharacters: 1000000,
           additionalSettings: '',
           display: '',
           time: [

--- a/apps/frontend/src/components/new-launch/providers/high.order.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/high.order.provider.tsx
@@ -40,6 +40,43 @@ interface CharacterCondition {
   maximumCharacters: number;
 }
 
+const parseAdditionalSettings = (additionalSettings?: string) => {
+  if (!additionalSettings) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(additionalSettings);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const getMaximumCharacters = (
+  integrationMaximumCharacters: number | undefined,
+  maximumCharacters: number | ((settings: any) => number) | undefined,
+  additionalSettings: any
+) => {
+  if (
+    typeof integrationMaximumCharacters === 'number' &&
+    Number.isFinite(integrationMaximumCharacters) &&
+    integrationMaximumCharacters > 0
+  ) {
+    return integrationMaximumCharacters;
+  }
+
+  if (typeof maximumCharacters === 'number') {
+    return maximumCharacters;
+  }
+
+  if (typeof maximumCharacters === 'function') {
+    return maximumCharacters(additionalSettings);
+  }
+
+  return 1000000;
+};
+
 export const withProvider = function <T extends object>(params: {
   comments?: boolean | 'no-media';
   postComment: PostComment;
@@ -118,21 +155,33 @@ export const withProvider = function <T extends object>(params: {
       }))
     );
 
+    const additionalSettings = useMemo(
+      () =>
+        parseAdditionalSettings(
+          selectedIntegration?.integration.additionalSettings
+        ),
+      [selectedIntegration?.integration.additionalSettings]
+    );
+    const resolvedMaximumCharacters = useMemo(
+      () =>
+        getMaximumCharacters(
+          selectedIntegration?.integration.maxCharacters,
+          maximumCharacters,
+          additionalSettings
+        ),
+      [
+        additionalSettings,
+        maximumCharacters,
+        selectedIntegration?.integration.maxCharacters,
+      ]
+    );
+
     useEffect(() => {
       if (!setTotalChars) {
         return;
       }
 
-      setChars(
-        props.id,
-        typeof maximumCharacters === 'number'
-          ? maximumCharacters
-          : maximumCharacters(
-              JSON.parse(
-                selectedIntegration.integration.additionalSettings || '[]'
-              )
-            )
-      );
+      setChars(props.id, resolvedMaximumCharacters);
 
       if (isGlobal) {
         setComments(true);
@@ -147,17 +196,23 @@ export const withProvider = function <T extends object>(params: {
         );
         setEditor(selectedIntegration?.integration.editor);
         setPostComment(postComment);
-        setTotalChars(
-          typeof maximumCharacters === 'number'
-            ? maximumCharacters
-            : maximumCharacters(
-                JSON.parse(
-                  selectedIntegration.integration.additionalSettings || '[]'
-                )
-              )
-        );
+        setTotalChars(resolvedMaximumCharacters);
       }
-    }, [justCurrent, current, isGlobal, setTotalChars]);
+    }, [
+      current,
+      isGlobal,
+      justCurrent,
+      params.comments,
+      postComment,
+      props.id,
+      resolvedMaximumCharacters,
+      selectedIntegration?.integration.editor,
+      setChars,
+      setComments,
+      setEditor,
+      setPostComment,
+      setTotalChars,
+    ]);
 
     const getInternalPlugs = useCallback(async () => {
       return (
@@ -207,21 +262,12 @@ export const withProvider = function <T extends object>(params: {
               ? await checkValidity(
                   value.map((p) => p.media || []),
                   settings,
-                  JSON.parse(
-                    selectedIntegration.integration.additionalSettings || '[]'
-                  )
+                  additionalSettings
                 )
               : true,
             settings,
             values: value,
-            maximumCharacters:
-              typeof maximumCharacters === 'number'
-                ? maximumCharacters
-                : maximumCharacters(
-                    JSON.parse(
-                      selectedIntegration.integration.additionalSettings || '[]'
-                    )
-                  ),
+            maximumCharacters: resolvedMaximumCharacters,
             fix: () => {
               setCurrent(props.id);
               setHide(true);
@@ -284,34 +330,23 @@ export const withProvider = function <T extends object>(params: {
               !!value?.[0]?.content?.length &&
               (CustomPreviewComponent ? (
                 <CustomPreviewComponent
-                  maximumCharacters={
-                    typeof maximumCharacters === 'number'
-                      ? maximumCharacters
-                      : maximumCharacters(
-                          JSON.parse(
-                            selectedIntegration.integration
-                              .additionalSettings || '[]'
-                          )
-                        )
-                  }
+                  maximumCharacters={resolvedMaximumCharacters}
                 />
               ) : (
                 <GeneralPreviewComponent
-                  maximumCharacters={
-                    typeof maximumCharacters === 'number'
-                      ? maximumCharacters
-                      : maximumCharacters(
-                          JSON.parse(
-                            selectedIntegration.integration
-                              .additionalSettings || '[]'
-                          )
-                        )
-                  }
+                  maximumCharacters={resolvedMaximumCharacters}
                 />
               ))}
             {(SettingsComponent || !!data?.internalPlugs?.length) &&
               createPortal(
-                <div data-id={props.id} className={isGlobal ? 'bg-newSettings pb-[12px] px-[12px]' : 'hidden bg-newSettings px-[12px] pb-[12px]'}>
+                <div
+                  data-id={props.id}
+                  className={
+                    isGlobal
+                      ? 'bg-newSettings pb-[12px] px-[12px]'
+                      : 'hidden bg-newSettings px-[12px] pb-[12px]'
+                  }
+                >
                   {isGlobal && (
                     <style>{`#wrapper-settings {display: flex !important} #social-empty {display: block !important;}`}</style>
                   )}
@@ -333,7 +368,9 @@ export const withProvider = function <T extends object>(params: {
                           src={`/icons/platforms/${selectedIntegration?.integration.identifier}.png`}
                         />
                       </div>
-                      <div className="text-[20px]">{selectedIntegration?.integration.name}</div>
+                      <div className="text-[20px]">
+                        {selectedIntegration?.integration.name}
+                      </div>
                     </div>
                   )}
                   <SettingsComponent />

--- a/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.provider.tsx
@@ -65,5 +65,4 @@ export default withProvider<LinkedinDto>({
     }
     return true;
   },
-  maximumCharacters: 3000,
 });

--- a/apps/frontend/src/components/new-launch/providers/x/x.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/x/x.provider.tsx
@@ -85,12 +85,15 @@ export default withProvider({
     }
     if (
       posts?.some(
-        (p) => p?.some((m) => (m?.path?.indexOf?.('mp4') ?? -1) > -1) && (p?.length ?? 0) > 1
+        (p) =>
+          p?.some((m) => (m?.path?.indexOf?.('mp4') ?? -1) > -1) &&
+          (p?.length ?? 0) > 1
       )
     ) {
       return 'There can be maximum 1 video in a post.';
     }
-    for (const load of posts?.flatMap((p) => p?.flatMap((a) => a?.path)) ?? []) {
+    for (const load of posts?.flatMap((p) => p?.flatMap((a) => a?.path)) ??
+      []) {
       if ((load?.indexOf?.('mp4') ?? -1) > -1) {
         const isValid = await checkVideoDuration(load, premium);
         if (!isValid) {
@@ -99,12 +102,6 @@ export default withProvider({
       }
     }
     return true;
-  },
-  maximumCharacters: (settings) => {
-    if (settings?.[0]?.value) {
-      return 4000;
-    }
-    return 280;
   },
 });
 const checkVideoDuration = async (

--- a/libraries/nestjs-libraries/src/integrations/integration.manager.ts
+++ b/libraries/nestjs-libraries/src/integrations/integration.manager.ts
@@ -76,6 +76,36 @@ export const socialIntegrationList: Array<SocialAbstract & SocialProvider> = [
 
 @Injectable()
 export class IntegrationManager {
+  private parseAdditionalSettings(additionalSettings?: string | unknown) {
+    if (Array.isArray(additionalSettings)) {
+      return additionalSettings;
+    }
+
+    if (!additionalSettings || typeof additionalSettings !== 'string') {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(additionalSettings);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  getComposerMetadata(
+    identifier: string,
+    additionalSettings?: string | unknown
+  ) {
+    const integration = this.getSocialIntegration(identifier);
+    return {
+      editor: integration.editor,
+      maxCharacters: integration.maxLength(
+        this.parseAdditionalSettings(additionalSettings)
+      ),
+    };
+  }
+
   async getAllIntegrations() {
     return {
       social: await Promise.all(
@@ -87,7 +117,9 @@ export class IntegrationManager {
           isExternal: !!p.externalUrl,
           isWeb3: !!p.isWeb3,
           isChromeExtension: !!p.isChromeExtension,
-          ...(p.extensionCookies ? { extensionCookies: p.extensionCookies } : {}),
+          ...(p.extensionCookies
+            ? { extensionCookies: p.extensionCookies }
+            : {}),
           ...(p.customFields ? { customFields: await p.customFields() } : {}),
         }))
       ),

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -35,8 +35,21 @@ export class XProvider extends SocialAbstract implements SocialProvider {
   editor = 'normal' as const;
   dto = XDto;
 
-  maxLength(isTwitterPremium: boolean) {
-    return isTwitterPremium ? 4000 : 200;
+  maxLength(
+    additionalSettings?:
+      | boolean
+      | {
+          title: string;
+          value: any;
+        }[]
+  ) {
+    const isTwitterPremium =
+      typeof additionalSettings === 'boolean'
+        ? additionalSettings
+        : !!additionalSettings?.find((setting) => setting?.title === 'Verified')
+            ?.value;
+
+    return isTwitterPremium ? 4000 : 280;
   }
 
   override handleErrors(body: string):


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature/refactor. This PR exposes provider composer limits through backend integration metadata and makes the frontend composer consume that shared metadata instead of duplicating provider-specific limits in multiple UI components.

## Why was this change needed?
Postiz is built around a multi-provider architecture, but composer character limits were partially duplicated in the frontend and had already drifted from backend definitions. This created avoidable maintenance overhead and a real inconsistency for X, where frontend and backend limits did not match. Centralizing those limits in provider metadata keeps the contract in one place and makes provider behavior easier to extend and maintain.

## Other information:
Validated locally with:
- `pnpm dlx prisma@6.5.0 generate --schema ./libraries/nestjs-libraries/src/database/prisma/schema.prisma`
- `pnpm exec tsc -p apps/backend/tsconfig.build.json --noEmit`
- `pnpm exec tsc -p apps/frontend/tsconfig.json --noEmit`

This PR also fixes the default non-premium X character limit drift by standardizing it to 280.
