### PR TITLE
Add Cloudflare self-hosted deployment (Workers + Containers) with pluggable AI Gateway routing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,8 @@ dist
 .git
 .github
 reports
+/apps/orchestrator/dist
+# Cloudflare deploy tooling is not part of the app image, except the
+# container boot/backup scripts
+deploy/cloudflare
+!deploy/cloudflare/container

--- a/apps/backend/src/api/routes/copilot.controller.ts
+++ b/apps/backend/src/api/routes/copilot.controller.ts
@@ -20,6 +20,13 @@ import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/s
 import { MastraAgent } from '@ag-ui/mastra';
 import { MastraService } from '@gitroom/nestjs-libraries/chat/mastra.service';
 import { Request, Response } from 'express';
+import OpenAI from 'openai';
+import {
+  aiApiKey,
+  aiBaseURL,
+  aiDefaultHeaders,
+  textModel,
+} from '@gitroom/nestjs-libraries/openai/ai.gateway.config';
 import { RequestContext } from '@mastra/core/di';
 import { CheckPolicies } from '@gitroom/backend/services/auth/permissions/permissions.ability';
 import { AuthorizationActions, Sections } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
@@ -29,6 +36,20 @@ export type ChannelsContext = {
   organization: string;
   ui: string;
 };
+
+// Route CopilotKit's OpenAI calls through the Cloudflare AI Gateway dynamic
+// route when configured (see ai.gateway.config.ts); stock OpenAI otherwise.
+const copilotServiceAdapter = () =>
+  new OpenAIAdapter({
+    model: textModel(),
+    // @copilotkit/runtime types against its own bundled `openai` copy; the
+    // instance is API-compatible, only the nominal type differs.
+    openai: new OpenAI({
+      apiKey: aiApiKey,
+      baseURL: aiBaseURL,
+      defaultHeaders: aiDefaultHeaders,
+    }) as any,
+  });
 
 @Controller('/copilot')
 export class CopilotController {
@@ -49,9 +70,7 @@ export class CopilotController {
     const copilotRuntimeHandler = copilotRuntimeNodeHttpEndpoint({
       endpoint: '/copilot/chat',
       runtime: new CopilotRuntime(),
-      serviceAdapter: new OpenAIAdapter({
-        model: 'gpt-4.1',
-      }),
+      serviceAdapter: copilotServiceAdapter(),
     });
 
     return copilotRuntimeHandler(req, res);
@@ -95,9 +114,7 @@ export class CopilotController {
       endpoint: '/copilot/agent',
       runtime,
       // properties: req.body.variables.properties,
-      serviceAdapter: new OpenAIAdapter({
-        model: 'gpt-4.1',
-      }),
+      serviceAdapter: copilotServiceAdapter(),
     });
 
     return copilotRuntimeHandler.handleRequest(req, res);

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -1,0 +1,111 @@
+# Postiz on Cloudflare (self-hosted)
+
+Runs the full Postiz stack on the Cloudflare Developer Platform: a Worker
+fronts a single all-in-one Container, uploads/state are persisted to R2, and
+every LLM call is routed through the account's **AI Gateway dynamic routes**.
+
+```
+                    ┌─────────────────────────────────────────────┐
+ browser ──────────▶│ Worker "postiz"                             │
+                    │  /__backup/*  ── R2 bucket postiz-backups   │
+                    │  /__ai/v1/images/generations ── Workers AI  │
+                    │       (env.AI.run + { gateway: { id } })    │
+                    │  /*  ─────────┐                             │
+                    │  cron */5 min │ keep-alive                  │
+                    └───────────────┼─────────────────────────────┘
+                                    ▼
+                    ┌─────────────────────────────────────────────┐
+                    │ Container (standard-2: 1 vCPU/6GiB/12GB)    │
+                    │  nginx :5000                                │
+                    │   ├─ /api/     → backend (NestJS :3000)     │
+                    │   ├─ /uploads/ → local files                │
+                    │   └─ /         → frontend (Next.js :4200)   │
+                    │  orchestrator (Temporal worker :3002)       │
+                    │  postgres 15 · redis (cache) ·              │
+                    │  temporal dev server (SQLite)               │
+                    │  backup loop → PUT /__backup/* every 5 min  │
+                    └─────────────────────────────────────────────┘
+                                    │ chat/completions
+                                    ▼
+        https://gateway.ai.cloudflare.com/v1/<acct>/x/compat
+                       model: dynamic/text_gen
+```
+
+## AI Gateway routing
+
+All text generation (OpenAI SDK, LangChain `ChatOpenAI`, CopilotKit, Mastra /
+ai-sdk) goes through the gateway's OpenAI-compat endpoint with the
+`dynamic/text_gen` route — configured centrally in
+`libraries/nestjs-libraries/src/openai/ai.gateway.config.ts` and enabled by
+`CF_AIG_TOKEN` + `CF_ACCOUNT_ID`. Without those env vars the app behaves like
+stock Postiz (direct OpenAI), so the fork stays upstream-mergeable.
+
+Image generation: the compat endpoint does not serve `images/generations`
+(gateway error 2019), so the Worker exposes an OpenAI-images-shaped endpoint
+at `/__ai/v1/images/generations` backed by
+`env.AI.run(IMAGE_MODEL, { prompt }, { gateway: { id } })` — the sanctioned
+Worker-side gateway pattern. Swap `IMAGE_MODEL` in `wrangler.jsonc` to any
+Workers AI image model.
+
+## Durability model (read this)
+
+Cloudflare Containers have **ephemeral disk**. Durability comes from the
+backup loop in `container/backup.sh`:
+
+- Postgres `pg_dumpall` → `db-latest.sql.gz` every 5 min (+ 7-day daily ring)
+- Temporal SQLite online-backup → `temporal-latest.db` every 5 min
+- `/uploads` files → `uploads/<path>` incrementally
+
+all PUT through the Worker into the `postiz-backups` R2 bucket (the container
+holds no S3 credentials; `INTERNAL_SECRET` authenticates it to the Worker).
+On a cold start the entrypoint restores all three before the app boots.
+
+**RPO is ~5 minutes** (`BACKUP_INTERVAL_SECONDS` to tune). If the container
+is evicted (deploy, host maintenance), in-flight changes since the last
+backup are lost. Good enough for a personal instance; for stronger
+guarantees, point `DATABASE_URL` (Worker secret) at a managed Postgres
+(Neon/Supabase, ideally via Hyperdrive) and `TEMPORAL_ADDRESS` at Temporal
+Cloud — the entrypoint then skips the in-container instances automatically.
+
+A cron trigger pings the container every 5 minutes so it stays warm —
+required for Temporal timers (scheduled posts) to fire and billed
+accordingly (this is an always-on instance by design).
+
+## Deploy
+
+```bash
+cd deploy/cloudflare
+
+# one-time secrets
+npx wrangler secret put JWT_SECRET       # any long random string
+npx wrangler secret put CF_AIG_TOKEN     # AI Gateway authentication token
+npx wrangler secret put INTERNAL_SECRET  # any long random string (container<->worker auth)
+
+./deploy.sh
+```
+
+The container image builds **fully from source** inside Docker
+(`container/Dockerfile`, build context = repo root) — node 22 bookworm-slim,
+`pnpm install`, `pnpm run build`, mirroring the repo's own `Dockerfile.dev`,
+plus Postgres/Redis/Temporal-CLI and the boot/backup scripts. (The published
+`ghcr.io/gitroomhq/postiz-app` image is an older Alpine/Caddy packaging and
+is not used.) The first build takes a while; later builds reuse the Docker
+layer cache — source changes only re-run the `pnpm install`/`build` layers.
+
+`vars.PUBLIC_URL` in `wrangler.jsonc` must match the deployed URL
+(workers.dev or a custom domain); the frontend reads it at runtime, so
+changing it only requires a redeploy, not an image rebuild.
+
+First request after a cold start takes ~1–2 min (restore + boot); check
+`npx wrangler tail` and the container logs in the dash if it seems stuck.
+
+## Env contract (container)
+
+Set by the Worker (`containerEnv()` in `worker/src/index.ts`):
+`MAIN_URL`/`FRONTEND_URL`/`NEXT_PUBLIC_BACKEND_URL` (from `PUBLIC_URL`),
+`JWT_SECRET`, `CF_ACCOUNT_ID`, `CF_GATEWAY_ID`, `CF_AIG_TOKEN`,
+`AI_TEXT_MODEL`, `AI_IMAGE_BASE_URL`, `OPENAI_API_KEY` (= gateway token, for
+feature gates), `BACKUP_URL`, `INTERNAL_SECRET`, optional `DATABASE_URL` /
+`REDIS_URL` overrides. Everything else defaults in
+`container/entrypoint.sh`. Social-network OAuth keys can be added to
+`containerEnv()` as Worker secrets when needed.

--- a/deploy/cloudflare/container/Dockerfile
+++ b/deploy/cloudflare/container/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+# Postiz all-in-one image for Cloudflare Containers, built fully from source.
+#
+# Mirrors the repo's Dockerfile.dev (node 22 bookworm-slim, pnpm install,
+# pnpm build, nginx + pm2) — the published ghcr.io image is an older
+# Alpine/Caddy packaging that can't be overlaid — and adds:
+#   - in-container Postgres + Redis + Temporal dev server
+#   - entrypoint that restores state from R2 (via the fronting Worker) on
+#     cold start, and a loop that backs it up continuously
+#
+# Container disk is EPHEMERAL: durability comes exclusively from the backup
+# loop. Build context is the repo root (see image_build_context in
+# wrangler.jsonc); the root .dockerignore keeps the context small.
+FROM node:22.20-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    g++ \
+    make \
+    python3-pip \
+    bash \
+    nginx \
+    postgresql \
+    postgresql-client \
+    redis-server \
+    sqlite3 \
+    curl \
+    ca-certificates \
+    procps \
+ && rm -rf /var/lib/apt/lists/*
+
+# nginx runs as www (matches var/docker/nginx.conf), same as upstream image
+RUN addgroup --system www \
+ && adduser --system --ingroup www --home /www --shell /usr/sbin/nologin www \
+ && mkdir -p /www \
+ && chown -R www:www /www /var/lib/nginx
+
+# Temporal CLI: single static binary whose dev server (SQLite-backed)
+# replaces the temporalio/auto-setup + postgres + elasticsearch stack from
+# the upstream docker-compose.
+ARG TEMPORAL_CLI_VERSION=1.7.2
+ARG TARGETARCH
+RUN curl -fsSL "https://github.com/temporalio/cli/releases/download/v${TEMPORAL_CLI_VERSION}/temporal_cli_${TEMPORAL_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin temporal \
+ && temporal --version
+
+# prisma pinned to the version the repo's prisma-db-push script uses, so
+# schema sync at boot downloads nothing
+RUN npm --no-update-notifier --no-fund --global install pnpm@10.6.1 pm2 prisma@6.5.0
+
+WORKDIR /app
+
+COPY . /app
+COPY var/docker/nginx.conf /etc/nginx/nginx.conf
+
+RUN pnpm install --frozen-lockfile
+RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm run build
+
+# Copied after the build layers so script tweaks don't bust the pnpm cache.
+COPY deploy/cloudflare/container/entrypoint.sh /postiz-cf/entrypoint.sh
+COPY deploy/cloudflare/container/backup.sh /postiz-cf/backup.sh
+RUN chmod +x /postiz-cf/entrypoint.sh /postiz-cf/backup.sh
+
+EXPOSE 5000
+CMD ["/postiz-cf/entrypoint.sh"]

--- a/deploy/cloudflare/container/backup.sh
+++ b/deploy/cloudflare/container/backup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Continuous state backup to R2 (through the fronting Worker's /__backup
+# routes). Container disk is ephemeral — this loop IS the durability story.
+# RPO == BACKUP_INTERVAL_SECONDS (default 5 minutes).
+set -uo pipefail
+
+log() { echo "[backup] $(date -u +%H:%M:%S) $*"; }
+
+[ -z "${BACKUP_URL:-}" ] && { log "BACKUP_URL not set; backups disabled"; exit 0; }
+
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-300}"
+UPLOAD_DIRECTORY="${UPLOAD_DIRECTORY:-/uploads}"
+MARKER=/data/.uploads-synced
+
+put() { # put <key> <file>
+  curl -fsS -X PUT \
+    -H "authorization: Bearer ${INTERNAL_SECRET:-}" \
+    --data-binary @"$2" \
+    -o /dev/null \
+    "$BACKUP_URL/$1"
+}
+
+last_daily=''
+while sleep "$INTERVAL"; do
+  # --- postgres (local instance only) ---
+  if [ -s /data/pg/PG_VERSION ]; then
+    if su postgres -s /bin/bash -c pg_dumpall > /tmp/db.sql 2>/tmp/db.err; then
+      gzip -f /tmp/db.sql
+      put db-latest.sql.gz /tmp/db.sql.gz && log "postgres backed up ($(du -h /tmp/db.sql.gz | cut -f1))" \
+        || log "postgres upload FAILED"
+      # one rotating snapshot per day (7-day ring)
+      today="$(date -u +%Y%m%d)"
+      if [ "$today" != "$last_daily" ]; then
+        put "db-daily-$(date -u +%u).sql.gz" /tmp/db.sql.gz && last_daily="$today"
+      fi
+    else
+      log "pg_dumpall FAILED: $(tail -1 /tmp/db.err)"
+    fi
+  fi
+
+  # --- temporal (sqlite online backup; holds scheduled-post workflow state) ---
+  if [ -f /data/temporal.db ]; then
+    if sqlite3 /data/temporal.db ".backup /tmp/temporal.bak" 2>/dev/null; then
+      put temporal-latest.db /tmp/temporal.bak || log "temporal upload FAILED"
+    fi
+  fi
+
+  # --- uploads: ship files added/changed since the last successful pass ---
+  if [ -d "$UPLOAD_DIRECTORY" ]; then
+    stamp=/tmp/.uploads-stamp
+    touch "$stamp"
+    fail=0
+    while IFS= read -r file; do
+      rel="${file#"$UPLOAD_DIRECTORY"/}"
+      put "uploads/$rel" "$file" || { fail=1; log "upload FAILED: $rel"; }
+    done < <(if [ -f "$MARKER" ]; then find "$UPLOAD_DIRECTORY" -type f -newer "$MARKER"; else find "$UPLOAD_DIRECTORY" -type f; fi)
+    [ "$fail" = 0 ] && mv "$stamp" "$MARKER"
+  fi
+done

--- a/deploy/cloudflare/container/entrypoint.sh
+++ b/deploy/cloudflare/container/entrypoint.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Boot sequence for Postiz on Cloudflare Containers.
+# Disk is ephemeral: on a fresh start this restores Postgres/Temporal/uploads
+# from R2 (through the fronting Worker's /__backup routes), then starts the
+# full stack and a continuous backup loop.
+set -uo pipefail
+
+log() { echo "[postiz-cf] $(date -u +%H:%M:%S) $*"; }
+
+DATA_DIR=/data
+mkdir -p "$DATA_DIR"
+
+# ---------- environment ----------
+export CF_GATEWAY_ID="${CF_GATEWAY_ID:-x}"
+# Feature gates across the app check OPENAI_API_KEY; the AI Gateway token
+# doubles as the OpenAI-compatible api key (see ai.gateway.config.ts).
+export OPENAI_API_KEY="${OPENAI_API_KEY:-${CF_AIG_TOKEN:-}}"
+export DATABASE_URL="${DATABASE_URL:-postgresql://postiz:postiz@127.0.0.1:5432/postiz}"
+export REDIS_URL="${REDIS_URL:-redis://127.0.0.1:6379}"
+export TEMPORAL_ADDRESS="${TEMPORAL_ADDRESS:-127.0.0.1:7233}"
+export BACKEND_INTERNAL_URL="${BACKEND_INTERNAL_URL:-http://127.0.0.1:3000}"
+export STORAGE_PROVIDER="${STORAGE_PROVIDER:-local}"
+export UPLOAD_DIRECTORY="${UPLOAD_DIRECTORY:-/uploads}"
+export NEXT_PUBLIC_UPLOAD_DIRECTORY="${NEXT_PUBLIC_UPLOAD_DIRECTORY:-/uploads}"
+export IS_GENERAL="${IS_GENERAL:-true}"
+export NX_ADD_PLUGINS=false
+mkdir -p "$UPLOAD_DIRECTORY"
+
+# The apps' start scripts load /app/.env via dotenv-cli; materialize the
+# container env there so every pm2 process sees the same configuration.
+ENV_KEYS=(
+  MAIN_URL FRONTEND_URL NEXT_PUBLIC_BACKEND_URL BACKEND_INTERNAL_URL
+  JWT_SECRET DATABASE_URL REDIS_URL TEMPORAL_ADDRESS
+  IS_GENERAL DISABLE_REGISTRATION API_LIMIT NX_ADD_PLUGINS
+  STORAGE_PROVIDER UPLOAD_DIRECTORY NEXT_PUBLIC_UPLOAD_DIRECTORY
+  OPENAI_API_KEY CF_ACCOUNT_ID CF_GATEWAY_ID CF_AIG_TOKEN
+  AI_TEXT_MODEL AI_IMAGE_MODEL AI_IMAGE_BASE_URL
+  BACKUP_URL INTERNAL_SECRET
+)
+: > /app/.env
+for key in "${ENV_KEYS[@]}"; do
+  value="${!key:-}"
+  [ -n "$value" ] && printf '%s="%s"\n' "$key" "$value" >> /app/.env
+done
+
+# Authenticated helper for the Worker's /__backup routes.
+bk() { curl -fsS --connect-timeout 10 -H "authorization: Bearer ${INTERNAL_SECRET:-}" "$@"; }
+
+# Boot progress reporting: containers have no easily reachable stdout from the
+# CLI, so milestones (and a diagnostics bundle) are PUT to R2 through the
+# Worker — readable with: GET $BACKUP_URL/boot-status.txt
+BOOT_LOG=/tmp/boot-status.txt
+report() {
+  log "$*"
+  echo "$(date -u +%H:%M:%S) $*" >> "$BOOT_LOG"
+  [ -n "${BACKUP_URL:-}" ] && bk -X PUT --data-binary @"$BOOT_LOG" "$BACKUP_URL/boot-status.txt" >/dev/null 2>&1
+}
+diagnostics() {
+  {
+    echo "=== $(date -u) exit=$? ==="
+    echo "--- df -h ---"; df -h 2>&1
+    echo "--- ps ---"; ps aux 2>&1 | head -30
+    echo "--- pg startup.log ---"; tail -30 "$DATA_DIR/pg/startup.log" 2>&1
+    echo "--- temporal.log ---"; tail -20 "$DATA_DIR/temporal.log" 2>&1
+    echo "--- pm2 list ---"; pm2 list 2>&1
+    echo "--- pm2 logs ---"; pm2 logs --nostream --lines 40 2>&1 | tail -80
+  } > /tmp/diagnostics.txt
+  [ -n "${BACKUP_URL:-}" ] && bk -X PUT --data-binary @/tmp/diagnostics.txt "$BACKUP_URL/diagnostics.txt" >/dev/null 2>&1
+}
+trap diagnostics EXIT
+report "boot start (entrypoint $(md5sum /postiz-cf/entrypoint.sh | cut -c1-8))"
+
+# ---------- postgres (skipped when DATABASE_URL points elsewhere) ----------
+FRESH_DB=0
+if [[ "$DATABASE_URL" == *"127.0.0.1"* || "$DATABASE_URL" == *"localhost"* ]]; then
+  PGBIN="$(ls -d /usr/lib/postgresql/*/bin | head -1)"
+  PGDATA="$DATA_DIR/pg"
+  # /run is a fresh tmpfs on Cloudflare's runtime (unlike plain docker run),
+  # so the socket/lock dir baked in by apt does not exist at boot.
+  mkdir -p /var/run/postgresql
+  chown postgres:postgres /var/run/postgresql
+  if [ ! -s "$PGDATA/PG_VERSION" ]; then
+    FRESH_DB=1
+    log "initializing fresh postgres data dir"
+    mkdir -p "$PGDATA"
+    chown -R postgres:postgres "$PGDATA"
+    su postgres -s /bin/bash -c "'$PGBIN/initdb' -D '$PGDATA' -U postgres --auth-local=trust --auth-host=md5" >/dev/null
+  fi
+  chown -R postgres:postgres "$PGDATA"
+  # log inside PGDATA — /data is root-owned and pg_ctl runs as postgres
+  su postgres -s /bin/bash -c "'$PGBIN/pg_ctl' -D '$PGDATA' -l '$PGDATA/startup.log' -w -t 60 start"
+  report "postgres started (pg_ctl exit $?)"
+
+  su postgres -s /bin/bash -c "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='postiz'\" | grep -q 1" \
+    || su postgres -s /bin/bash -c "psql -c \"CREATE ROLE postiz LOGIN PASSWORD 'postiz' SUPERUSER\""
+  su postgres -s /bin/bash -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='postiz'\" | grep -q 1" \
+    || su postgres -s /bin/bash -c "createdb -O postiz postiz"
+
+  if [ "$FRESH_DB" = 1 ] && [ -n "${BACKUP_URL:-}" ]; then
+    if bk -o /tmp/db-restore.sql.gz "$BACKUP_URL/db-latest.sql.gz" 2>/dev/null; then
+      log "restoring postgres from R2 backup"
+      # pg_dumpall output: pre-existing role/db statements fail harmlessly.
+      gunzip -c /tmp/db-restore.sql.gz | su postgres -s /bin/bash -c psql >/dev/null 2>&1
+      rm -f /tmp/db-restore.sql.gz
+      report "postgres restore finished"
+    else
+      report "no postgres backup found (first boot)"
+    fi
+  fi
+fi
+
+# ---------- redis (cache only — no persistence needed) ----------
+if [[ "$REDIS_URL" == *"127.0.0.1"* || "$REDIS_URL" == *"localhost"* ]]; then
+  redis-server --daemonize yes --dir "$DATA_DIR" --save '' --appendonly no
+fi
+
+# ---------- temporal dev server (SQLite-backed) ----------
+if [[ "$TEMPORAL_ADDRESS" == "127.0.0.1:"* || "$TEMPORAL_ADDRESS" == "localhost:"* ]]; then
+  if [ ! -f "$DATA_DIR/temporal.db" ] && [ -n "${BACKUP_URL:-}" ]; then
+    bk -o "$DATA_DIR/temporal.db" "$BACKUP_URL/temporal-latest.db" 2>/dev/null \
+      && log "restored temporal state from R2 backup" \
+      || rm -f "$DATA_DIR/temporal.db"
+  fi
+  TEMPORAL_PORT="${TEMPORAL_ADDRESS##*:}"
+  nohup temporal server start-dev \
+    --headless \
+    --ip 127.0.0.1 \
+    --port "$TEMPORAL_PORT" \
+    --db-filename "$DATA_DIR/temporal.db" \
+    --log-level warn \
+    > "$DATA_DIR/temporal.log" 2>&1 &
+  for _ in $(seq 1 60); do
+    (echo > "/dev/tcp/127.0.0.1/$TEMPORAL_PORT") 2>/dev/null && break
+    sleep 1
+  done
+  report "temporal dev server is up on $TEMPORAL_ADDRESS"
+fi
+
+# ---------- uploads restore (background; media for already-scheduled posts) ----------
+if [ -n "${BACKUP_URL:-}" ]; then
+  (
+    bk "$BACKUP_URL/?list=uploads/" 2>/dev/null | while IFS= read -r key; do
+      [ -z "$key" ] && continue
+      rel="${key#uploads/}"
+      file="$UPLOAD_DIRECTORY/$rel"
+      if [ ! -f "$file" ]; then
+        mkdir -p "$(dirname "$file")"
+        bk -o "$file" "$BACKUP_URL/$key" 2>/dev/null || rm -f "$file"
+      fi
+    done
+    log "uploads restore pass complete"
+  ) &
+fi
+
+# ---------- schema sync + services ----------
+report "running prisma db push"
+prisma db push --accept-data-loss --skip-generate \
+  --schema /app/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+
+report "prisma db push finished (exit $?)"
+
+nginx
+report "nginx started on :5000"
+
+nohup /postiz-cf/backup.sh > "$DATA_DIR/backup.log" 2>&1 &
+
+cd /app
+# Spawn the pm2 daemon BEFORE the parallel starts: concurrent `pm2 start`
+# calls race to create the daemon and registrations get dropped (upstream's
+# pm2-run serializes the same way via `pm2 delete all`).
+pm2 delete all >/dev/null 2>&1 || true
+pnpm run --parallel pm2
+report "postiz processes started"
+# steady-state diagnostics snapshot ~2 min after boot
+( sleep 120; diagnostics ) &
+exec pm2 logs --raw

