### PR TITLE
fix(instagram): catch avatar upload failure during provider connection

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -113,7 +113,13 @@ export class IntegrationService {
     const uploadedPicture = picture
       ? picture?.indexOf('imagedelivery.net') > -1
         ? picture
-        : await this.storage.uploadSimple(picture)
+        : await this.storage.uploadSimple(picture).catch((err) => {
+            console.error(
+              'Avatar upload failed, continuing without avatar:',
+              err.message
+            );
+            return undefined;
+          })
       : undefined;
 
     return this._integrationRepository.createOrUpdateIntegration(


### PR DESCRIPTION
## Problem

When connecting an Instagram account, the provider attempts to upload the user's avatar to the configured storage. If this upload fails (network error, CDN timeout, invalid image URL), the entire connection flow throws and the user cannot connect their account at all.

Fixes #918.

## Fix

Wrap `uploadSimple(picture)` in `.catch()` — log the error and return `undefined` instead of propagating. The integration is created without an avatar; the user can update their profile picture later.

## Why this is safe

The avatar is cosmetic metadata. A missing avatar has no impact on posting, scheduling or authentication. Failing silently here is strictly better than blocking the user from connecting their account.

## Tested

Connecting Instagram Standalone account with an avatar URL that returns 404 → connection succeeds, avatar is null in DB, no error shown to user.