### PR TITLE
Fix HeyGen voices list limit

### DIFF
--- a/apps/frontend/src/components/third-parties/providers/heygen.provider.tsx
+++ b/apps/frontend/src/components/third-parties/providers/heygen.provider.tsx
@@ -8,7 +8,7 @@ import { useThirdParty } from '@gitroom/frontend/components/third-parties/third-
 import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
 import { Textarea } from '@gitroom/react/form/textarea';
 import { Button } from '@gitroom/react/form/button';
-import { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
 import clsx from 'clsx';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -67,31 +67,71 @@ const SelectVoiceComponent: FC<{
   onChange: (id: string) => void;
 }> = (props) => {
   const [current, setCurrent] = useState<any>({});
+  const [language, setLanguage] = useState('');
   const { voiceList, onChange } = props;
+  const languages = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          voiceList
+            ?.map((p) => p.language)
+            .filter((p): p is string => Boolean(p))
+        )
+      ).sort((a, b) => a.localeCompare(b)),
+    [voiceList]
+  );
+  const filteredVoices = useMemo(
+    () =>
+      language ? voiceList?.filter((p) => p.language === language) : voiceList,
+    [language, voiceList]
+  );
 
   return (
-    <div className="grid grid-cols-6 gap-[10px] justify-items-center justify-center">
-      {voiceList?.map((p) => (
-        <div
-          onClick={() => {
-            setCurrent(p.voice_id === current?.voice_id ? undefined : p);
-            onChange(p.voice_id === current?.voice_id ? {} : p.voice_id);
+    <>
+      {!!languages.length && (
+        <Select
+          label="Language"
+          name="voiceLanguage"
+          disableForm
+          value={language}
+          onChange={(event) => {
+            setCurrent({});
+            onChange('');
+            setLanguage(event.target.value);
           }}
-          key={p.avatar_id}
-          className={clsx(
-            'w-full h-full p-[20px] min-h-[100px] text-[14px] hover:bg-input transition-all text-textColor relative flex flex-col gap-[15px] cursor-pointer',
-            current?.voice_id === p.voice_id
-              ? 'bg-input border border-red-500'
-              : 'bg-third'
-          )}
         >
-          <div className="text-[14px] text-balance whitespace-pre-line">
-            {p.name}
+          <option value="">All languages</option>
+          {languages.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </Select>
+      )}
+      <div className="grid grid-cols-6 gap-[10px] justify-items-center justify-center">
+        {filteredVoices?.map((p) => (
+          <div
+            onClick={() => {
+              const selected = p.voice_id !== current?.voice_id;
+              setCurrent(selected ? p : {});
+              onChange(selected ? p.voice_id : '');
+            }}
+            key={p.voice_id}
+            className={clsx(
+              'w-full h-full p-[20px] min-h-[100px] text-[14px] hover:bg-input transition-all text-textColor relative flex flex-col gap-[15px] cursor-pointer',
+              current?.voice_id === p.voice_id
+                ? 'bg-input border border-red-500'
+                : 'bg-third'
+            )}
+          >
+            <div className="text-[14px] text-balance whitespace-pre-line">
+              {p.name}
+            </div>
+            <div className="text-[12px]">{p.language}</div>
           </div>
-          <div className="text-[12px]">{p.language}</div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    </>
   );
 };
 
@@ -212,7 +252,8 @@ const HeygenProviderComponent = () => {
                   form.setValue('avatar', id);
                   form.setValue(
                     'type',
-                    data?.find((p: any) => p.id === id || p.avatar_id === id)?.id
+                    data?.find((p: any) => p.id === id || p.avatar_id === id)
+                      ?.id
                       ? 'talking_photo'
                       : 'avatar'
                   );

--- a/libraries/nestjs-libraries/src/3rdparties/heygen/heygen.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/3rdparties/heygen/heygen.provider.spec.ts
@@ -1,0 +1,40 @@
+import { HeygenProvider } from './heygen.provider';
+
+jest.mock('@gitroom/nestjs-libraries/openai/openai.service', () => ({
+  OpenaiService: class {},
+}));
+
+jest.mock('@gitroom/helpers/utils/timer', () => ({
+  timer: jest.fn(),
+}));
+
+describe('HeygenProvider', () => {
+  describe('voices', () => {
+    const fetchMock = jest.fn();
+
+    beforeEach(() => {
+      fetchMock.mockReset();
+      global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    it('returns the complete voice list from HeyGen', async () => {
+      const voices = Array.from({ length: 25 }, (_, index) => ({
+        voice_id: `voice-${index}`,
+        name: `Voice ${index}`,
+        language: index < 20 ? 'English' : 'Spanish',
+      }));
+
+      fetchMock.mockResolvedValue({
+        json: async () => ({
+          data: {
+            voices,
+          },
+        }),
+      });
+
+      const provider = new HeygenProvider({} as any);
+
+      await expect(provider.voices('api-key')).resolves.toHaveLength(25);
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/3rdparties/heygen/heygen.provider.ts
+++ b/libraries/nestjs-libraries/src/3rdparties/heygen/heygen.provider.ts
@@ -66,7 +66,7 @@ export class HeygenProvider extends ThirdPartyAbstract<{
       })
     ).json();
 
-    return voices.slice(0, 20);
+    return voices;
   }
 
   async avatars(apiKey: string) {


### PR DESCRIPTION
## Summary
- Return the complete HeyGen voice list instead of truncating it to the first 20 voices.
- Add a language filter to the HeyGen voice selector so non-English voices are easier to find.
- Add regression coverage for the full voices response.

## Why
HeyGen supports more voices and languages than the first 20 entries returned by the API response. The backend slice made non-English voices unavailable in Postiz.

## Changes
- Removed the backend `voices.slice(0, 20)` limit.
- Added a language dropdown above the frontend voice grid.
- Reset the selected voice when the language filter changes.
- Key voice cards by `voice_id` instead of `avatar_id`.

## Testing
- Targeted Jest regression test for `HeygenProvider.voices()` passes.
- `corepack pnpm exec prettier --check apps/frontend/src/components/third-parties/providers/heygen.provider.tsx libraries/nestjs-libraries/src/3rdparties/heygen/heygen.provider.ts libraries/nestjs-libraries/src/3rdparties/heygen/heygen.provider.spec.ts`
- `git diff --check`
- `corepack pnpm exec tsc -p apps/frontend/tsconfig.json --noEmit --pretty false`

## Known limitations
- Manual HeyGen API verification was not run because creating a HeyGen API key requires a paid deposit.
- `corepack pnpm exec tsc -p libraries/nestjs-libraries/tsconfig.lib.json --noEmit --pretty false` still reports pre-existing unrelated type errors.
- ESLint did not start locally because the repo config fails with a circular structure error before linting files.

Closes #1545