### PR TITLE
fix: remove processing GIF via sharp in linkedin

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -478,14 +478,13 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
 
   private async prepareMediaBuffer(mediaUrl: string): Promise<Buffer> {
     const isVideo = mediaUrl.indexOf('mp4') > -1;
+    const isGif = lookup(mediaUrl) === 'image/gif';
 
-    if (isVideo) {
+    if (isVideo || isGif) {
       return Buffer.from(await readOrFetch(mediaUrl));
     }
 
-    return await sharp(await readOrFetch(mediaUrl), {
-      animated: lookup(mediaUrl) === 'image/gif',
-    })
+    return await sharp(await readOrFetch(mediaUrl), { animated: false })
       .toFormat('jpeg')
       .resize({ width: 1000 })
       .toBuffer();


### PR DESCRIPTION
# What kind of change does this PR introduce?
Update the LinkedIn provider to make it such that GIF images won't be processed via sharp

# Why was this change needed?
Previously, all the GIF images were being converted to JPEG with all frames shown in a single long image
<img width="560" height="707" alt="Screenshot 2026-05-04 at 8 14 16 AM" src="https://github.com/user-attachments/assets/af846b68-29bb-451c-b4c7-cf999961743a" />


# Other information:
N/A

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were not similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue (do not include multiple issues or types of change in the same PR) For example, don't try and fix a UI issue and include new dependencies in the same PR.
