### PR TITLE
feat: unified inbox — pull Instagram comments into Postiz

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "dev": "dotenv -e ../../.env -- nest start --watch --entryFile=./apps/backend/src/main",
+    "dev": "dotenv -e ../../.env -- node --max-old-space-size=4096 ../../node_modules/.bin/nest start --watch --entryFile=./apps/backend/src/main",
     "build": "cross-env NODE_ENV=production nest build",
     "start": "dotenv -e ../../.env -- node --experimental-require-module ./dist/apps/backend/src/main.js",
     "pm2": "pm2 start pnpm --name backend -- start"

--- a/apps/backend/src/api/api.module.ts
+++ b/apps/backend/src/api/api.module.ts
@@ -6,6 +6,7 @@ import { AuthMiddleware } from '@gitroom/backend/services/auth/auth.middleware';
 import { StripeController } from '@gitroom/backend/api/routes/stripe.controller';
 import { StripeService } from '@gitroom/nestjs-libraries/services/stripe.service';
 import { AnalyticsController } from '@gitroom/backend/api/routes/analytics.controller';
+import { InboxController } from '@gitroom/backend/api/routes/inbox.controller';
 import { PoliciesGuard } from '@gitroom/backend/services/auth/permissions/permissions.guard';
 import { PermissionsService } from '@gitroom/backend/services/auth/permissions/permissions.service';
 import { IntegrationsController } from '@gitroom/backend/api/routes/integrations.controller';
