### PR TITLE
fix: pass actual HTTP status to handleErrors in runInConcurrent

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -79,7 +79,7 @@ export abstract class SocialAbstract {
     try {
       value = await func();
     } catch (err) {
-      const handle = this.handleErrors(safeStringify(err), 200);
+      const handle = this.handleErrors(safeStringify(err), err?.status || err?.response?.status || 0);
       value = { err: true, value: 'Unknown Error', ...(handle || {}) };
     }
 


### PR DESCRIPTION
Fixes #1413

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The catch block in runInConcurrent always passes 200 as the status parameter to handleErrors, regardless of the actual HTTP error code. This prevents providers from handling specific status codes — for example, the Facebook provider's 401 branch is unreachable through this path.

The fetch method correctly passes the real status. This one-line fix aligns runInConcurrent with that behavior.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue.