### PR TITLE
fix: pass actual HTTP status to handleErrors in runInConcurrent catch block

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -79,7 +79,7 @@ export abstract class SocialAbstract {
     try {
       value = await func();
     } catch (err) {
-      const handle = this.handleErrors(safeStringify(err), 200);
+      const handle = this.handleErrors(safeStringify(err), err?.status || err?.response?.status || 0);
       value = { err: true, value: 'Unknown Error', ...(handle || {}) };
     }
 


### PR DESCRIPTION
Fixes #1413

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The `runInConcurrent` catch block in `social.abstract.ts` (line 82) passes a hardcoded `200` as the HTTP status to `handleErrors()`:

```typescript
const handle = this.handleErrors(safeStringify(err), 200);
```

This prevents status-based error handling from working in downstream providers. Specifically, it breaks Facebook's 401 handling added in v2.21.6 — `facebook.provider.ts` checks `if (status === 401)` to return a user-friendly error, but this branch is unreachable through `runInConcurrent` since it always receives `200`.

The separate `fetch()` method at line 125 correctly passes `request.status`, so this bug only affects the `runInConcurrent` code path.

# What does this PR do?

Extracts the real HTTP status from the caught error object (`err.status` or `err.response.status`) and passes it to `handleErrors()`, with a fallback to `0` for errors without a status.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue.