### PR TITLE
feat: add dribbble tags support

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/dribbble/dribbble.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/dribbble/dribbble.provider.tsx
@@ -8,6 +8,7 @@ import {
 import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
 import { Input } from '@gitroom/react/form/input';
 import { DribbbleTeams } from '@gitroom/frontend/components/new-launch/providers/dribbble/dribbble.teams';
+import { DribbbleTags } from '@gitroom/frontend/components/new-launch/providers/dribbble/dribbble.tags';
 import { DribbbleDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/dribbble.dto';
 const DribbbleSettings: FC = () => {
   const { register, control } = useSettings();
@@ -15,6 +16,9 @@ const DribbbleSettings: FC = () => {
     <div className="flex flex-col">
       <Input label={'Title'} {...register('title')} />
       <DribbbleTeams {...register('team')} />
+      <div>
+        <DribbbleTags label="Tags (Maximum 12)" {...register('tags')} />
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/components/new-launch/providers/dribbble/dribbble.tags.tsx
+++ b/apps/frontend/src/components/new-launch/providers/dribbble/dribbble.tags.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+import { ReactTags } from 'react-tag-autocomplete';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+
+export const DribbbleTags: FC<{
+  name: string;
+  label: string;
+  onChange: (event: {
+    target: {
+      value: any[];
+      name: string;
+    };
+  }) => void;
+}> = (props) => {
+  const { onChange, name, label } = props;
+  const { getValues } = useSettings();
+  const [tagValue, setTagValue] = useState<any[]>([]);
+  const [suggestions, setSuggestions] = useState<string>('');
+  const t = useT();
+
+  const onDelete = useCallback(
+    (tagIndex: number) => {
+      const modify = tagValue.filter((_, i) => i !== tagIndex);
+      setTagValue(modify);
+      onChange({
+        target: {
+          value: modify,
+          name,
+        },
+      });
+    },
+    [tagValue]
+  );
+  const onAddition = useCallback(
+    (newTag: any) => {
+      if (tagValue.length >= 12) {
+        return;
+      }
+      const modify = [...tagValue, newTag];
+      setTagValue(modify);
+      onChange({
+        target: {
+          value: modify,
+          name,
+        },
+      });
+    },
+    [tagValue]
+  );
+  useEffect(() => {
+    const settings = getValues()[props.name];
+    if (settings) {
+      setTagValue(settings);
+    }
+  }, []);
+  const suggestionsArray = useMemo(() => {
+    return [
+      ...tagValue,
+      {
+        label: suggestions,
+        value: suggestions,
+      },
+    ].filter((f) => f.label);
+  }, [suggestions, tagValue]);
+  return (
+    <div>
+      <div className={`text-[14px] mb-[6px]`}>{label}</div>
+      <ReactTags
+        placeholderText={t('add_a_tag', 'Add a tag')}
+        suggestions={suggestionsArray}
+        selected={tagValue}
+        onAdd={onAddition}
+        onInput={setSuggestions}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+};

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/dribbble.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/dribbble.dto.ts
@@ -1,10 +1,22 @@
 import {
+  ArrayMaxSize,
+  IsArray,
   IsDefined,
   IsOptional,
   IsString,
   IsUrl,
   MinLength,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class DribbbleTagsSettings {
+  @IsString()
+  value: string;
+
+  @IsString()
+  label: string;
+}
 
 export class DribbbleDto {
   @IsString()
@@ -18,4 +30,11 @@ export class DribbbleDto {
   @IsOptional()
   @IsUrl()
   team: string;
+
+  @IsArray()
+  @ArrayMaxSize(12)
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => DribbbleTagsSettings)
+  tags: DribbbleTagsSettings[];
 }

--- a/libraries/nestjs-libraries/src/integrations/social/dribbble.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/dribbble.provider.ts
@@ -156,6 +156,12 @@ export class DribbbleProvider extends SocialAbstract implements SocialProvider {
     formData.append('title', postDetails[0].settings.title);
     formData.append('description', postDetails[0].message);
 
+    if (postDetails[0].settings?.tags?.length) {
+      for (const tag of postDetails[0].settings.tags) {
+        formData.append('tags[]', tag.label);
+      }
+    }
+
     const data2 = await axios.post(
       'https://api.dribbble.com/v2/shots',
       formData,


### PR DESCRIPTION
Adds support for Dribbble's `tags` parameter (up to 12 tags) when publishing shots via the API.

Reference: https://developer.dribbble.com/v2/shots/ (`POST /v2/shots` — `tags` array, limited to 12)

## Description
- Add `tags` array field to `DribbbleDto` with class-validator validation (max 12)
- Append tags to FormData as `tags[]` in the Dribbble provider `post()` method
- Add free-form tag input component (`dribbble.tags.tsx`) using `react-tag-autocomplete`, following the same pattern as Medium tags