### PR TITLE
Fix X thread comment delay units for API-created posts

### DIFF
--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.delay.spec.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.delay.spec.ts
@@ -1,0 +1,21 @@
+/// <reference types="jest" />
+
+import { commentDelayToMilliseconds } from './post.workflow.delay';
+
+describe('commentDelayToMilliseconds', () => {
+  it('keeps CLI/API delays above the UI preset range as milliseconds', () => {
+    expect(commentDelayToMilliseconds(5000)).toBe(5000);
+    expect(commentDelayToMilliseconds('2000')).toBe(2000);
+  });
+
+  it('keeps UI comment delays in minutes', () => {
+    expect(commentDelayToMilliseconds(1)).toBe(60000);
+    expect(commentDelayToMilliseconds(120)).toBe(7200000);
+  });
+
+  it('normalizes empty, invalid, and negative delays to zero', () => {
+    expect(commentDelayToMilliseconds()).toBe(0);
+    expect(commentDelayToMilliseconds('not-a-number')).toBe(0);
+    expect(commentDelayToMilliseconds(-5)).toBe(0);
+  });
+});

--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.delay.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.delay.ts
@@ -1,0 +1,17 @@
+const MAX_UI_COMMENT_DELAY_MINUTES = 120;
+
+export const commentDelayToMilliseconds = (delay?: number | string | null) => {
+  const numericDelay = Math.max(0, Number(delay ?? 0));
+
+  if (!Number.isFinite(numericDelay) || numericDelay === 0) {
+    return 0;
+  }
+
+  // UI-created comment delays are stored in minutes (1, 2, 5, 120, ...).
+  // Public API / CLI-created comment delays are documented in milliseconds
+  // and default to 5000. Treat values above the largest UI preset as the
+  // documented millisecond unit so CLI-created threads do not wait for days.
+  return numericDelay > MAX_UI_COMMENT_DELAY_MINUTES
+    ? numericDelay
+    : numericDelay * 60000;
+};

--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.5.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.5.ts
@@ -15,6 +15,7 @@ import { PostResponse } from '@gitroom/nestjs-libraries/integrations/social/soci
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { TypedSearchAttributes } from '@temporalio/common';
 import { postId as postIdSearchParam } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
+import { commentDelayToMilliseconds } from './post.workflow.delay';
 
 const proxyTaskQueue = (taskQueue: string) => {
   return proxyActivities<PostActivity>({
@@ -177,7 +178,7 @@ export async function postWorkflowV105({
           // then post the comments if any
         } else {
           if (postsList[i].delay) {
-            await sleep(60000 * Math.max(0, Number(postsList[i].delay ?? 0)));
+            await sleep(commentDelayToMilliseconds(postsList[i].delay));
           }
 
           postsResults.push(


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Fixes #1581.

X/Twitter thread replies created via the public API / CLI can be delayed by days instead of seconds.

The UI stores comment delays in minutes (`1`, `2`, `5`, `120`, ...), but the CLI/docs expose `--delay` as milliseconds and default to `5000`. The current `postWorkflowV105` always multiplies `postsList[i].delay` by `60000`, so an API/CLI-created reply with the default `5000` delay waits about 83 hours instead of 5 seconds. That makes scheduled X threads look like the reply never published.

This PR adds a small normalizer for comment delays:

- `<= 120`: treat as existing UI minutes
- `> 120`: treat as documented API/CLI milliseconds
- invalid, negative, or empty: normalize to `0`

Then `postWorkflowV105` uses that normalizer before sleeping between the main post and comments.

# Other information:

Validation performed:

```bash
NODE_OPTIONS=--max-old-space-size=8192 \
  npx --yes -p node@22 -p pnpm@10.6.1 pnpm exec jest \
  apps/orchestrator/src/workflows/post-workflows/post.workflow.delay.spec.ts \
  --runInBand --coverage=false \
  --config '{"testEnvironment":"node","transform":{"^.+\\.ts$":"ts-jest"},"testRegex":".*\\.spec\\.ts$","moduleFileExtensions":["ts","js","json"],"rootDir":"."}'
```

Result: 3 tests passed.

```bash
NODE_OPTIONS=--max-old-space-size=8192 \
  npx --yes -p node@22 -p pnpm@10.6.1 pnpm run build:orchestrator
```

Result: orchestrator build passed.

Local note: root `jest.config.ts` failed in this checkout because `@nx/jest` was not installed/resolved, so I ran the focused spec with an inline Jest config.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
