### PR TITLE
fix: surface X credit errors in calendar with readable post error messages

### DIFF
--- a/libraries/helpers/src/utils/posts.list.minify.ts
+++ b/libraries/helpers/src/utils/posts.list.minify.ts
@@ -25,6 +25,7 @@ const POST_ITEM_KEYS: Record<string, string> = {
   integration: 'n',
   intervalInDays: 'iv',
   actualDate: 'ad',
+  error: 'e',
 };
 
 const INTEGRATION_KEYS: Record<string, string> = {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -17,6 +17,67 @@ dayjs.extend(weekOfYear);
 dayjs.extend(isSameOrAfter);
 dayjs.extend(utc);
 
+function normalizePostError(err: unknown): string {
+  if (typeof err === 'string') {
+    try {
+      const parsed = JSON.parse(err);
+      if (parsed && typeof parsed === 'object') {
+        return normalizePostError(parsed);
+      }
+    } catch {
+      return err;
+    }
+  }
+
+  if (err && typeof err === 'object') {
+    const e = err as {
+      cause?: {
+        message?: string;
+        failure?: { message?: string };
+        cause?: { message?: string; failure?: { message?: string } };
+      };
+      failure?: { message?: string };
+      message?: string;
+    };
+
+    const candidates = [
+      e.cause?.failure?.message,
+      e.cause?.cause?.failure?.message,
+      e.cause?.cause?.message,
+      e.cause?.message,
+      e.failure?.message,
+      e.message,
+    ];
+
+    for (const message of candidates) {
+      if (typeof message === 'string' && message.trim()) {
+        return message;
+      }
+    }
+  }
+
+  return JSON.stringify(err);
+}
+
+function formatStoredPostError(error: string | null | undefined) {
+  if (!error) {
+    return error;
+  }
+
+  if (error.startsWith('{') || error.startsWith('[')) {
+    return normalizePostError(error);
+  }
+
+  return error;
+}
+
+function withReadablePostError<T extends { error?: string | null }>(post: T) {
+  return {
+    ...post,
+    error: formatStoredPostError(post.error),
+  };
+}
+
 @Injectable()
 export class PostsRepository {
   constructor(
@@ -171,6 +232,7 @@ export class PostsRepository {
         releaseURL: true,
         releaseId: true,
         state: true,
+        error: true,
         intervalInDays: true,
         group: true,
         tags: {
@@ -191,18 +253,20 @@ export class PostsRepository {
 
     return list.reduce((all, post) => {
       if (!post.intervalInDays) {
-        return [...all, post];
+        return [...all, withReadablePostError(post)];
       }
 
       const addMorePosts = [];
       let startingDate = dayjs.utc(post.publishDate);
       while (dayjs.utc(endDate).isSameOrAfter(startingDate)) {
         if (dayjs(startingDate).isSameOrAfter(dayjs.utc(post.publishDate))) {
-          addMorePosts.push({
-            ...post,
-            publishDate: startingDate.toDate(),
-            actualDate: post.publishDate,
-          });
+          addMorePosts.push(
+            withReadablePostError({
+              ...post,
+              publishDate: startingDate.toDate(),
+              actualDate: post.publishDate,
+            })
+          );
         }
 
         startingDate = startingDate.add(post.intervalInDays, 'days');
@@ -259,6 +323,7 @@ export class PostsRepository {
           releaseURL: true,
           releaseId: true,
           state: true,
+          error: true,
           group: true,
           tags: {
             select: {
@@ -279,7 +344,7 @@ export class PostsRepository {
     ]);
 
     return {
-      posts,
+      posts: posts.map(withReadablePostError),
       total,
       page,
       limit,
@@ -383,15 +448,15 @@ export class PostsRepository {
   }
 
   async changeState(id: string, state: State, err?: any, body?: any) {
+    const errorMessage = err ? normalizePostError(err) : undefined;
+
     const update = await this._post.model.post.update({
       where: {
         id,
       },
       data: {
         state,
-        ...(err
-          ? { error: typeof err === 'string' ? err : JSON.stringify(err) }
-          : {}),
+        ...(errorMessage ? { error: errorMessage } : {}),
       },
       include: {
         integration: {
@@ -406,7 +471,7 @@ export class PostsRepository {
       try {
         await this._errors.model.errors.create({
           data: {
-            message: typeof err === 'string' ? err : JSON.stringify(err),
+            message: errorMessage!,
             organizationId: update.organizationId,
             platform: update.integration.providerIdentifier,
             postId: update.id,

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -46,6 +46,30 @@ function safeStringify(obj: any) {
   });
 }
 
+function errorToHandleString(err: unknown): string {
+  if (typeof err === 'string') {
+    return err;
+  }
+
+  if (err && typeof err === 'object') {
+    const e = err as Record<string, unknown>;
+
+    if (e.data !== undefined) {
+      return typeof e.data === 'string' ? e.data : safeStringify(e.data);
+    }
+
+    if (e.errors !== undefined) {
+      return safeStringify(e.errors);
+    }
+
+    if (typeof e.message === 'string') {
+      return e.message;
+    }
+  }
+
+  return safeStringify(err);
+}
+
 export abstract class SocialAbstract {
   abstract identifier: string;
   maxConcurrentJob = 1;
@@ -79,7 +103,7 @@ export abstract class SocialAbstract {
     try {
       value = await func();
     } catch (err) {
-      const handle = this.handleErrors(safeStringify(err), 200);
+      const handle = this.handleErrors(errorToHandleString(err), 200);
       value = { err: true, value: 'Unknown Error', ...(handle || {}) };
     }
 

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -58,6 +58,18 @@ export class XProvider extends SocialAbstract implements SocialProvider {
         value: 'Posting failed - capped reached. Please try again later',
       };
     }
+
+    if (
+      body.includes('CreditsDepleted') ||
+      body.includes('does not have any credits') ||
+      body.includes('402 Payment Required')
+    ) {
+      return {
+        type: 'bad-body',
+        value:
+          "X couldn't publish this post — add credits to your X developer account.",
+      };
+    }
     if (body.includes('duplicate-rules')) {
       return {
         type: 'bad-body',


### PR DESCRIPTION
fix: surface X credit errors in calendar with readable post error messages

- Map X CreditsDepleted/402 errors to a user-friendly message
- Normalize Temporal error payloads when storing and returning Post.error
- Include error field in minified posts API responses

<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) before submitting a PR. -->

# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

When an X (Twitter) post fails due to depleted developer API credits, users had no actionable feedback in the calendar. The post would land in an error state, but the tooltip showed a generic message because:

1. **X credit errors were not mapped** — The X provider did not handle `CreditsDepleted`, `402 Payment Required`, or related API responses, so failures fell through to a generic “Unknown Error”.
2. **Errors were stored and returned as raw JSON** — Temporal/orchestrator failures (nested `cause.failure.message` payloads from twitter-api-v2) were stringified into `Post.error`, which the UI could not display meaningfully even though the calendar already reads `post.error` for tooltips.
3. **The minified posts API omitted `error`** — Calendar and list views use the minified posts endpoint; without `error` in `POST_ITEM_KEYS`, failed posts never received the failure message on the frontend.

This change ensures X credit exhaustion surfaces as a clear, user-facing message — *“X couldn't publish this post — add credits to your X developer account.”* — and that existing and newly stored errors are normalized before persistence and API responses.

Related: _(add issue link from [contribute.postiz.com](https://contribute.postiz.com/p/postiz) or GitHub issue here)_

# Other information:

- No UI changes were required; the calendar tooltip in `calendar.tsx` already displays `post.error` when present.
- `normalizePostError` also improves readability for other providers whose failures arrive as nested Temporal JSON, not only X credit errors.
- Posts that failed **before** this fix may still show the old JSON string until they are retried and fail again with the new handling.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue