### PR TITLE
Fix: move URL to position 3 in claude mcp add command examples

### DIFF
--- a/apps/frontend/src/components/public-api/public.component.tsx
+++ b/apps/frontend/src/components/public-api/public.component.tsx
@@ -41,7 +41,7 @@ const getMcpConfig = (
     switch (client) {
       case 'Claude Code':
         return {
-          config: `claude mcp add postiz --transport http "${urlWithKey}"`,
+          config: `claude mcp add postiz "${urlWithKey}" --transport http`,
           hint: 'Run this command in your terminal.',
         };
       case 'Cursor':
@@ -89,7 +89,7 @@ const getMcpConfig = (
   switch (client) {
     case 'Claude Code':
       return {
-        config: `claude mcp add postiz \\\n  --transport http \\\n  --header "Authorization: ${bearer}" \\\n  "${urlBase}"`,
+        config: `claude mcp add postiz "${urlBase}" \\\n  --transport http \\\n  --header "Authorization: ${bearer}"`,
         hint: 'Run this command in your terminal.',
       };
     case 'Cursor':


### PR DESCRIPTION
Claude Code's CLI requires <commandOrUrl> as the third positional argument, immediately after the MCP server name. The current command examples place the URL after the flags, which causes Claude Code's parser to fail with:

    error: missing required argument 'commandOrUrl'

This PR reorders both example commands so the URL comes right after `postiz`, matching the expected `claude mcp add <name> <commandOrUrl> [options]` signature.

Tested with Claude Code (2026-05): original command failed, fixed command succeeded and the Postiz MCP loads correctly.

<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) before submitting a PR. -->

# What kind of change does this PR introduce?

eg: Bug fix, feature, docs update, ...

# Why was this change needed?

Please link to related issues when possible, and explain WHY you changed things, not WHAT you changed.

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue
