### PR TITLE
Added Shlink to URL Shortner

### DIFF
--- a/libraries/nestjs-libraries/src/short-linking/providers/shlink.ts
+++ b/libraries/nestjs-libraries/src/short-linking/providers/shlink.ts
@@ -1,0 +1,148 @@
+import axios, { AxiosInstance } from 'axios';
+import { ShortLinking } from '../short-linking.interface';
+
+type ShlinkShortUrlResponse = {
+  shortUrl?: string;
+  shortCode?: string;
+  longUrl?: string;
+  visitsSummary?: {
+    total?: number;
+  };
+};
+
+export class ShlinkProvider implements ShortLinking {
+  public shortLinkDomain: string;
+
+  private readonly client: AxiosInstance;
+  private readonly apiBase: string;
+
+  constructor() {
+    const baseUrl = process.env.SHLINK_URL;
+    const apiKey = process.env.SHLINK_API_KEY;
+    const shortDomain = process.env.SHLINK_DOMAIN;
+
+    if (!baseUrl) {
+      throw new Error('SHLINK_URL is not set');
+    }
+
+    if (!apiKey) {
+      throw new Error('SHLINK_API_KEY is not set');
+    }
+
+    const parsedBaseUrl = new URL(baseUrl);
+
+    this.apiBase = `${baseUrl.replace(/\/$/, '')}/rest/v3`;
+    this.shortLinkDomain = shortDomain || parsedBaseUrl.host;
+
+    this.client = axios.create({
+      baseURL: this.apiBase,
+      timeout: 10000,
+      headers: {
+        'X-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  async convertLinkToShortLink(id: string, link: string): Promise<string> {
+    const payload: Record<string, unknown> = {
+      longUrl: link,
+      tags: id ? [id] : [],
+    };
+
+    if (process.env.SHLINK_DOMAIN) {
+      payload.domain = process.env.SHLINK_DOMAIN;
+    }
+
+    const response = await this.client.post<ShlinkShortUrlResponse>(
+      '/short-urls',
+      payload
+    );
+
+    if (response.data?.shortUrl) {
+      return response.data.shortUrl;
+    }
+
+    if (response.data?.shortCode) {
+      return `https://${this.shortLinkDomain}/${response.data.shortCode}`;
+    }
+
+    throw new Error('Shlink did not return a short URL');
+  }
+
+  async convertShortLinkToLink(shortLink: string): Promise<string> {
+    const shortCode = this.extractShortCode(shortLink);
+
+    const response = await this.client.get<ShlinkShortUrlResponse>(
+      `/short-urls/${encodeURIComponent(shortCode)}`
+    );
+
+    if (!response.data?.longUrl) {
+      throw new Error('Shlink did not return the original URL');
+    }
+
+    return response.data.longUrl;
+  }
+
+  async linksStatistics(
+    links: string[]
+  ): Promise<{ short: string; original: string; clicks: string }[]> {
+    const results = await Promise.all(
+      links.map(async (shortLink) => {
+        const shortCode = this.extractShortCode(shortLink);
+
+        const response = await this.client.get<ShlinkShortUrlResponse>(
+          `/short-urls/${encodeURIComponent(shortCode)}`
+        );
+
+        return {
+          short: response.data.shortUrl || shortLink,
+          original: response.data.longUrl || '',
+          clicks: String(response.data.visitsSummary?.total ?? 0),
+        };
+      })
+    );
+
+    return results;
+  }
+
+  async getAllLinksStatistics(
+    id: string,
+    page: number
+  ): Promise<{ short: string; original: string; clicks: string }[]> {
+    const pageNumber = Number.isFinite(page) && page > 0 ? page : 1;
+
+    const response = await this.client.get<{
+      shortUrls?: {
+        data?: ShlinkShortUrlResponse[];
+      };
+    }>('/short-urls', {
+      params: {
+        page: pageNumber,
+        itemsPerPage: 20,
+        tags: id || undefined,
+      },
+    });
+
+    const items = response.data?.shortUrls?.data || [];
+
+    return items.map((item) => ({
+      short:
+        item.shortUrl ||
+        (item.shortCode
+          ? `https://${this.shortLinkDomain}/${item.shortCode}`
+          : ''),
+      original: item.longUrl || '',
+      clicks: String(item.visitsSummary?.total ?? 0),
+    }));
+  }
+
+  private extractShortCode(shortLink: string): string {
+    try {
+      const url = new URL(shortLink);
+      return url.pathname.replace(/^\/+/, '');
+    } catch {
+      return shortLink.replace(/^\/+/, '');
+    }
+  }
+}

--- a/libraries/nestjs-libraries/src/short-linking/short.link.service.ts
+++ b/libraries/nestjs-libraries/src/short-linking/short.link.service.ts
@@ -5,10 +5,15 @@ import { Injectable } from '@nestjs/common';
 import { ShortIo } from './providers/short.io';
 import { Kutt } from './providers/kutt';
 import { LinkDrip } from './providers/linkdrip';
+import { ShlinkProvider } from './providers/shlink';
 import { uniq } from 'lodash';
 import striptags from 'striptags';
 
 const getProvider = (): ShortLinking => {
+  if (process.env.SHLINK_URL && process.env.SHLINK_API_KEY) {
+    return new ShlinkProvider();
+  }
+
   if (process.env.DUB_TOKEN) {
     return new Dub();
   }


### PR DESCRIPTION
ENV variables are

•	SHLINK_URL
•	SHLINK_API_KEY
•	SHLINK_DOMAIN

SHLINK_URL=https://your-shlink-server.example.com
SHLINK_API_KEY=your_shlink_api_key_here
SHLINK_DOMAIN=https://go.yourdomain.com

Here is the terminal command to test this from within your docker container

docker exec -it postiz /bin/sh -lc ' apk add --no-cache curl >/dev/null 2>&1 || true curl -s -X POST "$SHLINK_URL/rest/v3/short-urls" \ -H "X-Api-Key: $SHLINK_API_KEY" \ -H "Content-Type: application/json" \ -d "{\"longUrl\":\"https://example.com/test\"}" '

# What kind of change does this PR introduce?

This provides Shlink integration as an option for URL shortenerin Postiz

# Why was this change needed?

Well many use Shlink as a URL shortener 

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