--- a/deploy/cloudflare/deploy.sh
+++ b/deploy/cloudflare/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Deploy Postiz to Cloudflare (Worker + Container).
+#
+# The container image builds fully from source (deploy/cloudflare/container/
+# Dockerfile, build context = repo root): wrangler builds the linux/amd64
+# image with the local Docker daemon, pushes it to the Cloudflare registry,
+# and deploys the Worker. First build takes a while (full pnpm install +
+# monorepo build inside Docker); later builds reuse the layer cache.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+command -v docker >/dev/null || { echo "docker is required"; exit 1; }
+docker info >/dev/null 2>&1 || { echo "docker daemon is not running"; exit 1; }
+
+echo "==> installing worker dependencies"
+(cd "$HERE" && npm install --no-fund --no-audit)
+
+echo "==> wrangler deploy (builds + pushes the amd64 container image)"
+(cd "$HERE" && npx wrangler deploy "$@")

--- a/deploy/cloudflare/package-lock.json
+++ b/deploy/cloudflare/package-lock.json
@@ -1,0 +1,1519 @@
+{
+  "name": "postiz-cloudflare-deploy",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "postiz-cloudflare-deploy",
+      "dependencies": {
+        "@cloudflare/containers": "latest"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260601.0",
+        "wrangler": "^4"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260609.1.tgz",
+      "integrity": "sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260609.1.tgz",
+      "integrity": "sha512-4kKXfr7ZHU6xQ/R9ShdSuj1A1bEouoRcHzUWdjnuMPBlRsAAVanlxAVYISotFUulLEinayOpRFbhpsfwzrpSSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260609.1.tgz",
+      "integrity": "sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260609.1.tgz",
+      "integrity": "sha512-INfcYoSsKqEIvPL69/3RkqYoP8WUR0VEN6loWN/3tekXLoJrVOj3E5NjIetsdS8MJN6zc3st/ae4bMuWRRzoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260609.1.tgz",
+      "integrity": "sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260611.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260611.1.tgz",
+      "integrity": "sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.16.tgz",
+      "integrity": "sha512-yNm/fYEcnpRjYduLMaddTK9XKYil6xB88+qFg79ZdZhHu1PadfoQmFW7pVTx7FZqMBNcUuThiAhxhENgtAO2/w==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260609.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260609.0.tgz",
+      "integrity": "sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260609.1",
+        "ws": "8.20.1",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260609.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260609.1.tgz",
+      "integrity": "sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260609.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260609.1",
+        "@cloudflare/workerd-linux-64": "1.20260609.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260609.1",
+        "@cloudflare/workerd-windows-64": "1.20260609.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.99.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.99.0.tgz",
+      "integrity": "sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260609.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260609.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260609.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/deploy/cloudflare/package.json
+++ b/deploy/cloudflare/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "postiz-cloudflare-deploy",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "bash ./deploy.sh"
+  },
+  "dependencies": {
+    "@cloudflare/containers": "latest"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260601.0",
+    "wrangler": "^4"
+  }
+}

