### PR TITLE
Clarify TikTok pending-share error mentions the 24-hour window

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -147,7 +147,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       return {
         type: 'bad-body' as const,
         value:
-          'TikTok limit the maximum of pending posts to 5, TikTok limits you for now, please check your TikTok inbox at your TikTok mobile app and try again later',
+          'TikTok limits pending posts to 5 within any 24-hour period. Please check your TikTok inbox in the TikTok mobile app and try again after 24 hours.',
       };
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Copy fix — wording change in a user-facing error message.

# Why was this change needed?

When a TikTok publish fails with `spam_risk_too_many_pending_share`, we surface a message to the user. The old message said the limit was reached and to "try again later" — but TikTok's actual rule is **"at most 5 pending shares within any 24-hour period"** (per their daily upload cap documentation). Without the 24-hour figure, users either retry too soon and hit the same error, or assume the integration is broken.

This PR rewrites the message to state the window explicitly:

> TikTok limits pending posts to 5 within any 24-hour period. Please check your TikTok inbox in the TikTok mobile app and try again after 24 hours.

# Other information:

Single-line change in `libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts`. No logic change.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue