### PR TITLE
Fix password handling in Nostr provider

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -182,7 +182,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         tags: [],
         created_at: Math.floor(Date.now() / 1000),
       },
-      password
+      Uint8Array.from(password.match(/.{1,2}/g)!.map((byte: any) => parseInt(byte, 16)))
     );
 
     const eventId = await this.publish(id, textEvent);


### PR DESCRIPTION
# What kind of change does this PR introduce?
resolve Uint8Array type error in nostr.provider.ts

eg: Bug fix, feature, docs update, ...

# Why was this change needed?
This PR fixes the Error: expected Uint8Array, got type=string issue when attempting to post to Nostr. The finalizeEvent function in nostr.provider.ts requires the private key to be in bytes, but it was receiving a Hex string from environment variables. Added a check to convert the string to bytes using hexToBytes before signing.

Please link to related issues when possible, and explain WHY you changed things, not WHAT you changed.

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc? No

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x ] I checked that there were not similar issues or PRs already open for this.
- [x ] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
