### PR TITLE
lazy load wallet provider on auth page

### DIFF
--- a/apps/frontend/src/components/auth/login.tsx
+++ b/apps/frontend/src/components/auth/login.tsx
@@ -13,8 +13,15 @@ import { OauthProvider } from '@gitroom/frontend/components/auth/providers/oauth
 import { GoogleProvider } from '@gitroom/frontend/components/auth/providers/google.provider';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { FarcasterProvider } from '@gitroom/frontend/components/auth/providers/farcaster.provider';
-import WalletProvider from '@gitroom/frontend/components/auth/providers/wallet.provider';
+import dynamic from "next/dynamic"
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
+
+const WalletProvider = dynamic(
+  () => import ("@gitroom/frontend/components/auth/providers/wallet.provider"),
+  {
+    ssr: false,
+  }
+)
 type Inputs = {
   email: string;
   password: string;


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) before submitting a PR. -->

# What kind of change does this PR introduce?

Performance optimization

# Why was this change needed?

The wallet auth provider imports several Solana wallet-related dependencies that are only needed when wallet authentication is available and used.This change lazy-loads the wallet provider using next/dynamic so those dependencies are not included in the initial auth page render path, helping reduce unnecessary upfront JavaScript execution.


# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?
I’d also be interested in exploring additional auth page optimizations around initial bundle size and render performance in future contributions.
# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x ] I confirm I have not used AI to submit this PR or generate code for it.
- [x ] I checked that there were no similar issues or PRs already open for this.
- [x ] This PR fixes just ONE issue
