### PR TITLE
feat: update notification list to be scrollable and added time

### DIFF
--- a/apps/frontend/src/components/layout/set.timezone.tsx
+++ b/apps/frontend/src/components/layout/set.timezone.tsx
@@ -3,8 +3,10 @@ import dayjs, { ConfigType } from 'dayjs';
 import { FC, useEffect } from 'react';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
+import relativeTime from 'dayjs/plugin/relativeTime';
 dayjs.extend(timezone);
 dayjs.extend(utc);
+dayjs.extend(relativeTime);
 
 const { utc: originalUtc } = dayjs;
 

--- a/apps/frontend/src/components/notifications/notification.component.tsx
+++ b/apps/frontend/src/components/notifications/notification.component.tsx
@@ -4,6 +4,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import useSWR from 'swr';
 import { FC, useCallback, useState } from 'react';
 import clsx from 'clsx';
+import dayjs from 'dayjs';
 import { useClickAway } from '@uidotdev/usehooks';
 import ReactLoading from '@gitroom/frontend/components/layout/loading';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
@@ -26,16 +27,29 @@ export const ShowNotification: FC<{
   const [newNotification] = useState(
     new Date(notification.createdAt) > new Date(props.lastReadNotification)
   );
+  const createdAt = dayjs(notification.createdAt);
+  const isWithin24h = dayjs().diff(createdAt, 'hour') < 24;
+  const fullDate = createdAt.format('MMM D, YYYY h:mm A');
   return (
     <div
       className={clsx(
-        `text-textColor px-[16px] py-[10px] border-b border-tableBorder last:border-b-0 transition-colors overflow-hidden text-ellipsis`,
+        `text-textColor px-[16px] py-[10px] border-b border-tableBorder last:border-b-0 transition-colors`,
         newNotification && 'font-bold bg-seventh animate-newMessages'
       )}
-      dangerouslySetInnerHTML={{
-        __html: replaceLinks(notification.content),
-      }}
-    />
+    >
+      <div
+        className="break-words"
+        dangerouslySetInnerHTML={{
+          __html: replaceLinks(notification.content),
+        }}
+      />
+      <div
+        className="text-[11px] mt-[4px] opacity-60 font-normal"
+        title={isWithin24h ? fullDate : undefined}
+      >
+        {isWithin24h ? createdAt.fromNow() : fullDate}
+      </div>
+    </div>
   );
 };
 export const NotificationOpenComponent = () => {
@@ -57,7 +71,7 @@ export const NotificationOpenComponent = () => {
         {t('notifications', 'Notifications')}
       </div>
 
-      <div className="flex flex-col">
+      <div className="flex flex-col max-h-[400px] overflow-y-auto scrollbar scrollbar-thumb-fifth scrollbar-track-newBgColor">
         {isLoading && (
           <div className="flex-1 flex justify-center pt-12">
             <ReactLoading type="spin" color="#fff" width={36} height={36} />


### PR DESCRIPTION
# What kind of change does this PR introduce?
Improvement in the notification section

# Why was this change needed?
The notification dropdown would not be scrollable when we get lots of new notifications, making the UI messy. Also, it was very uncertain when a notification was received, last hour, 1 day back, or 1 year back?

# Other information:
<img width="457" height="539" alt="Screenshot 2026-05-04 at 7 00 09 PM" src="https://github.com/user-attachments/assets/a5059884-bdb6-4dad-a278-b260418bd55d" />


# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue 
