### PR TITLE
fix: exclude collaborators from Instagram carousel child items

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -571,7 +571,7 @@ export class InstagramProvider
           : ``;
 
         const collaborators =
-          firstPost?.settings?.collaborators?.length && !isStory
+          firstPost?.settings?.collaborators?.length && !isStory && !isCarousel
             ? `&collaborators=${JSON.stringify(
                 firstPost?.settings?.collaborators.map((p) => p.label)
               )}`
@@ -663,13 +663,19 @@ export class InstagramProvider
         },
       ];
     } else {
+      const carouselCollaborators =
+        firstPost?.settings?.collaborators?.length
+          ? `&collaborators=${JSON.stringify(
+              firstPost?.settings?.collaborators.map((p) => p.label)
+            )}`
+          : ``;
       const { id: containerId, ...all3 } = await (
         await this.fetch(
           `https://${type}/v20.0/${id}/media?caption=${encodeURIComponent(
             firstPost?.message
           )}&media_type=CAROUSEL&children=${encodeURIComponent(
             medias.join(',')
-          )}&access_token=${accessToken}`,
+          )}${carouselCollaborators}&access_token=${accessToken}`,
           {
             method: 'POST',
           }


### PR DESCRIPTION
## Summary

- Fix Instagram carousel posts failing when collaborators are set
- The `collaborators` parameter was being included on carousel child item requests, but Instagram's API only allows it on the top-level carousel container
- Added `collaborators` to the carousel container creation request where it belongs

Fixes #1405

## Test plan

- [ ] Create a carousel post (multiple images) with collaborators set
- [ ] Verify the collaborators param is NOT sent on individual child item creation requests
- [ ] Verify the collaborators param IS sent on the carousel container creation request
- [ ] Verify single image/video posts with collaborators still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)