### PR TITLE
fix: sanitize r2.uploader responses to prevent internal metadata exposure

### DIFF
--- a/libraries/nestjs-libraries/src/upload/r2.uploader.ts
+++ b/libraries/nestjs-libraries/src/upload/r2.uploader.ts
@@ -160,7 +160,7 @@ export async function prepareUploadParts(req: Request, res: Response) {
       response.presignedUrls[part.number] = url;
     } catch (err) {
       console.log('Error', err);
-      return res.status(500).json(err);
+      return res.status(500).json({ source: { status: 500 } });
     }
   }
 
@@ -182,7 +182,7 @@ export async function listParts(req: Request, res: Response) {
     return res.status(200).json(response['Parts']);
   } catch (err) {
     console.log('Error', err);
-    return res.status(500).json(err);
+    return res.status(500).json({ source: { status: 500 } });
   }
 }
 
@@ -231,14 +231,14 @@ export async function completeMultipartUpload(req: Request, res: Response) {
         .json({ message: 'File contents do not match declared type.' });
     }
 
-    response.Location =
+    const location =
       process.env.CLOUDFLARE_BUCKET_URL +
       '/' +
       response?.Location?.split('/').at(-1);
-    return response;
+    return res.status(200).json({ location });
   } catch (err) {
     console.log('Error', err);
-    return res.status(500).json(err);
+    return res.status(500).json({ source: { status: 500 } });
   }
 }
 


### PR DESCRIPTION
Fixes #1415

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

Two issues in `r2.uploader.ts`:

**1. Success path returns raw SDK object (line 238)**

`completeMultipartUpload` uses `return response` after file-type validation, returning the raw `CompleteMultipartUploadCommandOutput` AWS SDK object. This exposes internal S3 metadata (`Bucket`, `Key`, `RequestId`, `ETag`, `ServerSideEncryption`) to the client. It also bypasses Express response handling since `res.json()` is not called.

**2. Error paths leak raw error objects (lines 163, 185, 241)**

Three error handlers use `res.status(500).json(err)` which serializes the full AWS SDK error object, potentially exposing endpoint URLs, bucket names, request IDs, and stack traces.

By contrast, `createMultipartUpload` (line 135) already correctly uses `res.status(500).json({ source: { status: 500 } })`.

# What does this PR do?

- Success path: Returns only `{ location }` via `res.status(200).json()`, consistent with the existing `createMultipartUpload` response format
- Error paths: Sanitizes to `{ source: { status: 500 } }`, consistent with `createMultipartUpload`

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue.