### PR TITLE
remove Pinterest OAuth refresh logic from DribbbleProvider.refreshToken()

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -75,7 +75,7 @@ export class RefreshIntegrationService {
       .refreshToken(integration.refreshToken)
       .catch((err) => false);
 
-    if (!refresh || !refresh.accessToken) {
+    if (!refresh) {
       await this._integrationService.refreshNeeded(
         integration.organizationId,
         integration.id
@@ -92,6 +92,14 @@ export class RefreshIntegrationService {
       );
 
       return false;
+    }
+
+    if (!refresh.accessToken) {
+      return {
+        ...refresh,
+        accessToken: integration.token,
+        refreshToken: integration.refreshToken || '',
+      };
     }
 
     if (

--- a/libraries/nestjs-libraries/src/integrations/social/dribbble.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/dribbble.provider.ts
@@ -27,41 +27,16 @@ export class DribbbleProvider extends SocialAbstract implements SocialProvider {
   dto = DribbbleDto;
 
   async refreshToken(refreshToken: string): Promise<AuthTokenDetails> {
-    const { access_token, expires_in } = await (
-      await this.fetch('https://api-sandbox.pinterest.com/v5/oauth/token', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          Authorization: `Basic ${Buffer.from(
-            `${process.env.PINTEREST_CLIENT_ID}:${process.env.PINTEREST_CLIENT_SECRET}`
-          ).toString('base64')}`,
-        },
-        body: new URLSearchParams({
-          grant_type: 'refresh_token',
-          refresh_token: refreshToken,
-          scope: `${this.scopes.join(',')}`,
-          redirect_uri: `${process.env.FRONTEND_URL}/integrations/social/pinterest`,
-        }),
-      })
-    ).json();
-
-    const { id, profile_image, username } = await (
-      await this.fetch('https://api-sandbox.pinterest.com/v5/user_account', {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${access_token}`,
-        },
-      })
-    ).json();
-
+    // Dribbble OAuth tokens do not expire and have no refresh mechanism.
+    // Return empty details so the existing access token remains unchanged.
     return {
-      id: id,
-      name: username,
-      accessToken: access_token,
-      refreshToken: refreshToken,
-      expiresIn: expires_in,
-      picture: profile_image || '',
-      username,
+      id: '',
+      name: '',
+      accessToken: '',
+      refreshToken: '',
+      expiresIn: 999999999,
+      picture: '',
+      username: '',
     };
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

This removes pinterest OAuth data from the dribbble integration.
Or am I missing something here? :thinking: 

# Why was this change needed?

- https://developer.dribbble.com/v2/oauth/

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.

**PS:** I'm looking for a new adventure in case anybody is looking to hire or work with a PO/PM or Ruby/Rails/Crystal dev