### PR TITLE
feat(instagram): add story link sticker support

### DIFF
--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/instagram.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/instagram.dto.ts
@@ -30,4 +30,8 @@ export class InstagramDto {
   @IsArray()
   @IsOptional()
   collaborators: Collaborators[];
+
+  @IsOptional()
+  @IsString()
+  story_link_url?: string;
 }

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -548,17 +548,17 @@ export class InstagramProvider
           m.path.indexOf('.mp4') > -1
             ? firstPost?.media?.length === 1
               ? isStory
-                ? `video_url=${m.path}&media_type=STORIES`
+                ? `video_url=${m.path}&media_type=STORIES${firstPost.settings.story_link_url ? `&link=${encodeURIComponent(firstPost.settings.story_link_url)}` : ""}`
                 : `video_url=${m.path}&media_type=REELS&thumb_offset=${
                     m?.thumbnailTimestamp || 0
                   }`
               : isStory
-              ? `video_url=${m.path}&media_type=STORIES`
+              ? `video_url=${m.path}&media_type=STORIES${firstPost.settings.story_link_url ? `&link=${encodeURIComponent(firstPost.settings.story_link_url)}` : ""}`
               : `video_url=${m.path}&media_type=VIDEO&thumb_offset=${
                   m?.thumbnailTimestamp || 0
                 }`
             : isStory
-            ? `image_url=${m.path}&media_type=STORIES`
+            ? `image_url=${m.path}&media_type=STORIES${firstPost.settings.story_link_url ? `&link=${encodeURIComponent(firstPost.settings.story_link_url)}` : ""}`
             : `image_url=${m.path}`;
 
         const trialParams = isTrialReel


### PR DESCRIPTION
## What
Adds support for Instagram Story link stickers via the Graph API `link` parameter.

## Changes
- **instagram.dto.ts**: New optional `story_link_url` field in `InstagramDto`
- **instagram.provider.ts**: When `story_link_url` is set and `post_type` is `story`, the `link` parameter is appended to the media container request for both image and video stories

## Usage
```json
{
  "settings": {
    "__type": "instagram",
    "post_type": "story",
    "story_link_url": "https://example.com/my-landing-page"
  }
}
```

Closes #580

# What kind of change does this PR introduce?
Feature — adds link sticker support for Instagram Stories

# Why was this change needed?
Currently Postiz can publish Instagram Stories but cannot include link stickers. This is a commonly requested feature (#580) for marketing workflows where Stories need to drive traffic to external URLs (event tickets, landing pages, etc.).

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue.