### PR TITLE
feat: add Vugola integration (AI video clipping)

### DIFF
--- a/apps/frontend/src/components/third-parties/providers/vugola.provider.tsx
+++ b/apps/frontend/src/components/third-parties/providers/vugola.provider.tsx
@@ -1,0 +1,113 @@
+import { thirdPartyWrapper } from '@gitroom/frontend/components/third-parties/third-party.wrapper';
+import { useThirdPartySubmit } from '@gitroom/frontend/components/third-parties/third-party.function';
+import { useThirdParty } from '@gitroom/frontend/components/third-parties/third-party.media';
+import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
+import { Input } from '@gitroom/react/form/input';
+import { Select } from '@gitroom/react/form/select';
+import { Button } from '@gitroom/react/form/button';
+import { useCallback } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { object, string } from 'zod';
+import { LoadingComponent } from '@gitroom/frontend/components/layout/loading';
+
+const aspectRatio = [
+  { key: '9:16', value: 'Portrait (9:16)' },
+  { key: '16:9', value: 'Landscape (16:9)' },
+  { key: '1:1', value: 'Square (1:1)' },
+];
+
+const captionStyles = [
+  { key: 'none', value: 'None' },
+  { key: 'minimalist', value: 'Minimalist' },
+  { key: 'highlighted', value: 'Highlighted' },
+  { key: 'scale', value: 'Scale' },
+  { key: 'box', value: 'Box' },
+];
+
+type VugolaFormValues = {
+  video_url: string;
+  aspect_ratio: string;
+  caption_style: string;
+};
+
+const VugolaProviderComponent = () => {
+  const thirdParty = useThirdParty();
+  const send = useThirdPartySubmit();
+
+  const form = useForm<VugolaFormValues>({
+    values: {
+      video_url: '',
+      aspect_ratio: '',
+      caption_style: '',
+    },
+    mode: 'all',
+    resolver: zodResolver(
+      object({
+        video_url: string()
+          .url('Must be a valid URL')
+          .min(1, 'Video URL is required'),
+        aspect_ratio: string().min(1, 'Aspect ratio is required'),
+        caption_style: string().min(1, 'Caption style is required'),
+      })
+    ),
+  });
+
+  const submit: SubmitHandler<VugolaFormValues> = useCallback(
+    async (params) => {
+      thirdParty.onChange(await send(params));
+      thirdParty.close();
+    },
+    [thirdParty, send]
+  );
+
+  return (
+    <div>
+      {form.formState.isSubmitting && (
+        <div className="fixed left-0 top-0 w-full leading-[50px] pt-[200px] h-screen bg-black/90 z-50 flex flex-col justify-center items-center text-center text-3xl">
+          Clipping your video... This can take 10-30 minutes.
+          <br />
+          Vugola will also email you when it&apos;s done.
+          <br />
+          DO NOT CLOSE THIS WINDOW!
+          <br />
+          <LoadingComponent width={200} height={200} />
+        </div>
+      )}
+
+      <FormProvider {...form}>
+        <form
+          onSubmit={form.handleSubmit(submit)}
+          className="w-full flex flex-col"
+        >
+          <Input
+            label="Video URL"
+            {...form.register('video_url')}
+            placeholder="https://www.youtube.com/watch?v=..."
+          />
+
+          <Select label="Aspect Ratio" {...form.register('aspect_ratio')}>
+            <option value="">--SELECT--</option>
+            {aspectRatio.map((p) => (
+              <option key={p.key} value={p.key}>
+                {p.value}
+              </option>
+            ))}
+          </Select>
+
+          <Select label="Caption Style" {...form.register('caption_style')}>
+            <option value="">--SELECT--</option>
+            {captionStyles.map((p) => (
+              <option key={p.key} value={p.key}>
+                {p.value}
+              </option>
+            ))}
+          </Select>
+
+          <Button type="submit">Generate Clips</Button>
+        </form>
+      </FormProvider>
+    </div>
+  );
+};
+
+export default thirdPartyWrapper('vugola', VugolaProviderComponent);

--- a/apps/frontend/src/components/third-parties/third-party.media.tsx
+++ b/apps/frontend/src/components/third-parties/third-party.media.tsx
@@ -16,6 +16,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import useSWR from 'swr';
 import { TopTitle } from '@gitroom/frontend/components/launches/helpers/top.title.component';
 import './providers/heygen.provider';
+import './providers/vugola.provider';
 import { thirdPartyList } from '@gitroom/frontend/components/third-parties/third-party.wrapper';
 import { useLaunchStore } from '@gitroom/frontend/components/new-launch/store';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';

--- a/libraries/nestjs-libraries/src/3rdparties/thirdparty.module.ts
+++ b/libraries/nestjs-libraries/src/3rdparties/thirdparty.module.ts
@@ -1,11 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { HeygenProvider } from '@gitroom/nestjs-libraries/3rdparties/heygen/heygen.provider';
 import { ReelFarmProvider } from '@gitroom/nestjs-libraries/3rdparties/reelfarm/reelfarm.provider';
+import { VugolaProvider } from '@gitroom/nestjs-libraries/3rdparties/vugola/vugola.provider';
 import { ThirdPartyManager } from '@gitroom/nestjs-libraries/3rdparties/thirdparty.manager';
 
 @Global()
 @Module({
-  providers: [HeygenProvider, ReelFarmProvider, ThirdPartyManager],
+  providers: [HeygenProvider, ReelFarmProvider, VugolaProvider, ThirdPartyManager],
   get exports() {
     return this.providers;
   },

--- a/libraries/nestjs-libraries/src/3rdparties/vugola/vugola.provider.ts
+++ b/libraries/nestjs-libraries/src/3rdparties/vugola/vugola.provider.ts
@@ -1,0 +1,160 @@
+import {
+  ThirdParty,
+  ThirdPartyAbstract,
+} from '@gitroom/nestjs-libraries/3rdparties/thirdparty.interface';
+import { timer } from '@gitroom/helpers/utils/timer';
+
+const VUGOLA_API_BASE = 'https://api.vugolaai.com';
+const POLL_INTERVAL_MS = 5_000;
+const MAX_POLL_ITERATIONS = 720; // 5s * 720 = 1h ceiling
+
+@ThirdParty({
+  identifier: 'vugola',
+  title: 'Vugola',
+  description:
+    'AI video clipping — turn long videos (podcasts, YouTube, interviews) into short-form clips with captions.',
+  position: 'media',
+  fields: [],
+})
+export class VugolaProvider extends ThirdPartyAbstract<{
+  video_url: string;
+  aspect_ratio: string;
+  caption_style: string;
+}> {
+  async checkConnection(
+    apiKey: string
+  ): Promise<false | { name: string; username: string; id: string }> {
+    const response = await fetch(`${VUGOLA_API_BASE}/status`, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const body = (await response.json()) as { plan?: string };
+    const planLabel = typeof body?.plan === 'string' ? body.plan : 'account';
+
+    return {
+      name: `Vugola (${planLabel})`,
+      username: 'vugola',
+      id: apiKey.slice(-8),
+    };
+  }
+
+  async sendData(
+    apiKey: string,
+    data: {
+      video_url: string;
+      aspect_ratio: string;
+      caption_style: string;
+    }
+  ): Promise<string> {
+    const startResponse = await fetch(`${VUGOLA_API_BASE}/clip`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        video_url: data.video_url,
+        aspect_ratio: data.aspect_ratio,
+        caption_style: data.caption_style,
+      }),
+    });
+
+    if (!startResponse.ok) {
+      const errorText = await startResponse.text().catch(() => '');
+      throw new Error(
+        `Vugola failed to start clipping job (${startResponse.status})${
+          errorText ? `: ${errorText.slice(0, 200)}` : ''
+        }`
+      );
+    }
+
+    const { job_id: jobId } = (await startResponse.json()) as {
+      job_id: string;
+    };
+
+    if (!jobId) {
+      throw new Error('Vugola did not return a job_id');
+    }
+
+    for (let i = 0; i < MAX_POLL_ITERATIONS; i++) {
+      await timer(POLL_INTERVAL_MS);
+
+      const statusResponse = await fetch(
+        `${VUGOLA_API_BASE}/clip/${encodeURIComponent(jobId)}`,
+        {
+          method: 'GET',
+          headers: {
+            accept: 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+        }
+      );
+
+      if (!statusResponse.ok) {
+        throw new Error(
+          `Vugola status check failed (${statusResponse.status})`
+        );
+      }
+
+      const statusBody = (await statusResponse.json()) as {
+        status: string;
+        clips?: Array<{
+          download_url: string;
+          virality_score?: number;
+        }>;
+        error?: string;
+      };
+
+      if (statusBody.status === 'failed') {
+        throw new Error(
+          `Vugola clipping failed: ${statusBody.error ?? 'unknown error'}`
+        );
+      }
+
+      if (statusBody.status === 'complete') {
+        const clips = statusBody.clips ?? [];
+        if (clips.length === 0) {
+          throw new Error('Vugola returned no clips');
+        }
+
+        const best = [...clips].sort(
+          (a, b) => (b.virality_score ?? 0) - (a.virality_score ?? 0)
+        )[0];
+
+        if (!best?.download_url) {
+          throw new Error('Vugola clip is missing a download URL');
+        }
+
+        // Vugola download URLs require the same Bearer header. Postiz's
+        // storage fetches publicly, so we download the clip bytes here with
+        // auth and return a data: URL so downstream storage can read it.
+        const clipResponse = await fetch(best.download_url, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+
+        if (!clipResponse.ok) {
+          throw new Error(
+            `Vugola clip download failed (${clipResponse.status})`
+          );
+        }
+
+        const buffer = Buffer.from(await clipResponse.arrayBuffer());
+        return `data:video/mp4;base64,${buffer.toString('base64')}`;
+      }
+    }
+
+    throw new Error(
+      'Vugola clipping timed out. Check your Vugola dashboard and email for the completed clips.'
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds **Vugola** (https://www.vugolaai.com) as a third-party `media` integration, mirroring the existing HeyGen pattern. Vugola is an AI video clipping tool — users paste a long-form video URL (YouTube, podcast, interview), pick an aspect ratio + caption style, and get back a short-form clip with captions that slots in as a Postiz post attachment.

## Why

Requested by Nevo. Vugola has a public REST API and already ships an MCP server (https://github.com/VCoder25/vugola-mcp) — this PR brings the same capability into Postiz's integrations panel.

## Files changed

**New:**
- `libraries/nestjs-libraries/src/3rdparties/vugola/vugola.provider.ts` — backend provider (`checkConnection` + `sendData`).
- `apps/frontend/src/components/third-parties/providers/vugola.provider.tsx` — React form (video_url input, aspect ratio + caption style selects).

**Modified (minimal):**
- `libraries/nestjs-libraries/src/3rdparties/thirdparty.module.ts` — register `VugolaProvider`.
- `apps/frontend/src/components/third-parties/third-party.media.tsx` — import the provider component so its decorator runs.

## Vugola-specific design note

Vugola's download URLs require the same `Authorization: Bearer <key>` header as the rest of its API (security-by-default — clips belong to paying users). Postiz's `storage.uploadSimple()` fetches URLs publicly with no auth header, so we can't just hand it a Vugola download URL.

Workaround inside `sendData()`: after Vugola reports the job complete, we pick the highest-scoring clip, fetch its bytes with the Bearer header, and return a `data:video/mp4;base64,...` URL. `uploadSimple()` ingests data URLs natively on Node 20+. No core Postiz changes needed.

## Icon TODO

`apps/frontend/public/icons/third-party/vugola.png` (32×32) needs to be dropped in before merge. Happy to commit it in this branch once you confirm the rest looks good — didn't want to guess the brand mark.

## API reference

- Base URL: `https://api.vugolaai.com`
- Auth: `Authorization: Bearer vug_sk_*`
- `POST /clip` — start job → returns `{ job_id }`
- `GET /clip/:job_id` — poll status → `processing | complete | failed`
- `GET /status` — credits + plan (used for `checkConnection`)
- Full public reference available on request.

## Test plan

- [ ] User with Vugola Creator+ plan pastes `vug_sk_*` key — connection succeeds, card appears in Integrations → Media.
- [ ] Generate clip from a public YouTube URL (2+ min) with 9:16 + minimalist captions — clip attaches to post.
- [ ] Invalid API key returns connection failure with clear message.
- [ ] Bad video URL surfaces Vugola's rejection reason, doesn't hang.
- [ ] Long jobs don't starve — 60s poll ceiling is 1 hour; Vugola also emails the user when done as a backup.

🤖 Written via Claude Code per the project's agent-friendly workflow. Happy to iterate on anything.