@@ -48,6 +49,7 @@ import { OauthProvider } from '@gitroom/backend/services/auth/providers/oauth.pr
 const authenticatedController = [
   UsersController,
   AnalyticsController,
+  InboxController,
   IntegrationsController,
   SettingsController,
   PostsController,

--- a/apps/backend/src/api/routes/inbox.controller.ts
+++ b/apps/backend/src/api/routes/inbox.controller.ts
@@ -1,0 +1,49 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.request';
+import { Organization } from '@prisma/client';
+import { InboxService } from '@gitroom/nestjs-libraries/database/prisma/inbox/inbox.service';
+
+@ApiTags('Inbox')
+@Controller('/inbox')
+export class InboxController {
+  constructor(private _inboxService: InboxService) {}
+
+  @Get('/count')
+  getUnreadCount(@GetOrgFromRequest() org: Organization) {
+    return this._inboxService.getUnreadCount(org);
+  }
+
+  @Get('/')
+  getItems(
+    @GetOrgFromRequest() org: Organization,
+    @Query('platform') platform?: string,
+    @Query('type') type?: string,
+    @Query('unread') unread?: string,
+    @Query('page') page?: string
+  ) {
+    return this._inboxService.getItems(org, {
+      platform,
+      type,
+      unreadOnly: unread === 'true',
+      page: page ? +page : 0,
+    });
+  }
+
+  @Post('/:id/read')
+  markRead(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string
+  ) {
+    return this._inboxService.markRead(org, id);
+  }
+
+  @Post('/:id/reply')
+  reply(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string,
+    @Body('message') message: string
+  ) {
+    return this._inboxService.reply(org, id, message);
+  }
+}

--- a/apps/backend/src/api/routes/no.auth.integrations.controller.ts
+++ b/apps/backend/src/api/routes/no.auth.integrations.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
+import { InboxService } from '@gitroom/nestjs-libraries/database/prisma/inbox/inbox.service';
 
 @ApiTags('Integrations')
 @Controller('/integrations')
@@ -31,7 +32,8 @@ export class NoAuthIntegrationsController {
     private _integrationManager: IntegrationManager,
     private _integrationService: IntegrationService,
     private _refreshIntegrationService: RefreshIntegrationService,
-    private _organizationService: OrganizationService
+    private _organizationService: OrganizationService,
+    private _inboxService: InboxService
   ) {}
 
   @Get('/')
@@ -244,6 +246,10 @@ export class NoAuthIntegrationsController {
       .catch((err) => {
         console.log(err);
       });
+
+    this._inboxService.startInboxWorkflow(org.id).catch((err) => {
+      console.log(err);
+    });
 
     // Fetch pages if this is a two-step provider and not a refresh
     let pages: any[] = [];

--- a/apps/frontend/src/app/(app)/(site)/inbox/page.tsx
+++ b/apps/frontend/src/app/(app)/(site)/inbox/page.tsx
@@ -1,0 +1,6 @@
+export const dynamic = 'force-dynamic';
+import { InboxPage } from '@gitroom/frontend/components/inbox/inbox.page';
+
+export default function Page() {
+  return <InboxPage />;
+}

--- a/apps/frontend/src/components/inbox/inbox.page.tsx
+++ b/apps/frontend/src/components/inbox/inbox.page.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import useSWR from 'swr';
+import { useCallback, useState } from 'react';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import clsx from 'clsx';
+
+dayjs.extend(relativeTime);
+
+type InboxItemResponse = {
+  id: string;
+  platform: string;
+  type: string;
+  senderName: string;
+  senderAvatar?: string;
+  content: string;
+  createdAt: string;
+  readAt?: string;
+  repliedAt?: string;
+  integration: {
+    name: string;
+    picture?: string;
+    providerIdentifier: string;
+  };
+};
+
+const useInboxItems = (params: { platform?: string; type?: string; unreadOnly?: boolean; page?: number }) => {
+  const fetch = useFetch();
+  const query = new URLSearchParams();
+  if (params.platform) query.set('platform', params.platform);
+  if (params.type) query.set('type', params.type);
+  if (params.unreadOnly) query.set('unread', 'true');
+  if (params.page) query.set('page', String(params.page));
+
+  return useSWR(`inbox-${query.toString()}`, async () => {
+    const res = await fetch(`/inbox?${query.toString()}`);
+    return res.json() as Promise<InboxItemResponse[]>;
+  });
+};
+
+const useInboxCount = () => {
+  const fetch = useFetch();
+  return useSWR('inbox-count', async () => {
+    const res = await fetch('/inbox/count');
+    return res.json() as Promise<number>;
+  });
+};
+
+export const InboxPage = () => {
+  const fetch = useFetch();
+  const [filterPlatform, setFilterPlatform] = useState<string | undefined>();
+  const [filterType, setFilterType] = useState<string | undefined>();
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [replyingId, setReplyingId] = useState<string | null>(null);
+  const [replyMessage, setReplyMessage] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const { data: items, mutate } = useInboxItems({ platform: filterPlatform, type: filterType, unreadOnly });
+  const { mutate: mutateCount } = useInboxCount();
+
+  const markRead = useCallback(async (id: string) => {
+    await fetch(`/inbox/${id}/read`, { method: 'POST' });
+    mutate();
+    mutateCount();
+  }, [fetch, mutate, mutateCount]);
+
+  const sendReply = useCallback(async (id: string) => {
+    if (!replyMessage.trim()) return;
+    setSending(true);
+    try {
+      await fetch(`/inbox/${id}/reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: replyMessage }),
+      });
+      setReplyingId(null);
+      setReplyMessage('');
+      mutate();
+      mutateCount();
+    } finally {
+      setSending(false);
+    }
+  }, [fetch, replyMessage, mutate, mutateCount]);
+
+  return (
+    <div className="flex flex-col gap-4 p-4 max-w-4xl mx-auto">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Inbox</h1>
+        <div className="flex gap-2 items-center">
+          <button
+            onClick={() => setUnreadOnly((v) => !v)}
+            className={clsx(
+              'px-3 py-1 rounded-full text-sm border transition-colors',
+              unreadOnly
+                ? 'bg-primary text-white border-primary'
+                : 'border-gray-600 text-gray-400 hover:border-gray-400'
+            )}
+          >
+            Unread only
+          </button>
+          <select
+            className="bg-transparent border border-gray-600 rounded px-2 py-1 text-sm"
+            value={filterType ?? ''}
+            onChange={(e) => setFilterType(e.target.value || undefined)}
+          >
+            <option value="">All types</option>
+            <option value="comment">Comments</option>
+            <option value="mention">Mentions</option>
+          </select>
+        </div>
+      </div>
+
+      {!items || items.length === 0 ? (
+        <div className="text-center text-gray-500 py-16">
+          No inbox items yet. Connect Instagram to start pulling in comments.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className={clsx(
+                'rounded-lg border p-4 flex flex-col gap-3 transition-colors',
+                item.readAt ? 'border-fifth opacity-70' : 'border-primary bg-primary/5'
+              )}
+              onClick={() => !item.readAt && markRead(item.id)}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  {item.senderAvatar ? (
+                    <img src={item.senderAvatar} className="w-8 h-8 rounded-full" alt={item.senderName} />
+                  ) : (
+                    <div className="w-8 h-8 rounded-full bg-gray-600 flex items-center justify-center text-sm font-bold">
+                      {item.senderName[0]?.toUpperCase()}
+                    </div>
+                  )}
+                  <div>
+                    <div className="font-medium text-sm">{item.senderName}</div>
+                    <div className="text-xs text-gray-400 flex items-center gap-1">
+                      <span className="capitalize">{item.integration.name}</span>
+                      <span>·</span>
+                      <span className="capitalize">{item.type}</span>
+                      <span>·</span>
+                      <span>{dayjs(item.createdAt).fromNow()}</span>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  {!item.readAt && (
+                    <span className="w-2 h-2 rounded-full bg-primary mt-1 flex-shrink-0" />
+                  )}
+                  {item.repliedAt && (
+                    <span className="text-xs text-green-500">Replied</span>
+                  )}
+                </div>
+              </div>
+
+              <p className="text-sm text-gray-200">{item.content}</p>
+
+              {replyingId === item.id ? (
+                <div className="flex flex-col gap-2">
+                  <textarea
+                    className="w-full bg-sixth border border-fifth rounded p-2 text-sm resize-none"
+                    rows={3}
+                    placeholder="Write a reply..."
+                    value={replyMessage}
+                    onChange={(e) => setReplyMessage(e.target.value)}
+                    autoFocus
+                  />
+                  <div className="flex gap-2 justify-end">
+                    <button
+                      className="px-3 py-1 text-sm text-gray-400 hover:text-white"
+                      onClick={() => { setReplyingId(null); setReplyMessage(''); }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="px-4 py-1 text-sm bg-primary text-white rounded disabled:opacity-50"
+                      disabled={sending || !replyMessage.trim()}
+                      onClick={() => sendReply(item.id)}
+                    >
+                      {sending ? 'Sending...' : 'Reply'}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  className="self-start text-xs text-primary hover:underline"
+                  onClick={(e) => { e.stopPropagation(); setReplyingId(item.id); }}
+                >
+                  Reply
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/layout/top.menu.tsx
+++ b/apps/frontend/src/components/layout/top.menu.tsx
@@ -75,6 +75,27 @@ export const useMenuItem = () => {
       path: '/agents',
     },
     {
+      name: t('inbox', 'Inbox'),
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <path
+            d="M21 8L17.4392 12.6907C16.454 13.9328 15.9614 14.5538 15.3538 14.9383C14.8165 15.2788 14.2071 15.4874 13.5754 15.5477C12.8618 15.6159 12.1108 15.3922 10.6089 14.9449L3 12.5M21 8H3M21 8V17C21 18.1046 20.1046 19 19 19H5C3.89543 19 3 18.1046 3 17V8M3 8L6.97067 5H17.0293L21 8"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ),
+      path: '/inbox',
+    },
+    {
       name: t('analytics', 'Analytics'),
       icon: (
         <svg

--- a/apps/orchestrator/src/activities/inbox.activity.ts
+++ b/apps/orchestrator/src/activities/inbox.activity.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { Activity, ActivityMethod } from 'nestjs-temporal-core';
+import { InboxService } from '@gitroom/nestjs-libraries/database/prisma/inbox/inbox.service';
+import { IntegrationRepository } from '@gitroom/nestjs-libraries/database/prisma/integrations/integration.repository';
+
+@Injectable()
+@Activity()
+export class InboxActivity {
+  constructor(
+    private _inboxService: InboxService,
+    private _integrationRepository: IntegrationRepository
+  ) {}
+
+  @ActivityMethod()
+  async syncAllInboxes(orgId: string) {
+    const integrations =
+      await this._integrationRepository.getIntegrationsList(orgId);
+
+    for (const integration of integrations) {
+      try {
+        await this._inboxService.syncIntegration(integration.id);
+      } catch (err) {
+        console.error(`Inbox sync failed for ${integration.id}:`, err);
+      }
+    }
+  }
+}

--- a/apps/orchestrator/src/app.module.ts
+++ b/apps/orchestrator/src/app.module.ts
@@ -5,6 +5,7 @@ import { DatabaseModule } from '@gitroom/nestjs-libraries/database/prisma/databa
 import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
 import { EmailActivity } from '@gitroom/orchestrator/activities/email.activity';
 import { IntegrationsActivity } from '@gitroom/orchestrator/activities/integrations.activity';
+import { InboxActivity } from '@gitroom/orchestrator/activities/inbox.activity';
 import { HealthController } from '@gitroom/orchestrator/health.controller';
 
 const activities = [
@@ -12,6 +13,7 @@ const activities = [
   AutopostService,
   EmailActivity,
   IntegrationsActivity,
+  InboxActivity,
 ];
 @Module({
   imports: [

--- a/apps/orchestrator/src/workflows/inbox.workflow.ts
+++ b/apps/orchestrator/src/workflows/inbox.workflow.ts
@@ -1,0 +1,26 @@
+import { proxyActivities, sleep, continueAsNew } from '@temporalio/workflow';
+import { InboxActivity } from '@gitroom/orchestrator/activities/inbox.activity';
+
+const { syncAllInboxes } = proxyActivities<InboxActivity>({
+  startToCloseTimeout: '5 minute',
+  taskQueue: 'main',
+  cancellationType: 'ABANDON',
+});
+
+const POLL_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+
+export async function inboxSyncWorkflow({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  while (true) {
+    try {
+      await syncAllInboxes(organizationId);
+    } catch (err) {
+      // continue polling even on error
+    }
+    await sleep(POLL_INTERVAL_MS);
+    await continueAsNew<typeof inboxSyncWorkflow>({ organizationId });
+  }
+}

--- a/libraries/nestjs-libraries/src/database/prisma/database.module.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/database.module.ts
@@ -42,6 +42,8 @@ import { AnnouncementsRepository } from '@gitroom/nestjs-libraries/database/pris
 import { AnnouncementsService } from '@gitroom/nestjs-libraries/database/prisma/announcements/announcements.service';
 import { ErrorsRepository } from '@gitroom/nestjs-libraries/database/prisma/errors/errors.repository';
 import { ErrorsService } from '@gitroom/nestjs-libraries/database/prisma/errors/errors.service';
+import { InboxRepository } from '@gitroom/nestjs-libraries/database/prisma/inbox/inbox.repository';
+import { InboxService } from '@gitroom/nestjs-libraries/database/prisma/inbox/inbox.service';
 
 @Global()
 @Module({
@@ -93,6 +95,8 @@ import { ErrorsService } from '@gitroom/nestjs-libraries/database/prisma/errors/
     AnnouncementsService,
     ErrorsRepository,
     ErrorsService,
+    InboxRepository,
+    InboxService,
   ],
   get exports() {
     return this.providers;

--- a/libraries/nestjs-libraries/src/database/prisma/inbox/inbox.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/inbox/inbox.repository.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaRepository } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
+import { InboxItem as InboxItemType } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+
+@Injectable()
+export class InboxRepository {
+  constructor(private _inboxItem: PrismaRepository<'inboxItem'>) {}
+
+  upsertItems(
+    organizationId: string,
+    integrationId: string,
+    platform: string,
+    items: InboxItemType[]
+  ) {
+    return Promise.all(
+      items.map((item) =>
+        this._inboxItem.model.inboxItem.upsert({
+          where: {
+            integrationId_externalId: {
+              integrationId,
+              externalId: item.externalId,
+            },
+          },
+          create: {
+            organizationId,
+            integrationId,
+            platform,
+            externalId: item.externalId,
+            postId: item.postId,
+            type: item.type,
+            senderName: item.senderName,
+            senderAvatar: item.senderAvatar,
+            senderExternalId: item.senderExternalId,
+            content: item.content,
+            parentExternalId: item.parentExternalId,
+            createdAt: item.createdAt,
+          },
+          update: {},
+        })
+      )
+    );
+  }
+
+  getItems(
+    organizationId: string,
+    params: {
+      platform?: string;
+      type?: string;
+      unreadOnly?: boolean;
+      page?: number;
+    }
+  ) {
+    const { platform, type, unreadOnly, page = 0 } = params;
+    const take = 20;
+
+    return this._inboxItem.model.inboxItem.findMany({
+      where: {
+        organizationId,
+        ...(platform ? { platform } : {}),
+        ...(type ? { type } : {}),
+        ...(unreadOnly ? { readAt: null } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      skip: page * take,
+      take,
+      include: {
+        integration: {
+          select: { name: true, picture: true, providerIdentifier: true },
+        },
+      },
+    });
+  }
+
+  getUnreadCount(organizationId: string) {
+    return this._inboxItem.model.inboxItem.count({
+      where: { organizationId, readAt: null },
+    });
+  }
+
+  markRead(organizationId: string, id: string) {
+    return this._inboxItem.model.inboxItem.updateMany({
+      where: { id, organizationId },
+      data: { readAt: new Date() },
+    });
+  }
+
+  markReplied(organizationId: string, id: string) {
+    return this._inboxItem.model.inboxItem.updateMany({
+      where: { id, organizationId },
+      data: { repliedAt: new Date(), readAt: new Date() },
+    });
+  }
+
+  findById(organizationId: string, id: string) {
+    return this._inboxItem.model.inboxItem.findFirst({
+      where: { id, organizationId },
+      include: {
+        integration: true,
+      },
+    });
+  }
+
+  getLastSyncTime(integrationId: string) {
+    return this._inboxItem.model.inboxItem.findFirst({
+      where: { integrationId },
+      orderBy: { createdAt: 'desc' },
+      select: { createdAt: true },
+    });
+  }
+}

--- a/libraries/nestjs-libraries/src/database/prisma/inbox/inbox.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/inbox/inbox.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { InboxRepository } from '@gitroom/nestjs-libraries/database/prisma/inbox/inbox.repository';
+import { IntegrationManager } from '@gitroom/nestjs-libraries/integrations/integration.manager';
+import { IntegrationRepository } from '@gitroom/nestjs-libraries/database/prisma/integrations/integration.repository';
+import { Organization } from '@prisma/client';
+import { TemporalService } from 'nestjs-temporal-core';
+
+@Injectable()
+export class InboxService {
+  constructor(
+    private _inboxRepository: InboxRepository,
+    private _integrationManager: IntegrationManager,
+    private _integrationRepository: IntegrationRepository,
+    private _temporalService: TemporalService
+  ) {}
+
+  async syncIntegration(integrationId: string) {
+    const integration =
+      await this._integrationRepository.getIntegrationByIdOnly(integrationId);
+    if (!integration || integration.disabled || integration.deletedAt) return;
+
+    const provider = this._integrationManager.getSocialIntegration(
+      integration.providerIdentifier
+    );
+    if (!provider?.fetchInbox) return;
+
+    const last = await this._inboxRepository.getLastSyncTime(integrationId);
+    const since = last?.createdAt ?? undefined;
+
+    const items = await provider.fetchInbox(
+      integration.internalId,
+      integration.token,
+      integration,
+      since
+    );
+
+    if (items.length === 0) return;
+
+    await this._inboxRepository.upsertItems(
+      integration.organizationId,
+      integrationId,
+      integration.providerIdentifier,
+      items
+    );
+  }
+
+  getItems(org: Organization, params: { platform?: string; type?: string; unreadOnly?: boolean; page?: number }) {
+    return this._inboxRepository.getItems(org.id, params);
+  }
+
+  getUnreadCount(org: Organization) {
+    return this._inboxRepository.getUnreadCount(org.id);
+  }
+
+  async markRead(org: Organization, id: string) {
+    await this._inboxRepository.markRead(org.id, id);
+  }
+
+  async startInboxWorkflow(organizationId: string) {
+    try {
+      await this._temporalService.client
+        .getRawClient()
+        ?.workflow.start('inboxSyncWorkflow', {
+          workflowId: `inbox_sync_${organizationId}`,
+          taskQueue: 'main',
+          workflowIdConflictPolicy: 'USE_EXISTING',
+          args: [{ organizationId }],
+        });
+    } catch (err) {}
+  }
+
+  async reply(org: Organization, id: string, message: string) {
+    const item = await this._inboxRepository.findById(org.id, id);
+    if (!item) throw new Error('Inbox item not found');
+
+    const provider = this._integrationManager.getSocialIntegration(
+      item.integration.providerIdentifier
+    );
+    if (!provider?.comment) throw new Error('Provider does not support replies');
+
+    await provider.comment(
+      item.integration.internalId,
+      item.postId || item.externalId,
+      item.externalId,
+      item.integration.token,
+      [{ id, message, settings: {} }],
+      item.integration
+    );
+
+    await this._inboxRepository.markReplied(org.id, id);
+  }
+}

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.repository.ts
@@ -383,6 +383,12 @@ export class IntegrationRepository {
     });
   }
 
+  getIntegrationByIdOnly(id: string) {
+    return this._integration.model.integration.findFirst({
+      where: { id, deletedAt: null },
+    });
+  }
+
   async getIntegrationForOrder(
     id: string,
     order: string,

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Organization {
   webhooks            Webhooks[]
   oauthApp            OAuthApp[]
   oauthAuthorizations OAuthAuthorization[]
+  inboxItems          InboxItem[]
 
   @@index([apiKey])
   @@index([streakSince])
@@ -341,6 +342,7 @@ model Integration {
   orderItems            OrderItems[]
   plugs                 Plugs[]
   posts                 Post[]
+  inboxItems            InboxItem[]
 
   @@unique([organizationId, internalId])
   @@index([rootInternalId])
@@ -418,6 +420,7 @@ model Post {
   comments                   Comments[]
   errors                     Errors[]
   payoutProblems             PayoutProblems[]
+  inboxItems                 InboxItem[]
   integration                Integration               @relation(fields: [integrationId], references: [id])
   lastMessage                Messages?                 @relation(fields: [lastMessageId], references: [id])
   organization               Organization              @relation("organization", fields: [organizationId], references: [id])
@@ -956,4 +959,34 @@ model Announcement {
   description String
   color       AnnouncementColor @default(INFO)
   createdAt   DateTime          @default(now())
+}
+
+model InboxItem {
+  id               String      @id @default(uuid())
+  organizationId   String
+  integrationId    String
+  postId           String?
+  externalId       String
+  platform         String
+  type             String
+  senderName       String
+  senderAvatar     String?
+  senderExternalId String
+  content          String
+  parentExternalId String?
+  readAt           DateTime?
+  repliedAt        DateTime?
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @updatedAt
+  integration      Integration @relation(fields: [integrationId], references: [id])
+  organization     Organization @relation(fields: [organizationId], references: [id])
+  post             Post?        @relation(fields: [postId], references: [id])
+
+  @@unique([integrationId, externalId])
+  @@index([organizationId])
+  @@index([integrationId])
+  @@index([platform])
+  @@index([type])
+  @@index([readAt])
+  @@index([createdAt])
 }

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -1,6 +1,7 @@
 import {
   AnalyticsData,
   AuthTokenDetails,
+  InboxItem,
   PostDetails,
   PostResponse,
   SocialProvider,
@@ -754,6 +755,63 @@ export class InstagramProvider
         status: 'success',
       },
     ];
+  }
+
+  async fetchInbox(
+    id: string,
+    accessToken: string,
+    integration: Integration,
+    since?: Date,
+    type = 'graph.facebook.com'
+  ): Promise<InboxItem[]> {
+    // Get all media posted by this account
+    const sinceTimestamp = since ? Math.floor(since.getTime() / 1000) : undefined;
+    const mediaFields = 'id,timestamp,permalink';
+    const mediaUrl = `https://${type}/v20.0/${id}/media?fields=${mediaFields}&access_token=${accessToken}&limit=10`;
+
+    const mediaResponse = await (await this.fetch(mediaUrl)).json();
+    const mediaItems: { id: string; timestamp: string; permalink: string }[] =
+      mediaResponse.data || [];
+
+    const items: InboxItem[] = [];
+
+    for (const media of mediaItems) {
+      if (
+        sinceTimestamp &&
+        new Date(media.timestamp).getTime() / 1000 < sinceTimestamp - 86400 * 7
+      ) {
+        continue;
+      }
+
+      const commentsUrl = `https://${type}/v20.0/${media.id}/comments?fields=id,text,timestamp,from,username&access_token=${accessToken}&limit=50`;
+      const commentsResponse = await (await this.fetch(commentsUrl)).json();
+      const comments: {
+        id: string;
+        text: string;
+        timestamp: string;
+        from?: { id: string; name: string; pic?: string };
+        username?: string;
+      }[] = commentsResponse.data || [];
+
+      for (const c of comments) {
+        if (sinceTimestamp && new Date(c.timestamp).getTime() / 1000 < sinceTimestamp) {
+          continue;
+        }
+        items.push({
+          externalId: c.id,
+          postId: media.id,
+          type: 'comment',
+          senderName: c.from?.name || c.username || 'Unknown',
+          senderAvatar: undefined,
+          senderExternalId: c.from?.id || c.username || 'unknown',
+          content: c.text,
+          parentExternalId: media.id,
+          createdAt: new Date(c.timestamp),
+        });
+      }
+    }
+
+    return items;
   }
 
   private setTitle(name: string) {

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -81,13 +81,25 @@ export type AuthTokenDetails = {
   }[];
 };
 
+export type InboxItem = {
+  externalId: string;
+  postId?: string;
+  type: 'comment' | 'mention';
+  senderName: string;
+  senderAvatar?: string;
+  senderExternalId: string;
+  content: string;
+  parentExternalId?: string;
+  createdAt: Date;
+};
+
 export interface ISocialMediaIntegration {
   post(
     id: string,
     accessToken: string,
     postDetails: PostDetails[],
     integration: Integration
-  ): Promise<PostResponse[]>; // Schedules a new post
+  ): Promise<PostResponse[]>;
 
   comment?(
     id: string,
@@ -96,7 +108,14 @@ export interface ISocialMediaIntegration {
     accessToken: string,
     postDetails: PostDetails[],
     integration: Integration
-  ): Promise<PostResponse[]>; // Schedules a new post
+  ): Promise<PostResponse[]>;
+
+  fetchInbox?(
+    id: string,
+    accessToken: string,
+    integration: Integration,
+    since?: Date
+  ): Promise<InboxItem[]>;
 }
 
 export type PostResponse = {

--- a/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
+++ b/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
@@ -1,6 +1,12 @@
 import * as Sentry from '@sentry/nestjs';
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { capitalize } from 'lodash';
+
+let nodeProfilingIntegration: (() => any) | null = null;
+try {
+  nodeProfilingIntegration = require('@sentry/profiling-node').nodeProfilingIntegration;
+} catch {
+  // native module unavailable on this Node version
+}
 
 export const initializeSentry = (appName: string, allowLogs = false) => {
   if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
@@ -24,8 +30,7 @@ export const initializeSentry = (appName: string, allowLogs = false) => {
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       spotlight: process.env.SENTRY_SPOTLIGHT === '1',
       integrations: [
-        // Add our Profiling integration
-        nodeProfilingIntegration(),
+        ...(nodeProfilingIntegration ? [nodeProfilingIntegration()] : []),
         Sentry.consoleLoggingIntegration({ levels: ['log', 'info', 'warn', 'error', 'debug', 'assert', 'trace'] }),
         Sentry.openAIIntegration({
           recordInputs: true,


### PR DESCRIPTION
Adds a Unified Inbox feature so users can see and reply to Instagram comments from inside Postiz. Includes provider interface extension, Instagram fetchInbox() implementation, Temporal polling workflow every 15 min, inbox API endpoints, and frontend inbox page with reply composer.