### PR TITLE
fix(orchestrator): use AutopostActivity instead of AutopostService in Temporal activities

### DIFF
--- a/apps/orchestrator/src/app.module.ts
+++ b/apps/orchestrator/src/app.module.ts
@@ -2,13 +2,13 @@ import { Module } from '@nestjs/common';
 import { PostActivity } from '@gitroom/orchestrator/activities/post.activity';
 import { getTemporalModule } from '@gitroom/nestjs-libraries/temporal/temporal.module';
 import { DatabaseModule } from '@gitroom/nestjs-libraries/database/prisma/database.module';
-import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
+import { AutopostActivity } from '@gitroom/orchestrator/activities/autopost.activity';
 import { EmailActivity } from '@gitroom/orchestrator/activities/email.activity';
 import { IntegrationsActivity } from '@gitroom/orchestrator/activities/integrations.activity';
 
 const activities = [
   PostActivity,
-  AutopostService,
+  AutopostActivity,
   EmailActivity,
   IntegrationsActivity,
 ];


### PR DESCRIPTION
## Problem

`apps/orchestrator/src/app.module.ts` registers `AutopostService` (a database service class) in the Temporal `activities` array. Temporal requires activity classes to be decorated with `@Activity()` and `@ActivityMethod()`. `AutopostService` has neither, so RSS autoposts fail silently — the workflow can't dispatch the activity.

Related to issue #1280.

## Fix

Replace `AutopostService` with `AutopostActivity`, the correct Temporal-decorated wrapper that already injects `AutopostService` internally.

```diff
-import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
+import { AutopostActivity } from '@gitroom/orchestrator/activities/autopost.activity';

-  AutopostService,
+  AutopostActivity,
```

No logic changes. `AutopostActivity` wraps `AutopostService` with the correct decorators.