### PR TITLE
fix: agent chat history fails to load — Mastra message format mismatch

### DIFF
--- a/apps/backend/src/api/routes/copilot.controller.ts
+++ b/apps/backend/src/api/routes/copilot.controller.ts
@@ -123,12 +123,42 @@ export class CopilotController {
     const mastra = await this._mastraService.mastra();
     const memory = await mastra.getAgent('postiz').getMemory();
     try {
-      return await memory.recall({
+      const recalled = await memory.recall({
         resourceId: organization.id,
         threadId,
       });
+
+      // Transform Mastra memory messages into the CopilotKit uiMessages
+      // format that the frontend LoadMessages component expects.
+      // Mastra stores message content as an object { format, parts, content }
+      // but CopilotKit's TextMessage requires content as a plain string.
+      const messages = recalled.messages || [];
+      const uiMessages = messages.map((msg: any) => {
+        let textContent = '';
+        if (typeof msg.content === 'string') {
+          textContent = msg.content;
+        } else if (msg.content && typeof msg.content === 'object') {
+          if (typeof msg.content.content === 'string') {
+            textContent = msg.content.content;
+          } else if (Array.isArray(msg.content.parts)) {
+            textContent = msg.content.parts
+              .filter((p: any) => p.type === 'text')
+              .map((p: any) => p.text)
+              .join('\n');
+          }
+        }
+
+        return {
+          id: msg.id,
+          content: textContent,
+          role: msg.role,
+          createdAt: msg.createdAt,
+        };
+      });
+
+      return { uiMessages };
     } catch (err) {
-      return { messages: [] };
+      return { uiMessages: [] };
     }
   }
 


### PR DESCRIPTION
## Problem

Clicking on a previous agent conversation in the sidebar never loads the chat history — it always shows the default welcome message instead of the actual conversation.

## Root Cause

The `getMessagesList` endpoint (`GET /copilot/:thread/list`) returns the raw output from Mastra's `memory.recall()`, which has two issues:

1. **Wrong response key**: Returns `{ messages: [...] }` but the frontend `LoadMessages` component reads `data.uiMessages`
2. **Wrong content format**: Mastra stores message content as a structured object (`{ format: 2, parts: [{ type: 'text', text: '...' }], content: '...' }`), but CopilotKit's `TextMessage` constructor expects `content` as a plain string

The frontend code in `agent.chat.tsx`:
```ts
const data = await (await fetch(`/copilot/${idToSet}/list`)).json();
setMessages(
  data.uiMessages.map((p: any) => {
    return new TextMessage({ content: p.content, role: p.role });
  })
);
```

Since `data.uiMessages` is `undefined` (the backend returns `messages`, not `uiMessages`), the `.map()` call throws and the chat falls back to the welcome message.

## Fix

Transform the Mastra memory response in the backend controller to match what the frontend expects:
- Extract text content from Mastra's structured format into a plain string
- Return `{ uiMessages: [...] }` with the correct key
- Handle both string content (future-proofing) and structured Mastra content objects

## Testing

Verified on a live Postiz instance with ~20 agent conversations containing Mastra-formatted messages. After the fix, clicking any thread in the sidebar correctly loads and displays the full conversation history with proper user/assistant message styling.