--- a/deploy/cloudflare/tsconfig.json
+++ b/deploy/cloudflare/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["worker/src/**/*.ts"]
+}

--- a/deploy/cloudflare/worker/src/index.ts
+++ b/deploy/cloudflare/worker/src/index.ts
@@ -1,0 +1,218 @@
+import { Container, getContainer } from '@cloudflare/containers';
+
+/**
+ * Postiz on Cloudflare — fronting Worker.
+ *
+ * Routes:
+ *   /__backup/*                 container <-> R2 state backup/restore (auth:
+ *                               INTERNAL_SECRET). The container has no S3
+ *                               credentials; the Worker's R2 binding is the
+ *                               only path to durable storage.
+ *   /__ai/v1/images/generations OpenAI-images-shaped endpoint backed by
+ *                               Workers AI *through the AI Gateway*. The
+ *                               gateway compat endpoint doesn't serve
+ *                               images/generations (error 2019), so this is
+ *                               the sanctioned Worker-side exception — see
+ *                               ~/.claude/CLAUDE.md "Inside a Worker".
+ *   everything else             proxied to the container (nginx :5000).
+ *
+ * scheduled(): keep-alive ping so the in-container Temporal timers
+ * (scheduled posts) keep firing; container cold-starts restore from R2.
+ */
+
+interface Env {
+  POSTIZ_CONTAINER: DurableObjectNamespace<PostizContainer>;
+  BACKUPS: R2Bucket;
+  AI: Ai;
+  PUBLIC_URL: string;
+  CF_ACCOUNT_ID: string;
+  CF_GATEWAY_ID: string;
+  AI_TEXT_MODEL: string;
+  IMAGE_MODEL: string;
+  DISABLE_REGISTRATION: string;
+  // secrets
+  JWT_SECRET: string;
+  CF_AIG_TOKEN: string;
+  INTERNAL_SECRET: string;
+  // optional: external stores (skip in-container postgres/redis when set)
+  DATABASE_URL?: string;
+  REDIS_URL?: string;
+}
+
+const containerEnv = (env: Env): Record<string, string> => {
+  const publicUrl = env.PUBLIC_URL.replace(/\/$/, '');
+  const vars: Record<string, string> = {
+    MAIN_URL: publicUrl,
+    FRONTEND_URL: publicUrl,
+    NEXT_PUBLIC_BACKEND_URL: `${publicUrl}/api`,
+    BACKEND_INTERNAL_URL: 'http://127.0.0.1:3000',
+    JWT_SECRET: env.JWT_SECRET,
+    IS_GENERAL: 'true',
+    DISABLE_REGISTRATION: env.DISABLE_REGISTRATION || 'false',
+    STORAGE_PROVIDER: 'local',
+    UPLOAD_DIRECTORY: '/uploads',
+    NEXT_PUBLIC_UPLOAD_DIRECTORY: '/uploads',
+    API_LIMIT: '30',
+    // AI Gateway routing (consumed by ai.gateway.config.ts in the app)
+    CF_ACCOUNT_ID: env.CF_ACCOUNT_ID,
+    CF_GATEWAY_ID: env.CF_GATEWAY_ID,
+    CF_AIG_TOKEN: env.CF_AIG_TOKEN,
+    AI_TEXT_MODEL: env.AI_TEXT_MODEL,
+    AI_IMAGE_BASE_URL: `${publicUrl}/__ai/v1`,
+    // several feature gates check OPENAI_API_KEY truthiness
+    OPENAI_API_KEY: env.CF_AIG_TOKEN,
+    // backup plumbing
+    BACKUP_URL: `${publicUrl}/__backup`,
+    INTERNAL_SECRET: env.INTERNAL_SECRET,
+  };
+  if (env.DATABASE_URL) vars.DATABASE_URL = env.DATABASE_URL;
+  if (env.REDIS_URL) vars.REDIS_URL = env.REDIS_URL;
+  return vars;
+};
+
+export class PostizContainer extends Container<Env> {
+  defaultPort = 5000;
+  // The cron keep-alive (every 5 min) keeps it warm; this is the backstop.
+  sleepAfter = '6h';
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.envVars = containerEnv(env);
+  }
+
+  // RPC for /__admin/restart: tear the instance down so the next request
+  // boots a fresh container on the latest deployed image (state restores
+  // from R2). Long-lived instances otherwise keep serving the old image.
+  async restartContainer(): Promise<void> {
+    await this.destroy();
+  }
+}
+
+const unauthorized = () => new Response('unauthorized', { status: 401 });
+
+const checkAuth = (request: Request, secret: string): boolean => {
+  const header = request.headers.get('authorization') || '';
+  return !!secret && header === `Bearer ${secret}`;
+};
+
+async function handleBackup(request: Request, env: Env): Promise<Response> {
+  if (!checkAuth(request, env.INTERNAL_SECRET)) return unauthorized();
+
+  const url = new URL(request.url);
+  const key = decodeURIComponent(url.pathname.replace(/^\/__backup\/?/, ''));
+
+  // GET /__backup/?list=<prefix> -> newline-separated keys (shell-friendly)
+  const listPrefix = url.searchParams.get('list');
+  if (request.method === 'GET' && listPrefix !== null) {
+    const keys: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await env.BACKUPS.list({ prefix: listPrefix, cursor });
+      keys.push(...page.objects.map((o) => o.key));
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor);
+    return new Response(keys.join('\n'), {
+      headers: { 'content-type': 'text/plain' },
+    });
+  }
+
+  if (!key) return new Response('missing key', { status: 400 });
+
+  if (request.method === 'PUT') {
+    await env.BACKUPS.put(key, request.body);
+    return new Response('ok');
+  }
+
+  if (request.method === 'GET') {
+    const object = await env.BACKUPS.get(key);
+    if (!object) return new Response('not found', { status: 404 });
+    return new Response(object.body, {
+      headers: { 'content-type': 'application/octet-stream' },
+    });
+  }
+
+  return new Response('method not allowed', { status: 405 });
+}
+
+async function handleImageGeneration(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  // The container authenticates with the AI Gateway token (it is already a
+  // shared secret on both sides); INTERNAL_SECRET also accepted.
+  if (
+    !checkAuth(request, env.CF_AIG_TOKEN) &&
+    !checkAuth(request, env.INTERNAL_SECRET)
+  ) {
+    return unauthorized();
+  }
+  if (request.method !== 'POST') {
+    return new Response('method not allowed', { status: 405 });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    prompt?: string;
+  } | null;
+  if (!body?.prompt) {
+    return Response.json(
+      { error: { message: 'prompt is required' } },
+      { status: 400 }
+    );
+  }
+
+  // Worker-side calls cannot resolve dynamic/* routes (env.AI.run 404s on
+  // them), so we call a concrete Workers AI model id while still routing
+  // through the gateway for caching/observability/cost analytics. Swap back
+  // to dynamic/image_gen when the binding path supports it upstream.
+  const result = (await env.AI.run(
+    env.IMAGE_MODEL as Parameters<Ai['run']>[0],
+    { prompt: body.prompt },
+    { gateway: { id: env.CF_GATEWAY_ID } }
+  )) as { image?: string };
+
+  if (!result?.image) {
+    return Response.json(
+      { error: { message: 'image generation returned no data' } },
+      { status: 502 }
+    );
+  }
+
+  // OpenAI images API response shape (b64); mime is sniffed downstream.
+  return Response.json({
+    created: Math.floor(Date.now() / 1000),
+    data: [{ b64_json: result.image }],
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith('/__backup')) {
+      return handleBackup(request, env);
+    }
+    if (url.pathname === '/__admin/restart') {
+      if (!checkAuth(request, env.INTERNAL_SECRET)) return unauthorized();
+      if (request.method !== 'POST') {
+        return new Response('method not allowed', { status: 405 });
+      }
+      await getContainer(env.POSTIZ_CONTAINER).restartContainer();
+      return new Response('container stopped; next request boots the latest image\n');
+    }
+    if (url.pathname === '/__ai/v1/images/generations') {
+      return handleImageGeneration(request, env);
+    }
+    if (url.pathname.startsWith('/__ai')) {
+      return new Response('not found', { status: 404 });
+    }
+
+    return getContainer(env.POSTIZ_CONTAINER).fetch(request);
+  },
+
+  async scheduled(_controller: ScheduledController, env: Env): Promise<void> {
+    // Wake/keep the container so Temporal timers and the backup loop run.
+    await getContainer(env.POSTIZ_CONTAINER)
+      .fetch(new Request('https://keepalive.internal/api/'))
+      .catch((err) => console.log('keepalive failed', String(err)));
+  },
+} satisfies ExportedHandler<Env>;

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -1,0 +1,73 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "postiz",
+  "main": "worker/src/index.ts",
+  "compatibility_date": "2026-06-10",
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+
+  // All-in-one Postiz container: nginx(:5000) -> backend(:3000) + frontend(:4200),
+  // plus in-container Postgres, Redis (cache-only) and a Temporal dev server.
+  // State is continuously backed up to R2 through the Worker (see worker/src).
+  "containers": [
+    {
+      "class_name": "PostizContainer",
+      "image": "./container/Dockerfile",
+      "image_build_context": "../..",
+      "instance_type": "standard-2",
+      "max_instances": 1
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "POSTIZ_CONTAINER",
+        "class_name": "PostizContainer"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["PostizContainer"]
+    }
+  ],
+
+  "r2_buckets": [
+    {
+      "binding": "BACKUPS",
+      "bucket_name": "postiz-backups"
+    }
+  ],
+
+  // Used by /__ai/v1/images/generations: the gateway compat endpoint doesn't
+  // serve images, so the Worker runs a Workers AI image model *through the
+  // gateway* (env.AI.run(..., { gateway: { id } })) — the sanctioned
+  // Worker-side pattern from ~/.claude/CLAUDE.md "Inside a Worker".
+  "ai": {
+    "binding": "AI"
+  },
+
+  // Keep-alive ping: the container must stay up for Temporal timers
+  // (scheduled posts) to fire; a cold start restores state from R2.
+  "triggers": {
+    "crons": ["*/5 * * * *"]
+  },
+
+  "vars": {
+    // Public URL of this worker; set to the real workers.dev URL (or custom
+    // domain) — baked into the container env at start.
+    "PUBLIC_URL": "https://postiz.lazee.workers.dev",
+    "CF_ACCOUNT_ID": "85d376fc54617bcb57185547f08e528b",
+    "CF_GATEWAY_ID": "x",
+    "AI_TEXT_MODEL": "dynamic/text_gen",
+    // Workers AI model used by the Worker-side images endpoint.
+    "IMAGE_MODEL": "@cf/black-forest-labs/flux-1-schnell",
+    "DISABLE_REGISTRATION": "false"
+  }
+
+  // Secrets (wrangler secret put): JWT_SECRET, CF_AIG_TOKEN, INTERNAL_SECRET
+  // Optional secrets to move state off-container later: DATABASE_URL, REDIS_URL
+}

