### PR TITLE
Show TikTok title/content restriction notice for video posts

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
@@ -29,11 +29,28 @@ const TikTokSettings: FC<{
     return value?.[0]?.image?.some((p) => (p?.path?.indexOf?.('mp4') ?? -1) === -1);
   }, [value]);
 
+  const hasMedia = (value?.[0]?.image?.length ?? 0) > 0;
+  const isVideo = hasMedia && !isTitle;
+
   const disclose = watch('disclose');
   const brand_organic_toggle = watch('brand_organic_toggle');
   const brand_content_toggle = watch('brand_content_toggle');
   const content_posting_method = watch('content_posting_method');
   const isUploadMode = content_posting_method === 'UPLOAD';
+
+  const tiktokRestrictionNotice = useMemo(() => {
+    if (!hasMedia || !isVideo) return null;
+    if (!isUploadMode) {
+      return t(
+        'tiktok_restriction_direct_video',
+        'TikTok restriction: For direct post with video, your post content is used as the title. A separate title field is not available.'
+      );
+    }
+    return t(
+      'tiktok_restriction_upload_video',
+      'TikTok restriction: For upload-only video, TikTok does not accept a title or message. The content will default to "#Postiz" and you can edit it inside the TikTok app before publishing.'
+    );
+  }, [hasMedia, isUploadMode, isVideo, t]);
 
   const privacyLevel = [
     {
@@ -83,6 +100,25 @@ const TikTokSettings: FC<{
   return (
     <div className="flex flex-col">
       {/*<CheckTikTokValidity picture={props?.values?.[0]?.image?.[0]?.path} />*/}
+      {tiktokRestrictionNotice && (
+        <div className="bg-tableBorder p-[10px] mb-[18px] rounded-[10px] flex gap-[10px] items-start text-[13px] text-balance">
+          <div className="shrink-0 mt-[2px]">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22.201 17.6335L14.0026 3.39569C13.7977 3.04687 13.5052 2.75764 13.1541 2.55668C12.803 2.35572 12.4055 2.25 12.001 2.25C11.5965 2.25 11.199 2.35572 10.8479 2.55668C10.4968 2.75764 10.2043 3.04687 9.99944 3.39569L1.80101 17.6335C1.60388 17.9709 1.5 18.3546 1.5 18.7454C1.5 19.1361 1.60388 19.5199 1.80101 19.8572C2.00325 20.2082 2.29523 20.499 2.64697 20.6998C2.99871 20.9006 3.39755 21.0043 3.80257 21.0001H20.1994C20.6041 21.0039 21.0026 20.9001 21.354 20.6993C21.7054 20.4985 21.997 20.2079 22.1991 19.8572C22.3965 19.52 22.5007 19.1364 22.5011 18.7456C22.5014 18.3549 22.3978 17.9711 22.201 17.6335ZM11.251 9.75006C11.251 9.55115 11.33 9.36038 11.4707 9.21973C11.6113 9.07908 11.8021 9.00006 12.001 9.00006C12.1999 9.00006 12.3907 9.07908 12.5313 9.21973C12.672 9.36038 12.751 9.55115 12.751 9.75006V13.5001C12.751 13.699 12.672 13.8897 12.5313 14.0304C12.3907 14.171 12.1999 14.2501 12.001 14.2501C11.8021 14.2501 11.6113 14.171 11.4707 14.0304C11.33 13.8897 11.251 13.699 11.251 13.5001V9.75006ZM12.001 18.0001C11.7785 18.0001 11.561 17.9341 11.376 17.8105C11.191 17.6868 11.0468 17.5111 10.9616 17.3056C10.8765 17.1 10.8542 16.8738 10.8976 16.6556C10.941 16.4374 11.0482 16.2369 11.2055 16.0796C11.3628 15.9222 11.5633 15.8151 11.7815 15.7717C11.9998 15.7283 12.226 15.7505 12.4315 15.8357C12.6371 15.9208 12.8128 16.065 12.9364 16.25C13.06 16.4351 13.126 16.6526 13.126 16.8751C13.126 17.1734 13.0075 17.4596 12.7965 17.6706C12.5855 17.8815 12.2994 18.0001 12.001 18.0001Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div>{tiktokRestrictionNotice}</div>
+        </div>
+      )}
       {isTitle && <Input label="Title" {...register('title')} maxLength={89} />}
       <Select
         label={t('label_who_can_see_this_video', 'Who can see this video?')}


### PR DESCRIPTION
# What kind of change does this PR introduce?

Frontend UX improvement (no behavior change for the API).

# Why was this change needed?

When users attach a video on TikTok, the platform imposes two restrictions that aren't obvious in our UI:
- **Direct post + video**: the post content is used as the title; a separate title field is not available.
- **Upload-only + video**: TikTok rejects any title/message, so the content defaults to "#Postiz" and the user has to edit it inside the TikTok app before publishing.

Users were hitting this without warning and finding their captions silently dropped. This PR adds an inline notice in the TikTok provider settings that surfaces the relevant restriction based on the selected media and posting method.

# Other information:

Notice is shown only when a video is attached (no notice for images or no media). The text is wired through the `useT` translation helper so the strings are localizable.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

# Screenshots
<img width="932" height="73" alt="tiktok-warning-2" src="https://github.com/user-attachments/assets/dab93978-d601-42af-b371-b0b49a6e055b" />
<img width="931" height="67" alt="tiktok-warning-1" src="https://github.com/user-attachments/assets/59101e5c-eba4-4c7c-b267-537678eccf2d" />
