### PR TITLE
fix(reddit): use replaceAll for subreddit path normalization

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -222,7 +222,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
             }
           : {}),
         text: post.message,
-        sr: firstPostSettings.value.subreddit.replace('/r/', '').toLowerCase(),
+        sr: firstPostSettings.value.subreddit.replaceAll('/r/', '').toLowerCase(),
       };
 
       const all = await (


### PR DESCRIPTION
Fixes #1416

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The subreddit normalization in reddit.provider.ts uses String.replace with a string argument, which only removes the first occurrence. Switching to replaceAll ensures all occurrences are removed for correct normalization.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue.