### PR TITLE
fix: log errors in updateMedia instead of silently swallowing them

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -416,6 +416,7 @@ export class PostsService {
 
       return getImageList;
     } catch (err: any) {
+      console.error(`[updateMedia] Failed for post ${id}:`, err.message);
       return imagesList;
     }
   }


### PR DESCRIPTION
## Summary
- The `catch` block in `updateMedia()` (posts.service.ts) returns `imagesList` without any logging, making it impossible to diagnose why scheduled posts with media fail.
- Added `console.error` to surface the actual error while keeping the existing defensive fallback (no throw, so posts without media still work).

## Context
This was found while investigating why scheduled posts with images fail silently (related to the MCP server sending incorrect image payloads). Even after fixing the MCP side, this silent catch makes any future media-related issues invisible.

## Test plan
- [x] No behavioral change — still returns `imagesList` on failure
- [x] Errors are now visible in server logs for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)