### PR TITLE
fix(instagram): move collaborators param from carousel children to container

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -594,8 +594,11 @@ export class InstagramProvider
             )}`
           : ``;
 
+        // collaborators are only allowed on single-media posts, NOT on carousel children
+        // For carousels, collaborators are added to the container creation call instead
+        const isCarouselItem = (firstPost?.media?.length || 0) > 1 && !isStory;
         const collaborators =
-          firstPost?.settings?.collaborators?.length && !isStory
+          firstPost?.settings?.collaborators?.length && !isStory && !isCarouselItem
             ? `&collaborators=${JSON.stringify(
                 firstPost?.settings?.collaborators.map((p) => p.label)
               )}`
@@ -687,13 +690,21 @@ export class InstagramProvider
         },
       ];
     } else {
+      // Add collaborators to the carousel container (where IG's Graph API accepts them)
+      const carouselCollaborators =
+        firstPost?.settings?.collaborators?.length && !isStory
+          ? `&collaborators=${JSON.stringify(
+              firstPost?.settings?.collaborators.map((p: { label: string }) => p.label)
+            )}`
+          : ``;
+
       const { id: containerId, ...all3 } = await (
         await this.fetch(
           `https://${type}/v20.0/${id}/media?caption=${encodeURIComponent(
             firstPost?.message
           )}&media_type=CAROUSEL&children=${encodeURIComponent(
             medias.join(',')
-          )}&access_token=${accessToken}`,
+          )}${carouselCollaborators}&access_token=${accessToken}`,
           {
             method: 'POST',
           }


### PR DESCRIPTION
## Summary

Fixes #1547 — Instagram carousel posts fail when `collaborators` is set.

- **Remove** the `collaborators` parameter from carousel child media creation calls (`is_carousel_item=true`), where Instagram's Graph API rejects it
- **Add** the `collaborators` parameter to the carousel container creation call (`media_type=CAROUSEL`), where the API accepts it
- Single-image and single-video posts are **unaffected** (they still attach collaborators to the individual media endpoint)

## Root cause

The `collaborators` param was being appended to each child media item URL. Instagram's Graph API does not allow `collaborators` on `is_carousel_item=true` requests — it only accepts it on the parent `CAROUSEL` container endpoint (supported since 2024).

## Changes

`libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts`:
- Added `isCarouselItem` guard so `collaborators` is excluded from child media URLs
- Added `carouselCollaborators` variable to the carousel container creation URL

## Test plan

- [ ] Create a carousel post (2+ images) with collaborator tagging → should succeed
- [ ] Create a single-image post with collaborator tagging → should still succeed
- [ ] Create a carousel post without collaborators → should still succeed
- [ ] Create a story post → collaborators correctly excluded