### PR TITLE
fix(docker): run Prisma before nginx; add pm2-run-apps for container startup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,4 +25,4 @@ COPY var/docker/nginx.conf /etc/nginx/nginx.conf
 RUN pnpm install
 RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm run build
 
-CMD ["sh", "-c", "nginx && pnpm run pm2"]
+CMD ["sh", "-c", "pnpm run prisma-db-push && nginx && pnpm run pm2-run-apps"]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "publish-sdk": "pnpm run --filter ./apps/sdk publish",
     "publish-cli": "pnpm run --filter ./apps/cli publish",
     "pm2-run": "pm2 delete all || true && pnpm run prisma-db-push && pnpm run --parallel pm2 && pm2 logs",
+    "pm2-run-apps": "pm2 delete all || true && pnpm run --filter ./apps/backend --filter ./apps/frontend --filter ./apps/orchestrator --parallel pm2 && pm2 logs",
     "dev:stripe": "pnpm dlx concurrently \"stripe listen --forward-to localhost:3000/stripe\" \"pnpm run dev\"",
     "build": "pnpm -r --workspace-concurrency=1 --filter ./apps/frontend --filter ./apps/backend --filter ./apps/orchestrator run build",
     "build:backend": "rm -rf apps/backend/dist && pnpm --filter ./apps/backend run build",


### PR DESCRIPTION
Fixes: GH-1347
## Summary

- **Dockerfile.dev** `CMD`: run `prisma-db-push`, then `nginx`, then a new script `pm2-run-apps` (no second Prisma run).
- **package.json**: add `pm2-run-apps` — same PM2 app startup as `pm2-run` after Prisma, scoped with `--filter` to backend, frontend, and orchestrator.

## Why

Previously `nginx && pnpm run pm2` started nginx on **:5000** before `pm2-run` finished **`prisma db push`**, so `/api/` proxied to **:3000** and returned **502** for the entire migration window. Reordering avoids nginx accepting API traffic until after Prisma; health checks and reverse proxies behave more predictably.

## Backwards compatibility

- `pm2-run` is unchanged for existing local/compose flows that rely on the full chain in one script.