### PR TITLE
feat(wordpress): add author, categories, tags, excerpt, slug, status settings

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.author.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.author.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+import { Select } from '@gitroom/react/form/select';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useCustomProviderFunction } from '@gitroom/frontend/components/launches/helpers/use.custom.provider.function';
+import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+export const WordpressAuthor: FC<{
+  name: string;
+  onChange: (event: {
+    target: {
+      value: string;
+      name: string;
+    };
+  }) => void;
+}> = (props) => {
+  const { onChange, name } = props;
+  const t = useT();
+  const customFunc = useCustomProviderFunction();
+  const [authors, setAuthors] = useState([]);
+  const { getValues } = useSettings();
+  const [currentAuthor, setCurrentAuthor] = useState<string | undefined>();
+  const onChangeInner = (event: {
+    target: {
+      value: string;
+      name: string;
+    };
+  }) => {
+    setCurrentAuthor(event.target.value);
+    onChange({
+      target: {
+        value: event.target.value ? Number(event.target.value) : '',
+        name: event.target.name,
+      },
+    } as any);
+  };
+  useEffect(() => {
+    customFunc.get('authors').then((data) => setAuthors(data));
+    const settings = getValues()[props.name];
+    if (settings) {
+      setCurrentAuthor(String(settings));
+    }
+  }, []);
+  if (!authors.length) {
+    return null;
+  }
+  return (
+    <Select
+      name={name}
+      label="Author"
+      onChange={onChangeInner}
+      value={currentAuthor}
+    >
+      <option value="">{t('select_1', '--Select--')}</option>
+      {authors.map((author: any) => (
+        <option key={author.id} value={author.id}>
+          {author.name}
+        </option>
+      ))}
+    </Select>
+  );
+};

--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.categories.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.categories.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { FC, useCallback, useEffect, useState } from 'react';
+import { ReactTags } from 'react-tag-autocomplete';
+import { useCustomProviderFunction } from '@gitroom/frontend/components/launches/helpers/use.custom.provider.function';
+import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+export const WordpressCategories: FC<{
+  name: string;
+  label: string;
+  onChange: (event: {
+    target: {
+      value: any[];
+      name: string;
+    };
+  }) => void;
+}> = (props) => {
+  const { onChange, name, label } = props;
+  const form = useSettings();
+  const customFunc = useCustomProviderFunction();
+  const [categories, setCategories] = useState<any[]>([]);
+  const { getValues } = useSettings();
+  const [selected, setSelected] = useState<any[]>([]);
+  const onDelete = useCallback(
+    (tagIndex: number) => {
+      const modify = selected.filter((_, i) => i !== tagIndex);
+      setSelected(modify);
+      form.setValue(name, modify);
+    },
+    [selected, name, form]
+  );
+  const onAddition = useCallback(
+    (newTag: any) => {
+      const modify = [...selected, newTag];
+      setSelected(modify);
+      form.setValue(name, modify);
+    },
+    [selected, name, form]
+  );
+  useEffect(() => {
+    customFunc.get('categories').then((data) => setCategories(data));
+    const settings = getValues()[props.name];
+    if (settings) {
+      setSelected(settings);
+    }
+  }, []);
+  if (!categories.length) {
+    return null;
+  }
+  return (
+    <div>
+      <div className={`text-[14px] mb-[6px]`}>{label}</div>
+      <ReactTags
+        suggestions={categories}
+        selected={selected}
+        onAdd={onAddition}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+};

--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.provider.tsx
@@ -8,6 +8,10 @@ import {
 import { Input } from '@gitroom/react/form/input';
 import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
 import { WordpressPostType } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.post.type';
+import { WordpressAuthor } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.author';
+import { WordpressStatus } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.status';
+import { WordpressCategories } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.categories';
+import { WordpressTags } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.tags';
 import { MediaComponent } from '@gitroom/frontend/components/media/media.component';
 import { WordpressDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/wordpress.dto';
 
@@ -17,11 +21,27 @@ const WordpressSettings: FC = () => {
     <>
       <Input label="Title" {...form.register('title')} />
       <WordpressPostType {...form.register('type')} />
+      <WordpressAuthor {...form.register('author')} />
+      <WordpressStatus {...form.register('status')} />
+      <Input label="Slug" {...form.register('slug')} />
+      <Input label="Excerpt" {...form.register('excerpt')} />
       <MediaComponent
         label="Cover picture"
         description="Add a cover picture"
         {...form.register('main_image')}
       />
+      <div className="mt-[20px]">
+        <WordpressCategories
+          label="Categories"
+          {...form.register('categories', { value: [] })}
+        />
+      </div>
+      <div>
+        <WordpressTags
+          label="Tags"
+          {...form.register('tags', { value: [] })}
+        />
+      </div>
     </>
   );
 };

--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.status.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.status.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+import { Select } from '@gitroom/react/form/select';
+import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+export const WordpressStatus: FC<{
+  name: string;
+  onChange: (event: {
+    target: {
+      value: string;
+      name: string;
+    };
+  }) => void;
+}> = (props) => {
+  const { onChange, name } = props;
+  const { getValues } = useSettings();
+  const [currentStatus, setCurrentStatus] = useState<string>('publish');
+  const onChangeInner = (event: {
+    target: {
+      value: string;
+      name: string;
+    };
+  }) => {
+    setCurrentStatus(event.target.value);
+    onChange(event);
+  };
+  useEffect(() => {
+    const settings = getValues()[props.name];
+    if (settings) {
+      setCurrentStatus(settings);
+    }
+  }, []);
+  return (
+    <Select
+      name={name}
+      label="Status"
+      onChange={onChangeInner}
+      value={currentStatus}
+    >
+      <option value="publish">Publish</option>
+      <option value="draft">Draft</option>
+      <option value="pending">Pending Review</option>
+      <option value="private">Private</option>
+    </Select>
+  );
+};

--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.tags.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.tags.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { FC, useCallback, useEffect, useState } from 'react';
+import { ReactTags } from 'react-tag-autocomplete';
+import { useCustomProviderFunction } from '@gitroom/frontend/components/launches/helpers/use.custom.provider.function';
+import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+export const WordpressTags: FC<{
+  name: string;
+  label: string;
+  onChange: (event: {
+    target: {
+      value: any[];
+      name: string;
+    };
+  }) => void;
+}> = (props) => {
+  const { onChange, name, label } = props;
+  const form = useSettings();
+  const customFunc = useCustomProviderFunction();
+  const [tags, setTags] = useState<any[]>([]);
+  const { getValues } = useSettings();
+  const [selected, setSelected] = useState<any[]>([]);
+  const onDelete = useCallback(
+    (tagIndex: number) => {
+      const modify = selected.filter((_, i) => i !== tagIndex);
+      setSelected(modify);
+      form.setValue(name, modify);
+    },
+    [selected, name, form]
+  );
+  const onAddition = useCallback(
+    (newTag: any) => {
+      const modify = [...selected, newTag];
+      setSelected(modify);
+      form.setValue(name, modify);
+    },
+    [selected, name, form]
+  );
+  useEffect(() => {
+    customFunc.get('tags').then((data) => setTags(data));
+    const settings = getValues()[props.name];
+    if (settings) {
+      setSelected(settings);
+    }
+  }, []);
+  if (!tags.length) {
+    return null;
+  }
+  return (
+    <div>
+      <div className={`text-[14px] mb-[6px]`}>{label}</div>
+      <ReactTags
+        suggestions={tags}
+        selected={selected}
+        onAdd={onAddition}
+        onDelete={onDelete}
+      />
+    </div>
+  );
+};

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/wordpress.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/wordpress.dto.ts
@@ -1,5 +1,7 @@
 import {
+  IsArray,
   IsDefined,
+  IsNumber,
   IsOptional,
   IsString,
   MinLength,
@@ -7,6 +9,22 @@ import {
 } from 'class-validator';
 import { MediaDto } from '@gitroom/nestjs-libraries/dtos/media/media.dto';
 import { Type } from 'class-transformer';
+
+export class WordpressTagDto {
+  @IsString()
+  value: string;
+
+  @IsString()
+  label: string;
+}
+
+export class WordpressCategoryDto {
+  @IsNumber()
+  value: number;
+
+  @IsString()
+  label: string;
+}
 
 export class WordpressDto {
   @IsString()
@@ -22,4 +40,32 @@ export class WordpressDto {
   @IsString()
   @IsDefined()
   type: string;
+
+  @IsOptional()
+  @IsString()
+  excerpt?: string;
+
+  @IsOptional()
+  @IsString()
+  slug?: string;
+
+  @IsOptional()
+  @IsNumber()
+  author?: number;
+
+  @IsOptional()
+  @IsArray()
+  @Type(() => WordpressCategoryDto)
+  @ValidateNested({ each: true })
+  categories?: WordpressCategoryDto[];
+
+  @IsOptional()
+  @IsArray()
+  @Type(() => WordpressTagDto)
+  @ValidateNested({ each: true })
+  tags?: WordpressTagDto[];
+
+  @IsOptional()
+  @IsString()
+  status?: string;
 }

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/wordpress.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/wordpress.dto.ts
@@ -1,6 +1,7 @@
 import {
   IsArray,
   IsDefined,
+  IsIn,
   IsNumber,
   IsOptional,
   IsString,
@@ -11,8 +12,8 @@ import { MediaDto } from '@gitroom/nestjs-libraries/dtos/media/media.dto';
 import { Type } from 'class-transformer';
 
 export class WordpressTagDto {
-  @IsString()
-  value: string;
+  @IsNumber()
+  value: number;
 
   @IsString()
   label: string;
@@ -67,5 +68,6 @@ export class WordpressDto {
 
   @IsOptional()
   @IsString()
+  @IsIn(['publish', 'draft', 'pending', 'private', 'future'])
   status?: string;
 }

--- a/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
@@ -138,23 +138,27 @@ export class WordpressProvider
     }
   }
 
-  @Tool({
-    description: 'Get list of post types',
-    dataSchema: [],
-  })
-  async postTypes(token: string) {
+  private parseToken(token: string) {
     const body = JSON.parse(Buffer.from(token, 'base64').toString()) as {
       domain: string;
       username: string;
       password: string;
     };
-
     const auth = Buffer.from(`${body.username}:${body.password}`).toString(
       'base64'
     );
+    return { ...body, auth };
+  }
+
+  @Tool({
+    description: 'Get list of post types',
+    dataSchema: [],
+  })
+  async postTypes(token: string) {
+    const { domain, auth } = this.parseToken(token);
 
     const postTypes = await (
-      await this.fetch(`${body.domain}/wp-json/wp/v2/types`, {
+      await this.fetch(`${domain}/wp-json/wp/v2/types`, {
         headers: {
           Authorization: `Basic ${auth}`,
         },
@@ -179,21 +183,76 @@ export class WordpressProvider
     }, []);
   }
 
+  @Tool({
+    description: 'Get list of authors',
+    dataSchema: [],
+  })
+  async authors(token: string) {
+    const { domain, auth } = this.parseToken(token);
+
+    const users = await (
+      await this.fetch(`${domain}/wp-json/wp/v2/users?per_page=100`, {
+        headers: {
+          Authorization: `Basic ${auth}`,
+        },
+      })
+    ).json();
+
+    return (users as any[]).map((u: any) => ({
+      id: u.id,
+      name: u.name,
+    }));
+  }
+
+  @Tool({
+    description: 'Get list of categories',
+    dataSchema: [],
+  })
+  async categories(token: string) {
+    const { domain, auth } = this.parseToken(token);
+
+    const categories = await (
+      await this.fetch(`${domain}/wp-json/wp/v2/categories?per_page=100`, {
+        headers: {
+          Authorization: `Basic ${auth}`,
+        },
+      })
+    ).json();
+
+    return (categories as any[]).map((c: any) => ({
+      id: c.id,
+      name: c.name,
+    }));
+  }
+
+  @Tool({
+    description: 'Get list of tags',
+    dataSchema: [],
+  })
+  async tags(token: string) {
+    const { domain, auth } = this.parseToken(token);
+
+    const tags = await (
+      await this.fetch(`${domain}/wp-json/wp/v2/tags?per_page=100`, {
+        headers: {
+          Authorization: `Basic ${auth}`,
+        },
+      })
+    ).json();
+
+    return (tags as any[]).map((t: any) => ({
+      id: t.id,
+      name: t.name,
+    }));
+  }
+
   async post(
     id: string,
     accessToken: string,
     postDetails: PostDetails<WordpressDto>[],
     integration: Integration
   ): Promise<PostResponse[]> {
-    const body = JSON.parse(Buffer.from(accessToken, 'base64').toString()) as {
-      domain: string;
-      username: string;
-      password: string;
-    };
-
-    const auth = Buffer.from(`${body.username}:${body.password}`).toString(
-      'base64'
-    );
+    const { domain, auth } = this.parseToken(accessToken);
 
     let mediaId = '';
     if (postDetails?.[0]?.settings?.main_image?.path) {
@@ -207,7 +266,7 @@ export class WordpressProvider
       ).then((r) => r.blob());
 
       const mediaResponse = await (
-        await this.fetch(`${body.domain}/wp-json/wp/v2/media`, {
+        await this.fetch(`${domain}/wp-json/wp/v2/media`, {
           method: 'POST',
           headers: {
             Authorization: `Basic ${auth}`,
@@ -223,9 +282,11 @@ export class WordpressProvider
       mediaId = mediaResponse.id;
     }
 
+    const settings = postDetails?.[0]?.settings;
+
     const submit = await (
       await this.fetch(
-        `${body.domain}/wp-json/wp/v2/${postDetails?.[0]?.settings?.type}`,
+        `${domain}/wp-json/wp/v2/${settings?.type}`,
         {
           headers: {
             Authorization: `Basic ${auth}`,
@@ -233,15 +294,23 @@ export class WordpressProvider
           },
           method: 'POST',
           body: JSON.stringify({
-            title: postDetails?.[0]?.settings?.title,
+            title: settings?.title,
             content: postDetails?.[0]?.message,
-            slug: slugify(postDetails?.[0]?.settings?.title, {
+            slug: settings?.slug || slugify(settings?.title, {
               lower: true,
               strict: true,
               trim: true,
             }),
-            status: 'publish',
+            status: settings?.status || 'publish',
             ...(mediaId ? { featured_media: mediaId } : {}),
+            ...(settings?.author ? { author: settings.author } : {}),
+            ...(settings?.excerpt ? { excerpt: settings.excerpt } : {}),
+            ...(settings?.categories?.length
+              ? { categories: settings.categories.map((c) => c.value) }
+              : {}),
+            ...(settings?.tags?.length
+              ? { tags: settings.tags.map((t) => t.value) }
+              : {}),
           }),
         }
       )

--- a/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
@@ -10,10 +10,7 @@ import { Integration } from '@prisma/client';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { WordpressDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/wordpress.dto';
 import slugify from 'slugify';
-// import FormData from 'form-data';
-import axios from 'axios';
 import { Tool } from '@gitroom/nestjs-libraries/integrations/tool.decorator';
-import { string } from 'yup';
 
 export class WordpressProvider
   extends SocialAbstract
@@ -190,13 +187,20 @@ export class WordpressProvider
   async authors(token: string) {
     const { domain, auth } = this.parseToken(token);
 
-    const users = await (
-      await this.fetch(`${domain}/wp-json/wp/v2/users?per_page=100`, {
+    const response = await this.fetch(
+      `${domain}/wp-json/wp/v2/users?per_page=100`,
+      {
         headers: {
           Authorization: `Basic ${auth}`,
         },
-      })
-    ).json();
+      }
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const users = await response.json();
 
     return (users as any[]).map((u: any) => ({
       id: u.id,
@@ -211,17 +215,24 @@ export class WordpressProvider
   async categories(token: string) {
     const { domain, auth } = this.parseToken(token);
 
-    const categories = await (
-      await this.fetch(`${domain}/wp-json/wp/v2/categories?per_page=100`, {
+    const response = await this.fetch(
+      `${domain}/wp-json/wp/v2/categories?per_page=100`,
+      {
         headers: {
           Authorization: `Basic ${auth}`,
         },
-      })
-    ).json();
+      }
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const categories = await response.json();
 
     return (categories as any[]).map((c: any) => ({
-      id: c.id,
-      name: c.name,
+      value: c.id,
+      label: c.name,
     }));
   }
 
@@ -232,17 +243,24 @@ export class WordpressProvider
   async tags(token: string) {
     const { domain, auth } = this.parseToken(token);
 
-    const tags = await (
-      await this.fetch(`${domain}/wp-json/wp/v2/tags?per_page=100`, {
+    const response = await this.fetch(
+      `${domain}/wp-json/wp/v2/tags?per_page=100`,
+      {
         headers: {
           Authorization: `Basic ${auth}`,
         },
-      })
-    ).json();
+      }
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const tags = await response.json();
 
     return (tags as any[]).map((t: any) => ({
-      id: t.id,
-      name: t.name,
+      value: t.id,
+      label: t.name,
     }));
   }
 


### PR DESCRIPTION
## Summary

- Add optional WordPress post settings: `author`, `categories`, `tags`, `excerpt`, `slug`, `status`
- Add backend tool endpoints to fetch authors, categories, and tags from the connected WordPress instance
- Add frontend UI components: author dropdown, category/tag autocomplete pickers, status dropdown, slug/excerpt inputs
- Extract shared `parseToken()` helper to reduce duplication
- Add error handling for tool endpoint HTTP failures
- Remove unused `axios` and `yup` imports

All new fields are optional and fully backward-compatible.

## Motivation

The WordPress provider currently only exposes `title`, `main_image`, and `type`. Users cannot set the post author, assign categories/tags, provide an excerpt, customize the slug, or control publish status — all standard WordPress REST API fields. Related: #537

## Backend changes

**DTO** (`wordpress.dto.ts`):
- `excerpt` (optional string)
- `slug` (optional string, falls back to slugified title)
- `author` (optional number — WordPress user ID)
- `categories` (optional array of `{value: number, label: string}`)
- `tags` (optional array of `{value: number, label: string}`)
- `status` (optional, validated to `publish|draft|pending|private|future`, defaults to `publish`)

**Provider** (`wordpress.provider.ts`):
- New `parseToken()` private helper (DRY refactor)
- New `@Tool` endpoints: `authors()`, `categories()`, `tags()` — return data from the connected WordPress instance
- `post()` method passes all new fields to WordPress REST API when provided
- Error handling on tool endpoints (returns `[]` on HTTP failure)

## Frontend changes

**New components:**
- `wordpress.author.tsx` — author dropdown (same pattern as `WordpressPostType`)
- `wordpress.categories.tsx` — category autocomplete picker (same pattern as `DevtoTags`)
- `wordpress.tags.tsx` — tag autocomplete picker (same pattern as `DevtoTags`)
- `wordpress.status.tsx` — status dropdown (publish/draft/pending/private)

**Updated:** `wordpress.provider.tsx` — wires in all new components alongside existing title/type/main_image

## Known limitations

- Tool endpoints fetch up to 100 items (`?per_page=100`). Pagination for larger sites can come in a follow-up.

## Test plan

- [ ] Create a WordPress post with only `title` and `type` (backward compat)
- [ ] Create a post with `author`, `categories`, `tags`, `excerpt`, `slug`, `status` set
- [ ] Verify `authors`, `categories`, `tags` tool endpoints return data
- [ ] Verify invalid `status` values are rejected by validation
- [ ] Verify frontend components render and submit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)