### PR TITLE
fix(frontend): use standard Content-Type header in webhooks

### DIFF
--- a/apps/frontend/src/components/webhooks/webhooks.tsx
+++ b/apps/frontend/src/components/webhooks/webhooks.tsx
@@ -179,8 +179,8 @@ export const AddOrEditWebhook: FC<{
         body: JSON.stringify({
           ...(data?.id
             ? {
-                id: data.id,
-              }
+              id: data.id,
+            }
             : {}),
           ...values,
         }),
@@ -203,7 +203,7 @@ export const AddOrEditWebhook: FC<{
       await fetch(`/webhooks/send?url=${encodeURIComponent(url)}`, {
         method: 'POST',
         headers: {
-          contentType: 'application/json',
+          'Content-Type': 'application/json',
         },
         body: JSON.stringify([
           {


### PR DESCRIPTION
# What kind of change does this PR introduce?
Bug fix

# Why was this change needed?
Closes #1290

The webhooks component was sending `contentType` (camelCase) instead of the standard `Content-Type` HTTP header. Because `contentType` is not a recognized header name, browsers treat it as a custom header and trigger a CORS preflight `OPTIONS` request. If the backend doesn't explicitly list `contentType` in `Access-Control-Allow-Headers`, the preflight fails and the webhook request is blocked entirely.

Replacing it with the standard `Content-Type` header resolves this — it's a CORS-safelisted header for `application/json`, so no preflight is triggered.

# Other information:
This was reported in issue #1290. The fix is a one-line change and is self-contained — no discussion was needed before working on it.

# Checklist:
- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR)