### PR TITLE
fix(threads): wait ~40s before publishing video replies

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -291,9 +291,17 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
   private async publishThread(
     userId: string,
     accessToken: string,
-    creationId: string
+    creationId: string,
+    isVideoReply = false
   ): Promise<{ threadId: string; permalink: string }> {
     await this.checkLoaded(creationId, accessToken);
+
+    // Meta recommends ~30s between video container FINISHED and publish, otherwise
+    // the reply_to_id association may not have propagated and the reply is published
+    // as a standalone top-level post. checkLoaded already waits 2s post-FINISHED.
+    if (isVideoReply) {
+      await timer(38000);
+    }
 
     const { id: threadId } = await (
       await this.fetch(
@@ -417,11 +425,16 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
       replyToId
     );
 
+    const isVideoReply =
+      commentPost.media?.length === 1 &&
+      commentPost.media[0].path.indexOf('.mp4') > -1;
+
     // Publish the reply
     const { threadId: replyThreadId, permalink } = await this.publishThread(
       userId,
       accessToken,
-      replyContentId
+      replyContentId,
+      isVideoReply
     );
 
     return [


### PR DESCRIPTION
Closes #1441.

## Summary

- Video replies on Threads (media containing `.mp4` on a comment post) currently publish as **standalone top-level posts** instead of as replies to the parent thread.
- Root cause: `checkLoaded` waits only 2s after `FINISHED` before calling `/threads_publish`, but Meta's docs recommend ~30s for video containers to fully propagate — including the `reply_to_id` association.
- Fix: plumb an `isVideoReply` flag through `publishThread` and sleep 38s (≈40s total with the existing 2s) before publishing when the comment has a single `.mp4`. Image posts and non-reply video posts are unchanged.

## Test plan

- [x] Build passes (type-checked via `tsc` as part of the existing pipeline)
- [ ] Manual: schedule a Threads main post + video-comment, confirm the comment appears as a reply in Threads
- [ ] Manual: schedule a Threads main post + image-comment, confirm no regression (should still publish with existing timing)
- [ ] Manual: schedule a standalone video Threads post, confirm no regression

## References

- Meta docs: https://developers.facebook.com/docs/threads/retrieve-and-manage-replies/create-replies/ — "wait an average of 30 seconds before publishing Threads video content containers"
- Issue: #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)