### PR TITLE
chore(frontend): fix duplicate "the" in scroll comment

### DIFF
--- a/apps/frontend/src/components/new-launch/editor.tsx
+++ b/apps/frontend/src/components/new-launch/editor.tsx
@@ -300,7 +300,7 @@ export const EditorWrapper: FC<{
   const addValue = useCallback(
     (index: number) => () => {
       setTimeout(() => {
-        // scroll the the bottom
+        // scroll to the bottom
         document.querySelector('#social-content').scrollTo({
           top: document.querySelector('#social-content').scrollHeight,
         });


### PR DESCRIPTION
`apps/frontend/src/components/new-launch/editor.tsx:303` said "scroll the the bottom" → "scroll to the bottom" (matches the `scrollTo({ top: scrollHeight })` call below). Comment-only.