### PR TITLE
fix(instagram): treat post-publish permalink read as best-effort

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -551,6 +551,33 @@ export class InstagramProvider
     };
   }
 
+  // The post is already published once media_publish returns an id. The
+  // permalink read is non-critical: Instagram intermittently returns errors
+  // (e.g. error_subcode 33, or 2207051) on reads of just-published objects,
+  // which previously threw BadBody and marked an already-published post as
+  // ERROR. Treat the permalink read as best-effort so a transient read failure
+  // never discards a successful publish.
+  private async getPermalinkSafe(
+    type: string,
+    mediaId: string,
+    token: string
+  ): Promise<string> {
+    try {
+      const { permalink } = await (
+        await this.fetch(
+          `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${token}`
+        )
+      ).json();
+      return permalink || '';
+    } catch (err) {
+      console.error(
+        'Instagram: non-fatal permalink read failure after publish',
+        err
+      );
+      return '';
+    }
+  }
+
   async post(
     id: string,
     token: string,
@@ -650,12 +677,11 @@ export class InstagramProvider
         ).json();
         lastMediaId = mediaId;
 
-        const { permalink } = await (
-          await this.fetch(
-            `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${userToken || accessToken}`
-          )
-        ).json();
-        lastPermalink = permalink;
+        lastPermalink = await this.getPermalinkSafe(
+          type,
+          mediaId,
+          userToken || accessToken
+        );
       }
 
       return [
@@ -676,11 +702,11 @@ export class InstagramProvider
         )
       ).json();
 
-      const { permalink } = await (
-        await this.fetch(
-          `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${userToken || accessToken}`
-        )
-      ).json();
+      const permalink = await this.getPermalinkSafe(
+        type,
+        mediaId,
+        userToken || accessToken
+      );
 
       return [
         {
@@ -728,11 +754,11 @@ export class InstagramProvider
         )
       ).json();
 
-      const { permalink } = await (
-        await this.fetch(
-          `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${userToken || accessToken}`
-        )
-      ).json();
+      const permalink = await this.getPermalinkSafe(
+        type,
+        mediaId,
+        userToken || accessToken
+      );
 
       return [
         {


### PR DESCRIPTION
## Problem

Instagram publishes succeed (the post goes live) but Postiz marks them **ERROR**, and the post's `releaseURL`/`postId` are lost.

In `InstagramProvider.post()`, after `media_publish` returns a media id the post is already published. The code then does `GET /{mediaId}?fields=permalink` purely to populate `releaseURL`. But `SocialAbstract.fetch()` throws `BadBody` (nonRetryable) on **any** non-2xx response, so a transient Meta error on the read-back of a just-published object — e.g. `error_subcode 33`, or `2207051` — discards an already-published post and flags it ERROR.

This is observable in production: the carousel/post appears on the Instagram profile while Postiz shows ERROR. Reported in #1562 (the matching code 100 / subcode 33 read failures).

## Fix

Add `getPermalinkSafe()` — wraps the permalink read in try/catch and returns `''` on failure — and route the three publish paths (story loop, single image, carousel) through it. Once `media_publish` returns an id the post is live, so the permalink is best-effort and must never fail the post.

- One file, `+42/-16`.
- `instagram-standalone` inherits the fix (it delegates `post()` to `InstagramProvider`).
- Out of scope: `comment()` has the same fragile permalink read; left unchanged to keep this focused on the reported publish failure.

Fixes #1562
