### PR TITLE
ui: update the modal such that for long text won't cause overflow

### DIFF
--- a/apps/frontend/src/components/launches/import-debug-post.modal.tsx
+++ b/apps/frontend/src/components/launches/import-debug-post.modal.tsx
@@ -147,7 +147,7 @@ export const ImportDebugPostModal: FC<{ close: () => void }> = ({ close }) => {
             <div className="text-[13px] font-[600] text-textColor">
               {t('debug_info', 'Debug Info')}
             </div>
-            <div className="text-[12px] text-textColor/70 flex flex-col gap-[4px]">
+            <div className="text-[12px] text-textColor/70 flex flex-col gap-[4px] min-w-0 break-all">
               <div>
                 <span className="font-[500]">
                   {t('provider', 'Provider')}:
@@ -175,7 +175,7 @@ export const ImportDebugPostModal: FC<{ close: () => void }> = ({ close }) => {
                   <span className="font-[500]">
                     {t('error_details', 'Error Details')}:
                   </span>
-                  <div className="mt-[4px] max-h-[100px] overflow-y-auto bg-newBgColor p-[8px] rounded-[4px] text-[11px] font-mono">
+                  <div className="mt-[4px] max-h-[100px] overflow-y-auto bg-newBgColor p-[8px] rounded-[4px] text-[11px] font-mono break-all whitespace-pre-wrap">
                     {parsed._debug.errors.map((err, i) => (
                       <div key={i} className="mb-[4px]">
                         [{err.platform}] {err.message}

--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -433,6 +433,7 @@ const ImportDebugPost = () => {
   const handleClick = useCallback(() => {
     openModal({
       title: t('import_debug_post', 'Import Debug Post'),
+      maxSize: 800,
       children: (close) => <ImportDebugPostModal close={close} />,
     });
   }, []);

--- a/apps/frontend/src/components/layout/new-modal.tsx
+++ b/apps/frontend/src/components/layout/new-modal.tsx
@@ -31,6 +31,7 @@ interface OpenModalInterface {
     modal?: string;
   };
   size?: string | number;
+  maxSize?: string | number;
   height?: string | number;
   id?: string;
 }
@@ -200,10 +201,11 @@ export const Component: FC<{
                 modal.size ? '' : 'min-w-[600px]',
                 modal.fullScreen && 'h-full'
               )}
-              {...((!!modal.size || !!modal.height) && {
+              {...((!!modal.size || !!modal.height || !!modal.maxSize) && {
                 style: {
                   ...(modal.size ? { width: modal.size } : {}),
                   ...(modal.height ? { height: modal.height } : {}),
+                  ...(modal.maxSize ? { maxWidth: modal.maxSize } : {}),
                 },
               })}
               onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
# What kind of change does this PR introduce?
UI fix

# Why was this change needed?
The modal for debugging for getting unnecessary horizontal scroll with extremely long text without any breaks.

# Other information:
N/A

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
