### PR TITLE
fix(frontend): change 'contentType' to 'Content-Type' in webhook headers

### DIFF
--- a/apps/frontend/src/components/webhooks/webhooks.tsx
+++ b/apps/frontend/src/components/webhooks/webhooks.tsx
@@ -203,7 +203,7 @@ export const AddOrEditWebhook: FC<{
       await fetch(`/webhooks/send?url=${encodeURIComponent(url)}`, {
         method: 'POST',
         headers: {
-          contentType: 'application/json',
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify([
           {


### PR DESCRIPTION
The fetch call in the webhooks component was using `contentType` as a header key. This is not a standard header and caused CORS preflight failures because it wasn't listed in the backend's allowed headers. This PR changes it to the standard `Content-Type`.