### PR TITLE
fix: use global regex for subreddit normalization

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -222,7 +222,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
             }
           : {}),
         text: post.message,
-        sr: firstPostSettings.value.subreddit.replace('/r/', '').toLowerCase(),
+        sr: firstPostSettings.value.subreddit.replace(/\/r\//g, '').toLowerCase(),
       };
 
       const all = await (


### PR DESCRIPTION
## Fix

The subreddit normalization in `reddit.provider.ts` used `String.replace('/r/', '')` which only replaces the first occurrence. 

If a subreddit value contains `/r/` more than once (e.g. from malformed input), the second occurrence would not be stripped.

Changed to `replace(/\/r\//g, '')` to replace all occurrences globally.

**Before:** `'/r/test/r/other'.replace('/r/', '')` → `'test/r/other'`
**After:** `'/r/test/r/other'.replace(/\/r\//g, '')` → `'testother'`

Fixes #1416

## Testing
- Single `/r/` prefix works as before
- Multiple `/r/` occurrences now all stripped
- No other changes to the reddit provider