### PR TITLE
fix(bluesky): support subdomains in service URL validation

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -163,7 +163,7 @@ export class BlueskyProvider extends SocialAbstract implements SocialProvider {
         key: 'service',
         label: 'Service',
         defaultValue: 'https://bsky.social',
-        validation: `/^(https?:\\/\\/)?((([a-zA-Z0-9\\-_]{1,256}\\.[a-zA-Z]{2,6})|(([0-9]{1,3}\\.){3}[0-9]{1,3}))(:[0-9]{1,5})?)(\\/[^\\s]*)?$/`,
+        validation: `/^(https?:\\/\\/)?((([a-zA-Z0-9\\-_]{1,256}(\\.[a-zA-Z0-9\\-_]{1,256})*\\.[a-zA-Z]{2,6})|(([0-9]{1,3}\\.){3}[0-9]{1,3}))(:[0-9]{1,5})?)(\\/[^\\s]*)?$/`,
         type: 'text' as const,
       },
       {


### PR DESCRIPTION
## Summary
- Fixed regex validation for Bluesky service URL field to support subdomains
- Users with self-hosted PDS instances (e.g. `https://pds.example.com`) were unable to connect because the regex only matched single-level domains

## Test plan
- [x] `https://bsky.social` still validates
- [x] `https://pds.example.com` now validates
- [x] `https://sub.pds.example.com` now validates
- [x] Invalid URLs are still rejected

Fixes #952