### PR TITLE
fix(mastodon): replace 'profile' OAuth scope with 'read:accounts'

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -14,7 +14,7 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
   identifier = 'mastodon';
   name = 'Mastodon';
   isBetweenSteps = false;
-  scopes = ['write:statuses', 'profile', 'write:media'];
+  scopes = ['write:statuses', 'read:accounts', 'write:media'];
   editor = 'normal' as const;
   maxLength() {
     return 500;


### PR DESCRIPTION
## Problem

`MastodonProvider` requests the `profile` OAuth scope, which is an OIDC scope only supported by some Mastodon instances (e.g. mastodon.social) as a non-standard alias. Most Mastodon instances reject it, causing OAuth to fail for users on any instance that follows the standard Mastodon API spec.

Reported by users on instances like noc.social. Symptom: OAuth flow errors out during scope negotiation.

## Fix

Replace `profile` with `read:accounts`, the correct Mastodon API scope for reading account/profile data.

```diff
-scopes = ['write:statuses', 'profile', 'write:media'];
+scopes = ['write:statuses', 'read:accounts', 'write:media'];
```

`read:accounts` is defined in the [Mastodon OAuth scopes reference](https://docs.joinmastodon.org/api/oauth-scopes/) and is supported by all standard Mastodon instances.