### PR TITLE
feat(linkedin): support Showcase Pages in linkedin-page provider

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -6,12 +6,22 @@ import {
   SocialProvider,
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
-import { LinkedinProvider } from '@gitroom/nestjs-libraries/integrations/social/linkedin.provider';
+import {
+  LinkedinAuthorType,
+  LinkedinProvider,
+} from '@gitroom/nestjs-libraries/integrations/social/linkedin.provider';
 import dayjs from 'dayjs';
 import { Integration } from '@prisma/client';
 import { Plug } from '@gitroom/helpers/decorators/plug.decorator';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
+
+// Showcase Pages are an organizationBrand sub-type of Company Pages in LinkedIn's
+// data model. They share the linkedin-page provider but use a different URN prefix
+// (urn:li:organizationBrand vs urn:li:organization). We encode the type in
+// internalId by prefixing showcase IDs with "brand:". Bare numeric IDs remain
+// Company Pages for backward compatibility with existing integrations.
+const SHOWCASE_INTERNAL_ID_PREFIX = 'brand:';
 
 @Rules(
   'LinkedIn can have maximum one attachment when selecting video, when choosing a carousel on LinkedIn minimum amount of attachment must be two, and only pictures, if uploading a video, LinkedIn can have only one attachment'
@@ -36,6 +46,20 @@ export class LinkedinPageProvider
   ];
 
   override editor = 'normal' as const;
+
+  protected isShowcase(internalId: string): boolean {
+    return internalId.startsWith(SHOWCASE_INTERNAL_ID_PREFIX);
+  }
+
+  protected extractRawId(internalId: string): string {
+    return this.isShowcase(internalId)
+      ? internalId.slice(SHOWCASE_INTERNAL_ID_PREFIX.length)
+      : internalId;
+  }
+
+  protected authorTypeFor(internalId: string): LinkedinAuthorType {
+    return this.isShowcase(internalId) ? 'showcase' : 'company';
+  }
 
   override async refreshToken(
     refresh_token: string
@@ -101,7 +125,7 @@ export class LinkedinPageProvider
       originalIntegration,
       postId,
       information,
-      false
+      this.authorTypeFor(integration.internalId)
     );
   }
 
@@ -116,7 +140,7 @@ export class LinkedinPageProvider
       originalIntegration,
       postId,
       information,
-      false
+      this.authorTypeFor(integration.internalId)
     );
   }
 
@@ -136,7 +160,12 @@ export class LinkedinPageProvider
   }
 
   async companies(accessToken: string) {
-    const { elements, ...all } = await (
+    // The organizationalEntityAcls endpoint returns BOTH urn:li:organization
+    // (Company Pages) and urn:li:organizationBrand (Showcase Pages) entries.
+    // We detect the type from the URN prefix and encode showcase entries with
+    // a "brand:" id prefix so post(), analytics(), and other downstream methods
+    // can route them to the correct LinkedIn endpoints. Closes #1478.
+    const { elements } = await (
       await fetch(
         'https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=ADMINISTRATOR&projection=(elements*(organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))',
         {
@@ -149,15 +178,24 @@ export class LinkedinPageProvider
       )
     ).json();
 
-    return (elements || []).map((e: any) => ({
-      id: e.organizationalTarget.split(':').pop(),
-      page: e.organizationalTarget.split(':').pop(),
-      username: e['organizationalTarget~'].vanityName,
-      name: e['organizationalTarget~'].localizedName,
-      picture:
-        e['organizationalTarget~'].logoV2?.['original~']?.elements?.[0]
-          ?.identifiers?.[0]?.identifier,
-    }));
+    return (elements || []).map((e: any) => {
+      const urn: string = e.organizationalTarget;
+      const numericId = urn.split(':').pop()!;
+      const isShowcase = urn.includes(':organizationBrand:');
+      const id = isShowcase
+        ? `${SHOWCASE_INTERNAL_ID_PREFIX}${numericId}`
+        : numericId;
+      const baseName = e['organizationalTarget~'].localizedName;
+      return {
+        id,
+        page: id,
+        username: e['organizationalTarget~'].vanityName,
+        name: isShowcase ? `${baseName} (Showcase)` : baseName,
+        picture:
+          e['organizationalTarget~'].logoV2?.['original~']?.elements?.[0]
+            ?.identifiers?.[0]?.identifier,
+      };
+    });
   }
 
   async reConnect(
@@ -179,10 +217,15 @@ export class LinkedinPageProvider
   }
 
   async fetchPageInformation(accessToken: string, params: { page: string }) {
+    // Showcase Pages live under /v2/organizationBrands/{id}; Company Pages under
+    // /v2/organizations/{id}. We route based on the "brand:" prefix in page id.
     const pageId = params.page;
+    const isShowcase = this.isShowcase(pageId);
+    const rawId = this.extractRawId(pageId);
+    const endpoint = isShowcase ? 'organizationBrands' : 'organizations';
     const data = await (
       await fetch(
-        `https://api.linkedin.com/v2/organizations/${pageId}?projection=(id,localizedName,vanityName,logoV2(original~:playableStreams))`,
+        `https://api.linkedin.com/v2/${endpoint}/${rawId}?projection=(id,localizedName,vanityName,logoV2(original~:playableStreams))`,
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,
@@ -192,8 +235,12 @@ export class LinkedinPageProvider
     ).json();
 
     return {
-      id: data.id,
-      name: data.localizedName,
+      id: isShowcase
+        ? `${SHOWCASE_INTERNAL_ID_PREFIX}${data.id}`
+        : String(data.id),
+      name: isShowcase
+        ? `${data.localizedName} (Showcase)`
+        : data.localizedName,
       access_token: accessToken,
       picture:
         data?.logoV2?.['original~']?.elements?.[0]?.identifiers?.[0].identifier,
@@ -270,7 +317,17 @@ export class LinkedinPageProvider
     postDetails: PostDetails[],
     integration: Integration
   ): Promise<PostResponse[]> {
-    return super.post(id, accessToken, postDetails, integration, 'company');
+    // id is integration.internalId, which may carry the "brand:" prefix for
+    // Showcase Pages. We strip it and pass the raw numeric ID + the correct
+    // author-type discriminator down to the parent implementation, which
+    // handles URN construction via authorUrn().
+    return super.post(
+      this.extractRawId(id),
+      accessToken,
+      postDetails,
+      integration,
+      this.authorTypeFor(integration.internalId)
+    );
   }
 
   override async comment(
@@ -282,13 +339,13 @@ export class LinkedinPageProvider
     integration: Integration
   ): Promise<PostResponse[]> {
     return super.comment(
-      id,
+      this.extractRawId(id),
       postId,
       lastCommentId,
       accessToken,
       postDetails,
       integration,
-      'company'
+      this.authorTypeFor(integration.internalId)
     );
   }
 
@@ -297,6 +354,14 @@ export class LinkedinPageProvider
     accessToken: string,
     date: number
   ): Promise<AnalyticsData[]> {
+    // Showcase Pages don't expose organizationPageStatistics /
+    // organizationalEntityFollowerStatistics / organizationalEntityShareStatistics
+    // endpoints — LinkedIn limits these to Company Pages. Return an empty
+    // analytics set rather than 4xx the request and break the dashboard.
+    if (this.isShowcase(id)) {
+      return [];
+    }
+
     const endDate = dayjs().unix() * 1000;
     const startDate = dayjs().subtract(date, 'days').unix() * 1000;
 
@@ -423,6 +488,12 @@ export class LinkedinPageProvider
     postId: string,
     date: number
   ): Promise<AnalyticsData[]> {
+    // See analytics() — share/social-action stats are not exposed for
+    // urn:li:organizationBrand entities (Showcase Pages). Skip cleanly.
+    if (this.isShowcase(integrationId)) {
+      return [];
+    }
+
     const endDate = dayjs().unix() * 1000;
     const startDate = dayjs().subtract(date, 'days').unix() * 1000;
 
@@ -586,7 +657,10 @@ export class LinkedinPageProvider
       await timer(2000);
       await this.fetch(`https://api.linkedin.com/rest/posts`, {
         body: JSON.stringify({
-          author: `urn:li:organization:${integration.internalId}`,
+          author: this.authorUrn(
+            this.extractRawId(integration.internalId),
+            this.authorTypeFor(integration.internalId)
+          ),
           commentary: '',
           visibility: 'PUBLIC',
           distribution: {
@@ -673,7 +747,10 @@ export class LinkedinPageProvider
             Authorization: `Bearer ${integration.token}`,
           },
           body: JSON.stringify({
-            actor: `urn:li:organization:${integration.internalId}`,
+            actor: this.authorUrn(
+              this.extractRawId(integration.internalId),
+              this.authorTypeFor(integration.internalId)
+            ),
             object: id,
             message: {
               text: this.fixText(fields.post),

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -17,6 +17,8 @@ import imageToPDF from 'image-to-pdf';
 import { Readable } from 'stream';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
+export type LinkedinAuthorType = 'company' | 'personal' | 'showcase';
+
 @Rules(
   'LinkedIn can have maximum one attachment when selecting video, when choosing a carousel on LinkedIn minimum amount of attachment must be two, and only pictures, if uploading a video, LinkedIn can have only one attachment'
 )
@@ -40,6 +42,12 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   editor = 'normal' as const;
   maxLength() {
     return 3000;
+  }
+
+  protected authorUrn(id: string, type: LinkedinAuthorType): string {
+    if (type === 'personal') return `urn:li:person:${id}`;
+    if (type === 'showcase') return `urn:li:organizationBrand:${id}`;
+    return `urn:li:organization:${id}`;
   }
 
   override handleErrors(
@@ -232,7 +240,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     personId: string,
     picture: any,
-    type = 'personal' as 'company' | 'personal'
+    type: LinkedinAuthorType = 'personal'
   ) {
     // Determine the appropriate endpoint based on file type
     const isVideo = hasExtension(fileName, 'mp4');
@@ -262,10 +270,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
           },
           body: JSON.stringify({
             initializeUploadRequest: {
-              owner:
-                type === 'personal'
-                  ? `urn:li:person:${personId}`
-                  : `urn:li:organization:${personId}`,
+              owner: this.authorUrn(personId, type),
               ...(isVideo
                 ? {
                     fileSizeBytes: picture.length,
@@ -432,7 +437,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     postDetails: PostDetails<LinkedinDto>[],
     accessToken: string,
     personId: string,
-    type: 'company' | 'personal'
+    type: LinkedinAuthorType
   ): Promise<Record<string, string[]>> {
     const mediaUploads = await Promise.all(
       postDetails.flatMap(
@@ -518,14 +523,14 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
 
   private createLinkedInPostPayload(
     id: string,
-    type: 'company' | 'personal',
+    type: LinkedinAuthorType,
     message: string,
     mediaIds: string[],
     isPdf: boolean,
     pdfTitle?: string
   ) {
     const author =
-      type === 'personal' ? `urn:li:person:${id}` : `urn:li:organization:${id}`;
+      this.authorUrn(id, type);
 
     return {
       author,
@@ -547,7 +552,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     firstPost: PostDetails<LinkedinDto>,
     mediaIds: string[],
-    type: 'company' | 'personal',
+    type: LinkedinAuthorType,
     isPdf: boolean
   ): Promise<string> {
     const pdfTitle = isPdf
@@ -586,10 +591,10 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     post: PostDetails,
     parentPostId: string,
-    type: 'company' | 'personal'
+    type: LinkedinAuthorType
   ): Promise<string> {
     const actor =
-      type === 'personal' ? `urn:li:person:${id}` : `urn:li:organization:${id}`;
+      this.authorUrn(id, type);
 
     const response = await this.fetch(
       `https://api.linkedin.com/v2/socialActions/${encodeURIComponent(
@@ -637,7 +642,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     postDetails: PostDetails<LinkedinDto>[],
     integration: Integration,
-    type = 'personal' as 'company' | 'personal'
+    type: LinkedinAuthorType = 'personal'
   ): Promise<PostResponse[]> {
     let processedPostDetails = postDetails;
     const [firstPost] = postDetails;
@@ -686,7 +691,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     postDetails: PostDetails<LinkedinDto>[],
     integration: Integration,
-    type = 'personal' as 'company' | 'personal'
+    type: LinkedinAuthorType = 'personal'
   ): Promise<PostResponse[]> {
     const [commentPost] = postDetails;
 
@@ -720,7 +725,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     originalIntegration: Integration,
     postId: string,
     information: any,
-    isPersonal = true
+    type: LinkedinAuthorType = 'personal'
   ) {
     return this.comment(
       integration.internalId,
@@ -738,7 +743,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
         },
       ],
       integration,
-      isPersonal ? 'personal' : 'company'
+      type
     );
   }
 
@@ -754,13 +759,11 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     originalIntegration: Integration,
     postId: string,
     information: any,
-    isPersonal = true
+    type: LinkedinAuthorType = 'personal'
   ) {
     await this.fetch(`https://api.linkedin.com/rest/posts`, {
       body: JSON.stringify({
-        author:
-          (isPersonal ? 'urn:li:person:' : `urn:li:organization:`) +
-          `${integration.internalId}`,
+        author: this.authorUrn(integration.internalId, type),
         commentary: '',
         visibility: 'PUBLIC',
         distribution: {


### PR DESCRIPTION
## Problem

`linkedin-page` cannot post to LinkedIn Showcase Pages. The `companies()` selector silently lists Showcase entries from `organizationalEntityAcls`, but if a user picks one, publishing fails: Showcase Pages are `urn:li:organizationBrand:{id}` whereas the provider hardcodes `urn:li:organization:{id}` at every URN site (UGC posts, comments, reposts, media uploads).

Also affected if a Showcase ID slipped through today:

- `fetchPageInformation()` calls `/v2/organizations/{id}`, which 404s for `organizationBrand` IDs.
- `analytics()` and `postAnalytics()` call endpoints that LinkedIn does not expose for `organizationBrand` URNs.

Closes #1478.

## Solution

Three changes in the existing `linkedin-page` provider, no new provider class.

**1. Centralized URN helper in `LinkedinProvider`.** New type `LinkedinAuthorType = 'company' | 'personal' | 'showcase'` and a `protected authorUrn(id, type)` helper. The five inline URN ternaries are replaced with `this.authorUrn(...)` calls so the prefix cannot drift again. `repostPostUsers()`'s `isPersonal: boolean` parameter is replaced with `type: LinkedinAuthorType` for consistency.

**2. Showcase-aware `LinkedinPageProvider`.**

- `companies()` distinguishes `organizationBrand` URNs from `organization` URNs in the ACL response. Showcases are labeled `"<Name> (Showcase)"` and their `id` is returned with a `"brand:"` prefix.
- `post()`, `comment()`, `repostPostUsers()`, `addComment()`, `autoRepostPost()`, `autoPlugPost()` detect the type from `integration.internalId` and pass it down.
- `fetchPageInformation()` routes to `/v2/organizationBrands/{id}` for Showcase IDs.
- `analytics()` and `postAnalytics()` short-circuit to `[]` for Showcases (LinkedIn does not expose page statistics for `organizationBrand` URNs; returning empty avoids 4xx that would break the dashboard).

**3. Backward-compatible storage convention.** The URN type is encoded in `Integration.internalId`:

- Existing Company Pages: bare numeric (e.g. `"110852144"`) — unchanged
- New Showcase Pages: prefixed (e.g. `"brand:121964728"`)

No schema migration. No new env vars. No new OAuth scope (Showcase publishing is already covered by `w_organization_social`).

## Backward compatibility

| | Before | After |
|---|---|---|
| Existing Company Page (numeric `internalId`) | `urn:li:organization:{id}` | `urn:li:organization:{id}` (identical) |
| New Showcase Page (prefixed `internalId`) | publish fails | `urn:li:organizationBrand:{id}` |
| `analytics()` for Company | works | works (unchanged) |
| `analytics()` for Showcase | LinkedIn 4xx | `[]` (graceful) |

## Files changed

- `libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts`
- `libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts`

~80 LOC of behavior change. No new dependencies, no schema migration.

## Test plan

**Logic-level:** 16 assertions covering URN construction across all three types, Showcase detection, ID extraction, ACL mapping, `fetchPageInformation` endpoint routing, and end-to-end author URN building. Critical backward-compat case verified: existing Company Page integrations produce identical URNs to before this change.

**TypeScript:** `npx tsc --noEmit -p libraries/nestjs-libraries` passes.

**Suggested manual e2e** (against a self-hosted instance with a LinkedIn user that administers a Showcase Page):

1. Reconnect a `linkedin-page` integration. The picker should list the Showcase as `"<Name> (Showcase)"`.
2. Connect the Showcase, publish a test post.
3. Confirm the post lands at `linkedin.com/showcase/<vanity>` and not on the parent Company Page.
4. Confirm existing Company Page integrations publish correctly (URN identical pre/post).
