### PR TITLE
fix(backend): always enable CORS credentials for cross-origin uploads

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -23,7 +23,7 @@ async function start() {
   const app = await NestFactory.create(AppModule, {
     rawBody: true,
     cors: {
-      ...(!process.env.NOT_SECURED ? { credentials: true } : {}),
+      credentials: true,
       allowedHeaders: [
         'Content-Type',
         'Authorization',


### PR DESCRIPTION
## Summary
`NestJS` CORS was only setting `credentials: true` when `NOT_SECURED` was **not** set. With `NOT_SECURED=true` (plain `http://localhost` dev), the backend omitted `Access-Control-Allow-Credentials`.

The media upload flow uses Uppy `XHRUpload` with `withCredentials: true` against the API. Browsers then block reading the response unless credentials are allowed in CORS—so uploads could fail with a generic network error even when the file was processed.

## Change
Always set `credentials: true` on the CORS config (see `apps/backend/src/main.ts`).

## Testing
- Local: `NOT_SECURED=true`, frontend :4200, API :3000, `STORAGE_PROVIDER=local` — upload completes and UI receives JSON.


Made with [Cursor](https://cursor.com)