### PR TITLE
Change NX_ADD_PLUGINS value to string format

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
       STRIPE_SIGNING_KEY_CONNECT: ''
 
       # === Developer Settings
-      NX_ADD_PLUGINS: false
+      NX_ADD_PLUGINS: 'false'
 
       # === Short Link Service Settings (Optional - leave blank if unused)
       # DUB_TOKEN: ""


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix on the docs.

# Why was this change needed?

Following the documentation gave me this error:

ERROR: The Compose file './docker-compose.yml' is invalid because:  services.postiz.environment.NX_ADD_PLUGINS contains false, which is an invalid type, it should be a string, number, or a null

# Other information:

Nope.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
