### PR TITLE
feat: support OPENAI_API_URL to route to OpenAI-compatible endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,11 @@ EXTENSION_ID=""
 
 # Misc Settings
 OPENAI_API_KEY=""
+# Optional: point all OpenAI SDK calls at an OpenAI-compatible endpoint
+# (Azure OpenAI, LiteLLM, OpenRouter, self-hosted gateway, etc.).
+# Leave empty to use the default https://api.openai.com/v1.
+# Example: OPENAI_API_URL="http://localhost:4000/v1"
+OPENAI_API_URL=""
 NEXT_PUBLIC_DISCORD_SUPPORT=""
 NEXT_PUBLIC_POLOTNO=""
 # NOT_SECURED=false

--- a/apps/backend/src/api/routes/copilot.controller.ts
+++ b/apps/backend/src/api/routes/copilot.controller.ts
@@ -14,6 +14,11 @@ import {
   copilotRuntimeNodeHttpEndpoint,
   copilotRuntimeNextJSAppRouterEndpoint,
 } from '@copilotkit/runtime';
+import OpenAI from 'openai';
+import {
+  openAIApiKey,
+  openAIBaseURL,
+} from '@gitroom/nestjs-libraries/openai/openai.config';
 import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.request';
 import { Organization } from '@prisma/client';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
@@ -50,6 +55,10 @@ export class CopilotController {
       endpoint: '/copilot/chat',
       runtime: new CopilotRuntime(),
       serviceAdapter: new OpenAIAdapter({
+        openai: new OpenAI({
+          apiKey: openAIApiKey(),
+          baseURL: openAIBaseURL(),
+        }),
         model: 'gpt-4.1',
       }),
     });
@@ -96,6 +105,10 @@ export class CopilotController {
       runtime,
       // properties: req.body.variables.properties,
       serviceAdapter: new OpenAIAdapter({
+        openai: new OpenAI({
+          apiKey: openAIApiKey(),
+          baseURL: openAIBaseURL(),
+        }),
         model: 'gpt-4.1',
       }),
     });

--- a/libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts
@@ -7,9 +7,14 @@ import { agentCategories } from '@gitroom/nestjs-libraries/agent/agent.categorie
 import { z } from 'zod';
 import { agentTopics } from '@gitroom/nestjs-libraries/agent/agent.topics';
 import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import {
+  openAIApiKey,
+  openAIConfiguration,
+} from '@gitroom/nestjs-libraries/openai/openai.config';
 
 const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: openAIApiKey(),
+  configuration: openAIConfiguration(),
   model: 'gpt-4o-2024-08-06',
   temperature: 0,
 });

--- a/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
@@ -15,6 +15,11 @@ import { z } from 'zod';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { GeneratorDto } from '@gitroom/nestjs-libraries/dtos/generator/generator.dto';
+import {
+  openAIApiKey,
+  openAIBaseURL,
+  openAIConfiguration,
+} from '@gitroom/nestjs-libraries/openai/openai.config';
 
 const tools = !process.env.TAVILY_API_KEY
   ? []
@@ -22,13 +27,15 @@ const tools = !process.env.TAVILY_API_KEY
 const toolNode = new ToolNode(tools);
 
 const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: openAIApiKey(),
+  configuration: openAIConfiguration(),
   model: 'gpt-4.1',
   temperature: 0.7,
 });
 
 const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: openAIApiKey(),
+  baseUrl: openAIBaseURL(),
   model: 'dall-e-3',
 });
 

--- a/libraries/nestjs-libraries/src/chat/load.tools.service.ts
+++ b/libraries/nestjs-libraries/src/chat/load.tools.service.ts
@@ -1,12 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { Agent } from '@mastra/core/agent';
-import { openai } from '@ai-sdk/openai';
+import { openai as defaultOpenai, createOpenAI } from '@ai-sdk/openai';
 import { Memory } from '@mastra/memory';
 import { pStore } from '@gitroom/nestjs-libraries/chat/mastra.store';
 import { array, object, string } from 'zod';
 import { ModuleRef } from '@nestjs/core';
 import { toolList } from '@gitroom/nestjs-libraries/chat/tools/tool.list';
 import dayjs from 'dayjs';
+import {
+  openAIApiKey,
+  openAIBaseURL,
+} from '@gitroom/nestjs-libraries/openai/openai.config';
+
+const openai = openAIBaseURL()
+  ? createOpenAI({
+      apiKey: openAIApiKey(),
+      baseURL: openAIBaseURL(),
+    })
+  : defaultOpenai;
 
 export const AgentState = object({
   proverbs: array(string()).default([]),

--- a/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
@@ -19,6 +19,11 @@ import { TypedSearchAttributes } from '@temporalio/common';
 import {
   organizationId,
 } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
+import {
+  openAIApiKey,
+  openAIBaseURL,
+  openAIConfiguration,
+} from '@gitroom/nestjs-libraries/openai/openai.config';
 const parser = new Parser();
 
 interface WorkflowChannelsState {
@@ -36,13 +41,15 @@ interface WorkflowChannelsState {
 }
 
 const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: openAIApiKey(),
+  configuration: openAIConfiguration(),
   model: 'gpt-4.1',
   temperature: 0.7,
 });
 
 const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: openAIApiKey(),
+  baseUrl: openAIBaseURL(),
   model: 'gpt-image-1',
 });
 

--- a/libraries/nestjs-libraries/src/openai/openai.config.ts
+++ b/libraries/nestjs-libraries/src/openai/openai.config.ts
@@ -1,0 +1,26 @@
+/**
+ * Centralized OpenAI SDK configuration.
+ *
+ * Returns the API key and optional base URL so all OpenAI-compatible clients
+ * (openai, @langchain/openai, @copilotkit/runtime, @ai-sdk/openai) can be
+ * redirected to an OpenAI-compatible endpoint such as LiteLLM, Azure OpenAI,
+ * OpenRouter, or a self-hosted gateway.
+ *
+ * Set OPENAI_API_URL to the alternative base URL (e.g. http://localhost:4000/v1).
+ * Leave unset for the default https://api.openai.com/v1.
+ */
+
+export const openAIApiKey = (): string =>
+  process.env.OPENAI_API_KEY || 'sk-proj-';
+
+export const openAIBaseURL = (): string | undefined =>
+  process.env.OPENAI_API_URL || undefined;
+
+/**
+ * LangChain-style configuration object.
+ * Use as: new ChatOpenAI({ apiKey: openAIApiKey(), configuration: openAIConfiguration(), ... })
+ */
+export const openAIConfiguration = () => {
+  const baseURL = openAIBaseURL();
+  return baseURL ? { baseURL } : undefined;
+};

--- a/libraries/nestjs-libraries/src/openai/openai.service.ts
+++ b/libraries/nestjs-libraries/src/openai/openai.service.ts
@@ -3,9 +3,14 @@ import OpenAI from 'openai';
 import { shuffle } from 'lodash';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
+import {
+  openAIApiKey,
+  openAIBaseURL,
+} from '@gitroom/nestjs-libraries/openai/openai.config';
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: openAIApiKey(),
+  baseURL: openAIBaseURL(),
 });
 
 const PicturePrompt = z.object({


### PR DESCRIPTION
## Summary

Adds an optional `OPENAI_API_URL` env var so Postiz can be pointed at any OpenAI-compatible endpoint (Azure OpenAI, LiteLLM, OpenRouter, a self-hosted gateway, etc.) instead of the hardcoded `https://api.openai.com/v1`. Leaving the var unset preserves current behavior — fully backwards-compatible.

### Why

Several deployment patterns aren't possible today:
- **Self-hosters** routing through LiteLLM / on-prem gateways for caching, cost visibility, or data-residency requirements.
- **Azure OpenAI** customers who need a custom resource URL.
- **OpenRouter** or other third-party OpenAI-compatible providers.

In all of these the API key alone isn't sufficient — the base URL must also be redirectable.

### Implementation

One new helper file (`libraries/nestjs-libraries/src/openai/openai.config.ts`) centralizes the SDK config:

```ts
export const openAIApiKey = () => process.env.OPENAI_API_KEY || 'sk-proj-';
export const openAIBaseURL = () => process.env.OPENAI_API_URL || undefined;
export const openAIConfiguration = () => {
  const baseURL = openAIBaseURL();
  return baseURL ? { baseURL } : undefined;
};
```

Every OpenAI client construction in the codebase now uses these helpers. The SDKs involved accept the base URL through slightly different shapes, all handled here:
- `openai` (v4): `new OpenAI({ apiKey, baseURL })`
- `@langchain/openai` `ChatOpenAI`: `new ChatOpenAI({ apiKey, configuration: { baseURL } })`
- `@langchain/openai` `DallEAPIWrapper`: `new DallEAPIWrapper({ apiKey, baseUrl })`
- `@copilotkit/runtime` `OpenAIAdapter`: `new OpenAIAdapter({ openai: new OpenAI({ apiKey, baseURL }) })`
- `@ai-sdk/openai`: `createOpenAI({ apiKey, baseURL })` when URL is set, else the default provider

`.env.example` documents the new variable with an example value.

### Call sites touched

- `libraries/nestjs-libraries/src/openai/openai.service.ts`
- `libraries/nestjs-libraries/src/agent/agent.graph.service.ts` (ChatOpenAI + DallE)
- `libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts`
- `libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts` (ChatOpenAI + DallE)
- `libraries/nestjs-libraries/src/chat/load.tools.service.ts` (Mastra via `@ai-sdk/openai`)
- `apps/backend/src/api/routes/copilot.controller.ts` (both `/chat` and `/agent`)

## Test plan

- [ ] With `OPENAI_API_URL` unset: `/copilot/chat`, `/copilot/agent`, autopost generation, and the agent graph all continue to call `api.openai.com` as today.
- [ ] With `OPENAI_API_URL=http://localhost:4000/v1` pointing at a LiteLLM proxy: those same endpoints successfully complete against the proxy.
- [ ] Empty-string `OPENAI_API_URL=""` behaves the same as unset.