### PR TITLE
fix: register Temporal workers for hyphenated provider identifiers (instagram-standalone)

### DIFF
--- a/libraries/nestjs-libraries/src/temporal/temporal.module.ts
+++ b/libraries/nestjs-libraries/src/temporal/temporal.module.ts
@@ -22,7 +22,12 @@ export const getTemporalModule = (
             { identifier: 'main', maxConcurrentJob: undefined },
             ...socialIntegrationList,
           ]
-            .filter((f) => f.identifier.indexOf('-') === -1)
+            .filter(
+              (f, i, arr) =>
+                arr.findIndex(
+                  (g) => g.identifier.split('-')[0] === f.identifier.split('-')[0]
+                ) === i
+            )
             .map((integration) => ({
               taskQueue: integration.identifier.split('-')[0],
               workflowsPath: path!,


### PR DESCRIPTION
## Problem

The current filter in `temporal.module.ts` excludes any integration whose identifier contains a hyphen:

```ts
.filter((f) => f.identifier.indexOf('-') === -1)
```

This means `instagram-standalone` (and any future hyphenated provider) never gets a Temporal worker registered. Posts for those integrations are permanently stuck in `QUEUE` state and never published.

## Fix

Replace the exclusion filter with a deduplication strategy that keeps the first occurrence of each **base provider name** (split on `-`), which is the exact same value already used as `taskQueue`:

```ts
.filter(
  (f, i, arr) =>
    arr.findIndex(
      (g) => g.identifier.split('-')[0] === f.identifier.split('-')[0]
    ) === i
)
```

This correctly registers workers for `instagram`, `instagram-standalone`, and all future variants without duplication.

## Impact
- Instagram Standalone posts were permanently stuck in QUEUE state, never publishing
- No behavior change for providers without hyphens