### PR TITLE
Replace deprecated Instagram Basic scope with Business scope

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -29,7 +29,7 @@ export class InstagramProvider
   isBetweenSteps = true;
   toolTip = 'Instagram must be business and connected to a Facebook page';
   scopes = [
-    'instagram_basic',
+    'instagram_business_basic',
     'pages_show_list',
     'pages_read_engagement',
     'business_management',


### PR DESCRIPTION
# What kind of change does this PR introduce?
Bug fix

# Why was this change needed?
Fixes #1578

Meta deprecated the `instagram_basic` scope. When users tried to connect 
their Instagram account via "Instagram (Facebook Business)", the OAuth flow 
was failing with:

"Invalid Scopes: instagram_basic, pages_read_engagement, 
instagram_content_publish, instagram_manage_insights"

Replaced `instagram_basic` with `instagram_business_basic` in the scopes 
array inside `instagram.provider.ts` as per Meta's official API changelog.

# Other information:
Small one-line fix. Discussed in issue #1578 before working on it.
No future changes planned — this is a straightforward scope name update.

# Checklist:
- [X] I have read the CONTRIBUTING guide.
- [X] I have signed the Contributor License Agreement (CLA).
- [X ] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue