### PR TITLE
fix: add SSRF protection and XSS validation to public endpoints

### DIFF
--- a/apps/backend/src/api/routes/public.controller.ts
+++ b/apps/backend/src/api/routes/public.controller.ts
@@ -26,6 +26,7 @@ import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { pricing } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/pricing';
 import { Readable, pipeline } from 'stream';
 import { promisify } from 'util';
+import { isAllowedUrl } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 
 const pump = promisify(pipeline);
 
@@ -177,6 +178,10 @@ export class PublicController {
 
   @Post('/crypto/:path')
   async cryptoPost(@Body() body: any, @Param('path') path: string) {
+    // Validate path to prevent reflected XSS — only allow alphanumeric and hyphens
+    if (!/^[a-zA-Z0-9_-]+$/.test(path)) {
+      return { success: false, error: 'Invalid path' };
+    }
     console.log('cryptoPost', body, path);
     return this._nowpayments.processPayment(path, body);
   }
@@ -187,7 +192,7 @@ export class PublicController {
     @Res() res: Response,
     @Req() req: Request
   ) {
-    if (!url.endsWith('mp4')) {
+    if (!url.endsWith('mp4') || !isAllowedUrl(url)) {
       return res.status(400).send('Invalid video URL');
     }
 

--- a/apps/backend/src/api/routes/webhooks.controller.ts
+++ b/apps/backend/src/api/routes/webhooks.controller.ts
@@ -18,6 +18,7 @@ import {
   WebhooksDto,
 } from '@gitroom/nestjs-libraries/dtos/webhooks/webhooks.dto';
 import { AuthorizationActions, Sections } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
+import { isAllowedUrl } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 
 @ApiTags('Webhooks')
 @Controller('/webhooks')
@@ -56,6 +57,10 @@ export class WebhookController {
 
   @Post('/send')
   async sendWebhook(@Body() body: any, @Query('url') url: string) {
+    if (!isAllowedUrl(url)) {
+      return { send: false, error: 'Invalid or disallowed URL' };
+    }
+
     try {
       await fetch(url, {
         method: 'POST',

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -37,7 +37,7 @@ import * as Sentry from '@sentry/nestjs';
 import { socialIntegrationList, IntegrationManager } from '@gitroom/nestjs-libraries/integrations/integration.manager';
 import { getValidationSchemas } from '@gitroom/nestjs-libraries/chat/validation.schemas.helper';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
-import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import { RefreshToken, isAllowedUrl } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
 
@@ -80,6 +80,9 @@ export class PublicIntegrationsController {
     @Body() body: UploadDto
   ) {
     Sentry.metrics.count('public_api-request', 1);
+    if (!isAllowedUrl(body.url)) {
+      throw new HttpException({ msg: 'Invalid or disallowed URL' }, 400);
+    }
     const response = await axios.get(body.url, {
       responseType: 'arraybuffer',
     });

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -46,6 +46,44 @@ function safeStringify(obj: any) {
   });
 }
 
+/**
+ * Validates that a URL uses an allowed protocol (http/https) and does not
+ * target private/internal network addresses (SSRF protection).
+ */
+export function isAllowedUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
+    const hostname = parsed.hostname.toLowerCase();
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '[::1]' ||
+      hostname === '0.0.0.0' ||
+      hostname.startsWith('10.') ||
+      hostname.startsWith('192.168.') ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.internal') ||
+      hostname === 'metadata.google.internal' ||
+      hostname === '169.254.169.254'
+    ) {
+      return false;
+    }
+    // Block 172.16-31.x.x (private range)
+    if (hostname.startsWith('172.')) {
+      const secondOctet = parseInt(hostname.split('.')[1], 10);
+      if (secondOctet >= 16 && secondOctet <= 31) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export abstract class SocialAbstract {
   abstract identifier: string;
   maxConcurrentJob = 1;
@@ -104,6 +142,9 @@ export abstract class SocialAbstract {
     totalRetries = 0,
     ignoreConcurrency = false
   ): Promise<Response> {
+    if (!isAllowedUrl(url)) {
+      throw new BadBody(identifier, '{}', options.body || '{}', 'Invalid or disallowed URL');
+    }
     const request = await fetch(url, options);
 
     if (request.status === 200 || request.status === 201) {


### PR DESCRIPTION
## Summary

Several public endpoints are vulnerable to Server-Side Request Forgery (SSRF), allowing attackers to make the server send HTTP requests to internal network addresses (e.g., AWS metadata at `169.254.169.254`, internal services on `10.x`, `192.168.x`, `localhost`).

This PR adds an `isAllowedUrl()` utility and applies it to all vulnerable endpoints.

## Vulnerabilities Fixed

### SSRF (Server-Side Request Forgery)

| Endpoint | File | Issue |
|----------|------|-------|
| `GET /public/stream` | `public.controller.ts` | User-provided `?url=` fetched with only `.mp4` extension check — trivially bypassable |
| `POST /webhooks/send` | `webhooks.controller.ts` | User-provided `?url=` used for POST with **zero validation** |
| `POST /public/v1/upload-from-url` | `public.integrations.controller.ts` | User-provided URL in body fetched via axios |
| `SocialAbstract.fetch()` | `social.abstract.ts` | Base class fetch method used by all social providers had no URL validation |

### Reflected XSS

| Endpoint | File | Issue |
|----------|------|-------|
| `POST /public/crypto/:path` | `public.controller.ts` | Unvalidated URL path parameter returned in response |

## Changes

### New: `isAllowedUrl()` utility (`social.abstract.ts`)
- Validates URL uses `http:` or `https:` protocol
- Blocks private/internal network addresses:
  - `localhost`, `127.0.0.1`, `[::1]`, `0.0.0.0`
  - `10.x.x.x`, `192.168.x.x`, `172.16-31.x.x`
  - `169.254.169.254` (cloud metadata)
  - `*.local`, `*.internal`

### Endpoint hardening
- `/stream`: Added `isAllowedUrl` check alongside existing `.mp4` check
- `/webhooks/send`: Added `isAllowedUrl` check before fetch
- `/upload-from-url`: Added `isAllowedUrl` check before axios request
- `SocialAbstract.fetch()`: Added `isAllowedUrl` guard in base class
- `/crypto/:path`: Added alphanumeric regex validation on path parameter

## Test plan
- Verified all existing functionality works with valid external URLs
- Private IPs and localhost correctly rejected with appropriate error responses