### PR TITLE
fix: sanitize r2.uploader responses to prevent internal metadata exposure

### DIFF
--- a/libraries/nestjs-libraries/src/upload/r2.uploader.ts
+++ b/libraries/nestjs-libraries/src/upload/r2.uploader.ts
@@ -160,7 +160,7 @@ export async function prepareUploadParts(req: Request, res: Response) {
       response.presignedUrls[part.number] = url;
     } catch (err) {
       console.log('Error', err);
-      return res.status(500).json(err);
+      return res.status(500).json({ source: { status: 500 } });
     }
   }
 
@@ -182,7 +182,7 @@ export async function listParts(req: Request, res: Response) {
     return res.status(200).json(response['Parts']);
   } catch (err) {
     console.log('Error', err);
-    return res.status(500).json(err);
+    return res.status(500).json({ source: { status: 500 } });
   }
 }
 
@@ -231,14 +231,14 @@ export async function completeMultipartUpload(req: Request, res: Response) {
         .json({ message: 'File contents do not match declared type.' });
     }
 
-    response.Location =
+    const location =
       process.env.CLOUDFLARE_BUCKET_URL +
       '/' +
       response?.Location?.split('/').at(-1);
-    return response;
+    return res.status(200).json({ location });
   } catch (err) {
     console.log('Error', err);
-    return res.status(500).json(err);
+    return res.status(500).json({ source: { status: 500 } });
   }
 }
 


### PR DESCRIPTION
Fixes #1415

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

The completeMultipartUpload success path returns the raw AWS SDK response object directly instead of calling res.json(), exposing internal S3 metadata to the client. Three error handlers also serialize full error objects, potentially leaking endpoint URLs and stack traces.

The createMultipartUpload function already handles both cases correctly — this fix applies the same pattern to the other functions.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue.