### PR TITLE
fix: restore keyboard focus visibility (WCAG 2.4.7)

### DIFF
--- a/apps/frontend/src/app/global.scss
+++ b/apps/frontend/src/app/global.scss
@@ -16,8 +16,14 @@ body {
   color: var(--new-btn-text);
 }
 
-body * {
-  outline: none !important;
+*:focus {
+  outline: none;
+}
+
+*:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .box {


### PR DESCRIPTION
`body * { outline: none !important }` in global.scss kills focus rings for keyboard users.
This makes the app completely unusable without a mouse.

The fix:
- Remove the nuclear `!important` rule
- Add `*:focus { outline: none }` (keeps clean look for mouse clicks)
- Add `*:focus-visible` with a subtle ring (only shows on keyboard nav)

No visual change for mouse users. Keyboard users can finally see where they are.

Tested on Chrome, Firefox, Safari — `focus-visible` has 97%+ browser support.

Made with [Cursor](https://cursor.com)