### PR TITLE
fix: stop likes/views/comments/share/save doubling

### DIFF
--- a/apps/frontend/src/components/analytics/chart-social.tsx
+++ b/apps/frontend/src/components/analytics/chart-social.tsx
@@ -22,9 +22,19 @@ export const ChartSocial: FC<{
 }> = (props) => {
   const { data, color = 'purple' } = props;
   const [mode] = useCookie('mode', 'dark');
+
   const list = useMemo(() => {
-    return mergeDataPoints(data, 7);
+    const merged = data.length < 7 ? data : mergeDataPoints(data, 7);
+    if (merged.length === 1) {
+      return [
+        // duplicating single datapoints metrics for chart to display a line on analytics
+        merged[0],
+        merged[0],
+      ];
+    }
+    return merged;
   }, [data]);
+
   const ref = useRef<any>(null);
   const chart = useRef<null | DrawChart>(null);
 

--- a/apps/frontend/src/components/platform-analytics/render.analytics.tsx
+++ b/apps/frontend/src/components/platform-analytics/render.analytics.tsx
@@ -56,7 +56,7 @@ const AnalyticsCard: FC<{
   const colorVariants = ['purple', 'green', 'blue'] as const;
   const color = colorVariants[index % colorVariants.length];
 
-  const hasMultipleDataPoints = item.data.length > 1;
+  const hasDataPoints = item.data.length >= 1;
 
   return (
     <div className="group relative">
@@ -92,7 +92,7 @@ const AnalyticsCard: FC<{
         </div>
 
         {/* Content */}
-        {hasMultipleDataPoints ? (
+        {hasDataPoints ? (
           <>
             {/* Chart */}
             <div className="flex-1 px-[12px] py-[8px]">

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -840,10 +840,6 @@ export class InstagramProvider
             total: d.total_value.value,
             date: dayjs().format('YYYY-MM-DD'),
           },
-          {
-            total: d.total_value.value,
-            date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
-          },
         ],
       }))
     );


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) before submitting a PR. -->
Closes #1436 

# What kind of change does this PR introduce?
The PR introduces a bug fix appearing in **Analytics** Page for **Instagram** where the total value of metrics like likes/views/comments/share/saves are appearing in 2x values.

# Why was this change needed?
Issue Link - #1436

https://github.com/gitroomhq/postiz-app/blob/main/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
```javascript
    analytics.push(
      ...data2.map((d: any) => ({
        label: this.setTitle(d.name),
        percentageChange: 5,
        data: [
          {
            total: d.total_value.value,
            date: dayjs().format('YYYY-MM-DD'),
          },
          // duplicacy to show line on chart
          {
            total: d.total_value.value,
            date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
          },
        ],
      }))
    );
``` 

To make the chart render a line (which requires at least 2 points), the backend was duplicating this value into two data points. This caused the frontend to sum both entries, displaying double the actual metric. For example, if actual Like counts were 2, it would display 4(2x of actual data) on analytics chart. Similarly, if comments were 2, it would display 4(2x of actual data).

### Fix

[Backend](https://github.com/gitroomhq/postiz-app/blob/main/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts): Removed the duplicate data point for total_value metrics. Now pushes a single honest data point.

```javascript
    analytics.push(
      ...data2.map((d: any) => ({
        label: this.setTitle(d.name),
        percentageChange: 5,
        data: [
          {
            total: d.total_value.value,
            date: dayjs().format('YYYY-MM-DD'),
          },
        ],
      }))
    );
``` 


Frontend ([ChartSocial](https://github.com/gitroomhq/postiz-app/blob/main/apps/frontend/src/components/analytics/chart-social.tsx)): When a dataset has only one data point, a duplicate point is prepended so the chart can render a line and show actual data.
```javascript
  const list = useMemo(() => {
    const merged = data.length < 7 ? data : mergeDataPoints(data, 7);
    if (merged.length === 1) {
      return [
        // duplicating single datapoints metrics for chart to display a line on analytics
        merged[0],
        merged[0],
      ];
    }
    return merged;
  }, [data]);
``` 



# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
