### PR TITLE
feat:Support PDF/document uploads for LinkedIn carousel posts via API

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -47,6 +47,7 @@ const PUBLIC_API_ALLOWED_MIME = new Set<string>([
   'image/bmp',
   'image/tiff',
   'video/mp4',
+  'application/pdf',
 ]);
 import * as Sentry from '@sentry/nestjs';
 import { socialIntegrationList, IntegrationManager } from '@gitroom/nestjs-libraries/integrations/integration.manager';

--- a/libraries/helpers/src/utils/valid.url.path.ts
+++ b/libraries/helpers/src/utils/valid.url.path.ts
@@ -13,14 +13,15 @@ export class ValidUrlExtension implements ValidatorConstraintInterface {
       !!text?.split?.('?')?.[0].endsWith('.jpeg') ||
       !!text?.split?.('?')?.[0].endsWith('.gif') ||
       !!text?.split?.('?')?.[0].endsWith('.webp') ||
-      !!text?.split?.('?')?.[0].endsWith('.mp4')
+      !!text?.split?.('?')?.[0].endsWith('.mp4') ||
+      !!text?.split?.('?')?.[0].endsWith('.pdf')
     );
   }
 
   defaultMessage(args: ValidationArguments) {
     // here you can provide default error message if validation failed
     return (
-      'File must have a valid extension: .png, .jpg, .jpeg, .gif, .webp, or .mp4'
+      'File must have a valid extension: .png, .jpg, .jpeg, .gif, .webp, .mp4, or .pdf'
     );
   }
 }


### PR DESCRIPTION
Feature Request
Summary
Add support for PDF document uploads in the POST /public/v1/posts API endpoint for LinkedIn integrations, enabling LinkedIn carousel/document posts.

Current Behaviour
The /public/v1/posts API only accepts image/video attachments (.png, .jpg, .jpeg, .gif, .webp, .mp4). Uploading a PDF via /public/v1/upload works, but passing the resulting file reference in a post payload returns:

{
  "message": ["posts.0.value.0.image.0.File must have a valid extension: .png, .jpg, .jpeg, .gif, .webp, or .mp4"],
  "error": "Bad Request",
  "statusCode": 400
}
Desired Behaviour
Allow .pdf as a valid file type in the post payload for LinkedIn integrations
Pass the PDF to LinkedIn's native document/carousel upload flow (LinkedIn supports PDF uploads as document posts with slide pagination)
Optionally expose a type: "document" field in the post payload to distinguish from image posts
Why This Matters
LinkedIn document/carousel posts (PDF uploads) consistently outperform standard image posts in reach and engagement. They display with a "1/N pages" pagination UI that drives click-through. Many users want to schedule these via API automation rather than manually through the UI.

LinkedIn API Reference
LinkedIn supports document uploads via the Assets API — the upload registers a urn:li:digitalmediaAsset which is then referenced in the post share payload with media.mediaType: "document".

Platform
LinkedIn integration
API: POST /public/v1/posts
Upload: POST /public/v1/upload

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X]  I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X]  I confirm I have not used AI to submit this PR or generate code for it.
- [X]  I checked that there were not similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
