### PR TITLE
fix: cap token refresh retry loop in public API triggerIntegrationTool

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -435,7 +435,8 @@ export class PublicIntegrationsController {
       throw new HttpException({ msg: 'Tool not found' }, 404);
     }
 
-    while (true) {
+    const MAX_REFRESH_RETRIES = 5;
+    for (let attempt = 0; attempt < MAX_REFRESH_RETRIES; attempt++) {
       try {
         // @ts-ignore
         const result = await integrationProvider[body.methodName](


### PR DESCRIPTION
Fixes #1414

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The triggerIntegrationTool method uses an unbounded while-true loop for token refresh retries. If the refresh succeeds but the API call keeps failing with the same error, this loop runs indefinitely and blocks the worker thread.

The orchestrator workflow already caps the same pattern at 5 retries. This fix applies the same bound to the public API controller for consistency.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue.