### PR TITLE
fix: Add the missing ContentType for uploadFile on R2

### DIFF
--- a/libraries/nestjs-libraries/src/upload/cloudflare.storage.ts
+++ b/libraries/nestjs-libraries/src/upload/cloudflare.storage.ts
@@ -92,6 +92,7 @@ class CloudflareStorage implements IUploadProvider {
         ACL: 'public-read',
         Key: `${id}.${extension}`,
         Body: file.buffer,
+        ContentType: file.mimetype,
       });
 
       await this._client.send(command);


### PR DESCRIPTION
# What kind of change does this PR introduce?
Bug fix

# Why was this change needed?
When uploading files via the Public API endpoints (POST /public/v1/upload and POST /public/v1/upload-from-url) with Cloudflare R2 as the storage provider, all files are stored with Content-Type: application/octet-stream instead of their actual MIME type (e.g., image/png). This causes issues when social media platforms or other consumers try to use the uploaded media.

<img width="813" height="45" alt="image" src="https://github.com/user-attachments/assets/a319613f-0deb-4eb3-9609-c85a45cca300" />


The root cause is that CloudflareStorage.uploadFile() in cloudflare.storage.ts does not pass ContentType to the PutObjectCommand, so R2/S3 defaults to application/octet-stream. The uploadSimple() method in the same file and the multipart upload path in r2.uploader.ts both set ContentType correctly — only uploadFile() was missing it.

This is why uploads from the web UI (which use the multipart path) work fine, but API uploads (which use uploadFile()) do not.

Sorry didn't created an issue for this.

# Other information:
The fix is a one-line addition — passing ContentType: file.mimetype to the PutObjectCommand in the uploadFile() method, consistent with how uploadSimple() and createMultipartUpload() already handle it.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
