### PR TITLE
fix: redirect /auth/register to /auth/login when registration is disabled

### DIFF
--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -72,7 +72,7 @@ export async function middleware(request: NextRequest) {
 
   if (
     nextUrl.pathname.startsWith('/auth/register') &&
-    process.env.NEXT_PUBLIC_DISABLE_REGISTRATION === 'true'
+    process.env.DISABLE_REGISTRATION === 'true'
   ) {
     return NextResponse.redirect(new URL('/auth/login', nextUrl.href));
   }


### PR DESCRIPTION
Fixes #1275

## What does this PR do?
When `NEXT_PUBLIC_DISABLE_REGISTRATION=true`, any user attempting 
to access `/auth/register` is automatically redirected to `/auth/login`.

## Changes
- Added a middleware check in `apps/frontend/src/middleware.ts`
- Uses existing `NEXT_PUBLIC_DISABLE_REGISTRATION` env variable

## How to test
1. Set `NEXT_PUBLIC_DISABLE_REGISTRATION=true` in your `.env`
2. Try visiting `/auth/register`
3. You should be redirected to `/auth/login`