### PR TITLE
fix: register Temporal workers for hyphenated provider identifiers (instagram-standalone)

### DIFF
--- a/libraries/nestjs-libraries/src/temporal/temporal.module.ts
+++ b/libraries/nestjs-libraries/src/temporal/temporal.module.ts
@@ -18,25 +18,33 @@ export const getTemporalModule = (
     logLevel: 'error',
     ...(isWorkers
       ? {
-          workers: [
-            { identifier: 'main', maxConcurrentJob: undefined },
-            ...socialIntegrationList,
-          ]
-            .filter((f) => f.identifier.indexOf('-') === -1)
-            .map((integration) => ({
-              taskQueue: integration.identifier.split('-')[0],
-              workflowsPath: path!,
-              activityClasses: activityClasses!,
-              autoStart: true,
-              ...(integration.maxConcurrentJob
-                ? {
-                    workerOptions: {
-                      maxConcurrentActivityTaskExecutions:
-                        integration.maxConcurrentJob,
-                    },
-                  }
-                : {}),
-            })),
+          workers: (() => {
+            const seenQueues = new Set<string>();
+            return [
+              { identifier: 'main', maxConcurrentJob: undefined },
+              ...socialIntegrationList,
+            ]
+              .filter((integration) => {
+                const queue = integration.identifier.split('-')[0];
+                if (seenQueues.has(queue)) return false;
+                seenQueues.add(queue);
+                return true;
+              })
+              .map((integration) => ({
+                taskQueue: integration.identifier.split('-')[0],
+                workflowsPath: path!,
+                activityClasses: activityClasses!,
+                autoStart: true,
+                ...(integration.maxConcurrentJob
+                  ? {
+                      workerOptions: {
+                        maxConcurrentActivityTaskExecutions:
+                          integration.maxConcurrentJob,
+                      },
+                    }
+                  : {}),
+              }));
+          })(),
         }
       : {}),
   });


### PR DESCRIPTION
## Problem

Providers with hyphenated identifiers (e.g. `instagram-standalone`) are excluded by the worker filter in `temporal.module.ts`:

```ts
.filter((f) => f.identifier.indexOf('-.indexOf(') === -1)
```

This means **no Temporal worker is ever created for Instagram**, causing posts to remain stuck in `QUEUE` state indefinitely and never getting published.

## Fix

Replace the exclusion filter with deduplication by base provider name (the part before the first hyphen). A `Set` tracks seen queue names so only one worker is registered per base provider:

```ts
.filter((integration) => {
  const queue = integration.identifier.split('-.split(')[0];
  if (seenQueues.has(queue)) return false;
  seenQueues.add(queue);
  return true;
})
```

This ensures `instagram-standalone` gets a worker on the `instagram` task queue, while still preventing duplicate workers for providers that share the same base name.

## Impact

- Instagram posts now publish correctly via Temporal workers
- No breaking changes for existing providers without hyphens
- Backward compatible: `main`, `youtube`, `pinterest` etc. continue working as before