### PR TITLE
public-api: add POST /media/information for alt-text

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -22,6 +22,7 @@ import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/po
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
+import { SaveMediaInformationDto } from '@gitroom/nestjs-libraries/dtos/media/save.media.information.dto';
 import { GetPostsDto } from '@gitroom/nestjs-libraries/dtos/posts/get.posts.dto';
 import { ChangePostStatusDto } from '@gitroom/nestjs-libraries/dtos/posts/change.post.status.dto';
 import {
@@ -505,4 +506,13 @@ export class PublicIntegrationsController {
       }
     }
   }
+
+  @Post('/media/information')
+  saveMediaInformation(
+    @GetOrgFromRequest() org: Organization,
+    @Body() body: SaveMediaInformationDto
+  ) {
+    return this._mediaService.saveMediaInformation(org.id, body);
+  }
+
 }


### PR DESCRIPTION
## Problem

The authenticated controller (`apps/backend/src/api/routes/media.controller.ts`) already exposes `POST /media/information`, which sets `Media.alt`, `Media.thumbnail`, and `Media.thumbnailTimestamp` via `_mediaService.saveMediaInformation`. The Public API at `/public/v1` does not expose this endpoint, so API-key callers (automation, integrations, MCP servers) cannot set alt-text on uploaded media without falling back to a private session or direct DB writes.

Alt-text on Instagram posts is required for accessibility (WCAG 2.1 SC 1.1.1) and a major SEO/discovery signal for Google Lens and AI Overviews. Today the only public-API path to a posted image is `POST /upload` -> `POST /posts`; the alt-text field is unreachable.

## Change

Add `POST /public/v1/media/information` mirroring the auth-protected route. `MediaService` is already injected into `PublicIntegrationsController`, so the change is a single route declaration plus one DTO import.

```ts
@Post('/media/information')
saveMediaInformation(
  @GetOrgFromRequest() org: Organization,
  @Body() body: SaveMediaInformationDto
) {
  return this._mediaService.saveMediaInformation(org.id, body);
}
```

Org-scoping is preserved via `@GetOrgFromRequest()` exactly as in the authenticated controller. The DTO (`{ id, alt, thumbnail?, thumbnailTimestamp? }`) is unchanged and already validates inputs.

## Why this and not a different surface

- Adding `alt` as a multipart field on `POST /upload` would also work, but that requires changing `MediaRepository.saveFile`'s signature — an actually-breaking change for every existing storage backend. The information endpoint is purpose-built for this, and the auth controller already uses it.
- A separate `PUT /media/:id` would be inconsistent with the auth API, which uses `POST /media/information`.

## Test

```bash
# 1. Upload a media asset
curl -X POST -H "Authorization: $POSTIZ_API_KEY" -F file=@image.jpg \
  http://localhost:5000/api/public/v1/upload
# -> { "id": "...", "path": "..." }

# 2. Set alt-text
curl -X POST -H "Authorization: $POSTIZ_API_KEY" -H "Content-Type: application/json" \
  -d '{"id":"<id>","alt":"Snusdose Aluminium Pink mit Lasergravur"}' \
  http://localhost:5000/api/public/v1/media/information
# -> { "id": "...", "alt": "Snusdose Aluminium Pink mit Lasergravur", ... }
```

## Use case

We run an MCP server that creates and schedules Instagram posts via the public API. Alt-text was previously a manual step in the Postiz UI for every post — fragile and easy to forget. This route lets the schedule path set alt-text inline as part of the upload + create-post flow. WCAG 2.1 SC 1.1.1 is now satisfied on every automated post.

## Notes

- No new dependencies.
- DTO already exists; only one new import.
- `MediaService` already injected into `PublicIntegrationsController` (used by the existing `/upload` route).
- No migration needed; the `Media.alt` column already exists.
- No breaking changes; this only adds a new route.
