### PR TITLE
fix: update tiktok provider to properly use this.fetch

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -246,7 +246,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
 
     const { access_token, refresh_token, ...all } = await (
-      await fetch('https://open.tiktokapis.com/v2/oauth/token/', {
+      await this.fetch('https://open.tiktokapis.com/v2/oauth/token/', {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
@@ -260,7 +260,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
         user: { avatar_url, display_name, open_id, username },
       },
     } = await (
-      await fetch(
+      await this.fetch(
         'https://open.tiktokapis.com/v2/user/info/?fields=open_id,avatar_url,display_name,union_id,username',
         {
           method: 'GET',
@@ -323,7 +323,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
 
     const { access_token, refresh_token, scope } = await (
-      await fetch('https://open.tiktokapis.com/v2/oauth/token/', {
+      await this.fetch('https://open.tiktokapis.com/v2/oauth/token/', {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
@@ -339,7 +339,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
         user: { avatar_url, display_name, open_id, username },
       },
     } = await (
-      await fetch(
+      await this.fetch(
         'https://open.tiktokapis.com/v2/user/info/?fields=open_id,avatar_url,display_name,union_id,username',
         {
           method: 'GET',
@@ -365,7 +365,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     const {
       data: { max_video_post_duration_sec },
     } = await (
-      await fetch(
+      await this.fetch(
         'https://open.tiktokapis.com/v2/post/publish/creator_info/query/',
         {
           method: 'POST',


### PR DESCRIPTION
# What kind of change does this PR introduce?
Improvement to the TikTok provider to ensure errors are better cached

# Why was this change needed?
Some of the fetches within the TikTok provider didn't use `this.fetch`, which had a potential scope for failure where the errors wouldn't be properly cached.

# Other information:
N/A

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
