### PR TITLE
Add cover_url support for Instagram Reels

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -573,13 +573,17 @@ export class InstagramProvider
           (firstPost?.media?.length || 0) > 1 && !isStory
             ? `&is_carousel_item=true`
             : ``;
+        const coverUrl =
+          firstPost?.media?.length === 1 && !isStory && m.thumbnail
+            ? `&cover_url=${encodeURIComponent(m.thumbnail)}`
+            : ``;
         const mediaType = hasExtension(m.path, 'mp4')
           ? firstPost?.media?.length === 1
             ? isStory
               ? `video_url=${m.path}&media_type=STORIES`
               : `video_url=${m.path}&media_type=REELS&thumb_offset=${
                   m?.thumbnailTimestamp || 0
-                }`
+                }${coverUrl}`
             : isStory
             ? `video_url=${m.path}&media_type=STORIES`
             : `video_url=${m.path}&media_type=VIDEO&thumb_offset=${


### PR DESCRIPTION
## Summary

- adds support for forwarding a media thumbnail as `cover_url` when publishing single-video Instagram Reels
- keeps the existing `thumb_offset` behavior as a fallback
- limits the change to non-story single-video Reels

Fixes #1572.

## Testing

- `git diff --check`
- attempted `pnpm exec tsc --noEmit --pretty false --skipLibCheck`, but this fresh clone has no installed dependencies and `tsc` is not available
