### PR TITLE
fix(x): fall back to v1.1 verify_credentials when v2 /users/me returns 403

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Thumbs.db
 .secrets/
 libraries/plugins/src/plugins.ts
 i18n.cache
+
+# ignore local dev file uploads
+var/postiz-uploads

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -1,4 +1,4 @@
-import { TweetV2, TwitterApi } from 'twitter-api-v2';
+import { ApiResponseError, TweetV2, TwitterApi } from 'twitter-api-v2';
 import {
   AnalyticsData,
   AuthTokenDetails,
@@ -267,35 +267,62 @@ export class XProvider extends SocialAbstract implements SocialProvider {
       code
     );
 
-    const {
-      data: { username, verified, profile_image_url, name, id },
-    } = await client.v2.me({
-      'user.fields': [
-        'username',
-        'verified',
-        'verified_type',
-        'profile_image_url',
-        'name',
-      ],
-    });
+    const profile = await this.readOAuthUserProfile(client);
 
     return {
-      id: String(id),
+      id: profile.id,
       accessToken: accessToken + ':' + accessSecret,
-      name,
+      name: profile.name,
       refreshToken: '',
       expiresIn: 999999999,
-      picture: profile_image_url || '',
-      username,
+      picture: profile.profile_image_url || '',
+      username: profile.username,
       additionalSettings: [
         {
           title: 'Verified',
           description: 'Is this a verified user? (Premium)',
           type: 'checkbox' as const,
-          value: verified,
+          value: profile.verified,
         },
       ],
     };
+  }
+
+  /** v2 user lookup; on 403 (common for restricted X projects) fall back to v1.1. */
+  private async readOAuthUserProfile(client: TwitterApi) {
+    try {
+      const { data } = await client.v2.me({
+        'user.fields': [
+          'username',
+          'verified',
+          'verified_type',
+          'profile_image_url',
+          'name',
+        ],
+      });
+      return {
+        id: String(data.id),
+        name: data.name,
+        username: data.username,
+        verified: !!data.verified,
+        profile_image_url: data.profile_image_url,
+      };
+    } catch (err) {
+      if (!(err instanceof ApiResponseError) || err.code !== 403) {
+        throw err;
+      }
+      const u = await client.v1.verifyCredentials({
+        include_entities: false,
+        skip_status: true,
+      });
+      return {
+        id: String(u.id_str),
+        name: u.name,
+        username: u.screen_name,
+        verified: !!u.verified,
+        profile_image_url: u.profile_image_url_https,
+      };
+    }
   }
 
   private async getClient(accessToken: string) {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (X / Twitter OAuth): complete account linking when v2 user lookup returns 403.

# Why was this change needed?

Some X developer projects cannot use `GET /2/users/me` and respond with HTTP 403 even after a valid OAuth 1.0a token exchange, which prevented connecting X in Postiz. The flow still calls v2 first; if the error is a 403 `ApiResponseError`, we fall back to v1.1 `account/verify_credentials` and map the same profile fields. That matches setups where v2 user endpoints are restricted but v1.1 remains usable.

# Other information:

- Logic lives in a private `readOAuthUserProfile` helper on `XProvider` so `authenticate` stays a straight line after `login()`.
- Also ignores `var/postiz-uploads` in `.gitignore` for local dev uploads (no behavior change in production).

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