--- a/libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts
@@ -7,11 +7,21 @@ import { agentCategories } from '@gitroom/nestjs-libraries/agent/agent.categorie
 import { z } from 'zod';
 import { agentTopics } from '@gitroom/nestjs-libraries/agent/agent.topics';
 import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import {
+  aiApiKey,
+  aiBaseURL,
+  aiDefaultHeaders,
+  textModel,
+} from '@gitroom/nestjs-libraries/openai/ai.gateway.config';
 
 const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'gpt-4o-2024-08-06',
+  apiKey: aiApiKey,
+  model: textModel('gpt-4o-2024-08-06'),
   temperature: 0,
+  configuration: {
+    baseURL: aiBaseURL,
+    defaultHeaders: aiDefaultHeaders,
+  },
 });
 
 interface WorkflowChannelsState {

--- a/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
@@ -5,7 +5,14 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import { END, START, StateGraph } from '@langchain/langgraph';
-import { ChatOpenAI, DallEAPIWrapper } from '@langchain/openai';
+import { ChatOpenAI } from '@langchain/openai';
+import {
+  aiApiKey,
+  aiBaseURL,
+  aiDefaultHeaders,
+  generateAiImage,
+  textModel,
+} from '@gitroom/nestjs-libraries/openai/ai.gateway.config';
 import { TavilySearch } from '@langchain/tavily';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
@@ -22,14 +29,13 @@ const tools = !process.env.TAVILY_API_KEY
 const toolNode = new ToolNode(tools);
 
 const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'gpt-4.1',
+  apiKey: aiApiKey,
+  model: textModel(),
   temperature: 0.7,
-});
-
-const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'chatgpt-image-latest',
+  configuration: {
+    baseURL: aiBaseURL,
+    defaultHeaders: aiDefaultHeaders,
+  },
 });
 
 interface WorkflowChannelsState {
@@ -320,7 +326,7 @@ export class AgentGraphService {
 
     const newContent = await Promise.all(
       (state.content || []).map(async (p) => {
-        const image = await dalle.invoke(p.prompt!);
+        const image = (await generateAiImage(p.prompt!)) || undefined;
         return {
           ...p,
           image,

--- a/libraries/nestjs-libraries/src/chat/load.tools.service.ts
+++ b/libraries/nestjs-libraries/src/chat/load.tools.service.ts
@@ -1,7 +1,27 @@
 import { Injectable } from '@nestjs/common';
 import { Agent } from '@mastra/core/agent';
-import { openai } from '@ai-sdk/openai';
+import { createOpenAI } from '@ai-sdk/openai';
+import {
+  aiApiKey,
+  aiBaseURL,
+  aiDefaultHeaders,
+  aiGatewayEnabled,
+  textModel,
+} from '@gitroom/nestjs-libraries/openai/ai.gateway.config';
 import { Memory } from '@mastra/memory';
+
+// AI Gateway dynamic routes only resolve via the OpenAI chat/completions
+// compat endpoint, so force the chat protocol (the default provider would use
+// the Responses API, which the gateway compat endpoint does not serve).
+const openaiProvider = createOpenAI({
+  apiKey: aiApiKey,
+  baseURL: aiBaseURL,
+  headers: aiDefaultHeaders,
+});
+const agentModel = () =>
+  aiGatewayEnabled
+    ? openaiProvider.chat(textModel())
+    : openaiProvider('gpt-5.2');
 import { pStore } from '@gitroom/nestjs-libraries/chat/mastra.store';
 import { array, object, string } from 'zod';
 import { ModuleRef } from '@nestjs/core';
@@ -87,7 +107,7 @@ export class LoadToolsService {
       )}
 `;
       },
-      model: openai('gpt-5.2'),
+      model: agentModel(),
       tools,
       memory: new Memory({
         storage: pStore,

--- a/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
@@ -6,7 +6,14 @@ import { END, START, StateGraph } from '@langchain/langgraph';
 import { AutoPost, Integration } from '@prisma/client';
 import { BaseMessage } from '@langchain/core/messages';
 import striptags from 'striptags';
-import { ChatOpenAI, DallEAPIWrapper } from '@langchain/openai';
+import { ChatOpenAI } from '@langchain/openai';
+import {
+  aiApiKey,
+  aiBaseURL,
+  aiDefaultHeaders,
+  generateAiImage,
+  textModel,
+} from '@gitroom/nestjs-libraries/openai/ai.gateway.config';
 import { JSDOM } from 'jsdom';
 import { z } from 'zod';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
@@ -36,14 +43,13 @@ interface WorkflowChannelsState {
 }
 
 const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'gpt-4.1',
+  apiKey: aiApiKey,
+  model: textModel(),
   temperature: 0.7,
-});
-
-const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'chatgpt-image-latest',
+  configuration: {
+    baseURL: aiBaseURL,
+    defaultHeaders: aiDefaultHeaders,
+  },
 });
 
 const generateContent = z.object({
@@ -257,7 +263,7 @@ export class AutopostService {
           content: state.load.description || state.description,
         });
 
-    const image = await dalle.invoke(generatedTextToBeSentToDallE);
+    const image = (await generateAiImage(generatedTextToBeSentToDallE)) || '';
 
     return { ...state, image };
   }

--- a/libraries/nestjs-libraries/src/openai/ai.gateway.config.ts
+++ b/libraries/nestjs-libraries/src/openai/ai.gateway.config.ts
@@ -1,0 +1,101 @@
+import OpenAI from 'openai';
+
+/**
+ * Cloudflare AI Gateway routing (dynamic routes).
+ *
+ * When CF_AIG_TOKEN and CF_ACCOUNT_ID are set, every OpenAI-compatible text
+ * call is routed through the AI Gateway universal OpenAI-compat endpoint and
+ * model ids are replaced with *dynamic route* slugs (default
+ * `dynamic/text_gen`), so model selection, fallbacks, caching, BYOK keys and
+ * observability live in the gateway — not in this codebase.
+ *
+ * The compat endpoint does NOT support `images/generations` (gateway error
+ * 2019), so image generation goes to AI_IMAGE_BASE_URL instead: the fronting
+ * Cloudflare Worker exposes an OpenAI-images-shaped endpoint backed by
+ * `env.AI.run(model, input, { gateway: { id } })` — the sanctioned
+ * Worker-side gateway pattern (see deploy/cloudflare/worker/src/index.ts).
+ *
+ * When CF_AIG_TOKEN is not set everything falls back to stock OpenAI
+ * behaviour, leaving upstream Postiz installs unaffected.
+ */
+
+const accountId =
+  process.env.CF_ACCOUNT_ID || process.env.CLOUDFLARE_ACCOUNT_ID || '';
+const gatewayId = process.env.CF_GATEWAY_ID || 'x';
+const gatewayToken = process.env.CF_AIG_TOKEN || '';
+
+export const aiGatewayEnabled = !!(accountId && gatewayToken);
+
+/** Base URL for chat/completions-compatible calls (OpenAI SDK appends paths). */
+export const aiBaseURL = aiGatewayEnabled
+  ? `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/compat`
+  : undefined;
+
+/**
+ * The gateway accepts the AI Gateway token as a plain `Authorization: Bearer`
+ * key (verified against this account), so it can be used as `apiKey` by any
+ * OpenAI-compatible SDK. cf-aig-zdr enforces zero-data-retention routing.
+ */
+export const aiApiKey = aiGatewayEnabled
+  ? gatewayToken
+  : process.env.OPENAI_API_KEY || 'sk-proj-';
+
+export const aiDefaultHeaders: Record<string, string> | undefined =
+  aiGatewayEnabled
+    ? {
+        'cf-aig-authorization': `Bearer ${gatewayToken}`,
+        'cf-aig-zdr': 'true',
+      }
+    : undefined;
+
+/** Dynamic route for text generation; fallback keeps upstream model choice. */
+export const textModel = (fallback = 'gpt-4.1') =>
+  aiGatewayEnabled ? process.env.AI_TEXT_MODEL || 'dynamic/text_gen' : fallback;
+
+export const imageModel = (fallback = 'chatgpt-image-latest') =>
+  aiGatewayEnabled
+    ? process.env.AI_IMAGE_MODEL || 'dynamic/image_gen'
+    : fallback;
+
+/**
+ * Where OpenAI-images-shaped requests go. With the gateway enabled this must
+ * point at the fronting Worker (e.g. `https://<app>/__ai/v1`); without it,
+ * undefined keeps the OpenAI SDK default.
+ */
+export const aiImagesBaseURL = aiGatewayEnabled
+  ? process.env.AI_IMAGE_BASE_URL || undefined
+  : undefined;
+
+let imagesClient: OpenAI | undefined;
+const getImagesClient = () => {
+  if (!imagesClient) {
+    imagesClient = new OpenAI({
+      apiKey: aiApiKey,
+      baseURL: aiImagesBaseURL,
+      defaultHeaders: aiDefaultHeaders,
+    });
+  }
+  return imagesClient;
+};
+
+/**
+ * Drop-in replacement for `new DallEAPIWrapper(...).invoke(prompt)`.
+ * Returns either a `data:` URL (b64 responses) or a remote URL — both are
+ * accepted by `IUploadProvider.uploadSimple`.
+ */
+export async function generateAiImage(
+  prompt: string,
+  opts: { isVertical?: boolean } = {}
+): Promise<string | null> {
+  const generate = await getImagesClient().images.generate({
+    prompt,
+    model: imageModel(),
+    size: opts.isVertical ? '1024x1536' : '1024x1024',
+  });
+
+  const image = generate.data?.[0];
+  if (image?.b64_json) {
+    return `data:image/png;base64,${image.b64_json}`;
+  }
+  return image?.url || null;
+}

--- a/libraries/nestjs-libraries/src/openai/openai.service.ts
+++ b/libraries/nestjs-libraries/src/openai/openai.service.ts
@@ -3,9 +3,28 @@ import OpenAI from 'openai';
 import { shuffle } from 'lodash';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
+import {
+  aiApiKey,
+  aiBaseURL,
+  aiDefaultHeaders,
+  aiImagesBaseURL,
+  imageModel,
+  textModel,
+} from '@gitroom/nestjs-libraries/openai/ai.gateway.config';
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
+  apiKey: aiApiKey,
+  baseURL: aiBaseURL,
+  defaultHeaders: aiDefaultHeaders,
+});
+
+// The AI Gateway compat endpoint does not serve images/generations, so image
+// calls use a separate client pointed at the Worker-backed images endpoint
+// (see ai.gateway.config.ts). Without the gateway both clients hit OpenAI.
+const openaiImages = new OpenAI({
+  apiKey: aiApiKey,
+  baseURL: aiImagesBaseURL,
+  defaultHeaders: aiDefaultHeaders,
 });
 
 const PicturePrompt = z.object({
@@ -22,9 +41,9 @@ export class OpenaiService {
     // gpt-image models always return base64 (b64_json) and do not accept the
     // `response_format` parameter, unlike the deprecated dall-e-3.
     const generate = (
-      await openai.images.generate({
+      await openaiImages.images.generate({
         prompt,
-        model: 'chatgpt-image-latest',
+        model: imageModel(),
         size: isVertical ? '1024x1536' : '1024x1024',
       })
     ).data[0];
@@ -36,7 +55,7 @@ export class OpenaiService {
     return (
       (
         await openai.chat.completions.parse({
-          model: 'gpt-4.1',
+          model: textModel(),
           messages: [
             {
               role: 'system',
@@ -57,7 +76,7 @@ export class OpenaiService {
     return (
       (
         await openai.chat.completions.parse({
-          model: 'gpt-4.1',
+          model: textModel(),
           messages: [
             {
               role: 'system',
@@ -91,7 +110,7 @@ export class OpenaiService {
           ],
           n: 5,
           temperature: 1,
-          model: 'gpt-4.1',
+          model: textModel(),
         }),
         openai.chat.completions.create({
           messages: [
@@ -107,7 +126,7 @@ export class OpenaiService {
           ],
           n: 5,
           temperature: 1,
-          model: 'gpt-4.1',
+          model: textModel(),
         }),
       ])
     ).flatMap((p) => p.choices);
@@ -145,7 +164,7 @@ export class OpenaiService {
           content,
         },
       ],
-      model: 'gpt-4.1',
+      model: textModel(),
     });
 
     const { content: articleContent } = websiteContent.choices[0].message;
@@ -165,7 +184,7 @@ export class OpenaiService {
     const posts =
       (
         await openai.chat.completions.parse({
-          model: 'gpt-4.1',
+          model: textModel(),
           messages: [
             {
               role: 'system',
@@ -198,7 +217,7 @@ export class OpenaiService {
               return (
                 (
                   await openai.chat.completions.parse({
-                    model: 'gpt-4.1',
+                    model: textModel(),
                     messages: [
                       {
                         role: 'system',
@@ -234,7 +253,7 @@ export class OpenaiService {
         const parse =
           (
             await openai.chat.completions.parse({
-              model: 'gpt-4.1',
+              model: textModel(),
               messages: [
                 {
                   role: 'system',


### PR DESCRIPTION
## What

Adds a fully self-contained way to self-host Postiz on the Cloudflare Developer Platform, plus an opt-in abstraction for routing all LLM calls through a Cloudflare AI Gateway.

**1. Pluggable LLM routing (`libraries/nestjs-libraries/src/openai/ai.gateway.config.ts`)**
- All OpenAI-compatible call sites (OpenAI SDK, LangChain `ChatOpenAI`, CopilotKit adapters, Mastra/ai-sdk) now construct their clients from one shared config module.
- When `CF_AIG_TOKEN` + `CF_ACCOUNT_ID` are set, calls go through the AI Gateway OpenAI-compat endpoint with dynamic-route model slugs (`dynamic/text_gen` by default), giving caching, fallbacks, rate limits, BYOK keys and observability at the gateway layer. **When unset, behavior is exactly as before (stock OpenAI + `OPENAI_API_KEY`)**, so existing installs are unaffected.
- `DallEAPIWrapper` usages were replaced with a shared `generateAiImage()` helper because the gateway compat endpoint does not serve `images/generations`; with the gateway enabled, image requests go to an OpenAI-images-shaped endpoint served by the fronting Worker (backed by Workers AI through the gateway), and the result flows into the existing `uploadSimple()` data-URL path.

**2. Cloudflare deployment (`deploy/cloudflare/`)**
- One Worker + one Container (Durable-Object-backed) running the full stack from the existing nginx config: backend, frontend, orchestrator, plus in-container Postgres 15, Redis (cache-only) and a Temporal CLI dev server (SQLite) — replacing the 8-service docker-compose stack for single-instance installs.
- Container disk on Cloudflare is ephemeral, so the entrypoint restores Postgres/Temporal/uploads from R2 on cold start and a loop backs them up every 5 minutes **through the Worker's R2 binding** — the container never holds S3 credentials. A cron trigger keeps the instance warm so Temporal timers (scheduled posts) fire.
- The image builds from source (mirrors `Dockerfile.dev`: node 22 bookworm-slim + pnpm build). `.dockerignore` additions keep the deploy tooling out of the app image.

## Why

Cloudflare Containers + Workers + R2 + AI Gateway is now a viable, cheap single-vendor target for personal Postiz instances, but the published image and compose stack can't run there (no compose, ephemeral disk, no raw TCP ingress). This makes the repo deployable to it with `deploy/cloudflare/deploy.sh` while keeping upstream behavior untouched.

## Reviewer notes

- No new npm dependencies in the app workspaces; the worker tooling under `deploy/cloudflare/` has its own `package.json`.
- `deploy/cloudflare/wrangler.jsonc` `vars` contain deployment-specific values (account id, workers.dev URL) that each deployer replaces — documented in `deploy/cloudflare/README.md`.
- One `as any` in `copilot.controller.ts`: `@copilotkit/runtime` types against its own bundled `openai` package, so an externally-constructed (API-compatible) client fails nominal typing.
- Boot-debugging niceties that proved necessary on Cloudflare's runtime are documented in the README (e.g. `/run` is a fresh tmpfs there, unlike plain `docker run`).
- Tested end-to-end on a live Cloudflare account: registration page, API, Postgres restore/backup cycle, Temporal workers, and gateway-routed text + image generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)