### PR TITLE
fix(instagram): stop doubling analytics values (likes/views/comments/shares/saves/replies)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -831,18 +831,24 @@ export class InstagramProvider
       })) || [])
     );
 
+    // Instagram Graph API exposes `likes,views,comments,shares,saves,replies`
+    // only as `metric_type=total_value` (single aggregate over the window).
+    // The frontend widget sums data[].total to render the big number, so we
+    // emit a zero-valued start point and a single end point carrying the real
+    // total. This keeps the line chart renderable (two points) while the sum
+    // still equals the true total_value.
     analytics.push(
       ...data2.map((d: any) => ({
         label: this.setTitle(d.name),
         percentageChange: 5,
         data: [
           {
-            total: d.total_value.value,
-            date: dayjs().format('YYYY-MM-DD'),
+            total: 0,
+            date: dayjs.unix(since).format('YYYY-MM-DD'),
           },
           {
             total: d.total_value.value,
-            date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
+            date: dayjs().format('YYYY-MM-DD'),
           },
         ],
       }))


### PR DESCRIPTION
Fixes #1436

### Problem
The six Instagram account-level metrics that use `metric_type=total_value` (`likes`, `views`, `comments`, `shares`, `saves`, `replies`) were displayed at exactly **2× the real value** on the Analytics screen. Full reproduction and numbers in the linked issue.

### Root cause
`instagram.provider.ts` pushed the same `total_value.value` twice in the `data` array so the chart would render two points:

```ts
data: [
  { total: d.total_value.value, date: dayjs().format('YYYY-MM-DD') },
  { total: d.total_value.value, date: dayjs().add(1, 'day').format('YYYY-MM-DD') },
]
```

The widget in `render.analytics.tsx` sums `data[].total` to render the big number:

```ts
data.reduce((acc, curr) => acc + curr.total, 0)
```

Result: every such metric is displayed at 2×.

### API limitation
`likes/views/comments/shares/saves/replies` are only available as `metric_type=total_value` on the account-level Insights endpoint; `metric_type=time_series` returns an empty `data` array for them. Using time-series here is not an option.

### Fix
Keep two data points so the chart still renders a line, but set the first point to `0` at the start of the window and only the second point to the real `total_value.value` at today. The sum now matches the true total, and the chart visually represents "growth over the period" — which is what the widget already conceptually claims to show.

```ts
data: [
  { total: 0,                      date: dayjs.unix(since).format('YYYY-MM-DD') },
  { total: d.total_value.value,    date: dayjs().format('YYYY-MM-DD') },
]
```

### Not changed
- `reach` / `follower_count` path — already correct (uses time-series).
- `instagram.standalone.provider.ts` — already delegates to `instagramProvider.analytics`, so the fix applies to both providers.
- `postAnalytics` path — different endpoint (`/media/{id}/insights`), not affected.

### Verification
Compared Postiz UI after local patch against direct Graph API `total_value` responses — numbers match.