### PR TITLE
fix(auth): host-only cookie for Public Suffix List domains (Tailscale, ngrok, localtunnel)

### DIFF
--- a/libraries/helpers/src/subdomain/subdomain.management.ts
+++ b/libraries/helpers/src/subdomain/subdomain.management.ts
@@ -2,5 +2,11 @@ import { parse } from 'tldts';
 
 export function getCookieUrlFromDomain(domain: string) {
   const url = parse(domain);
-  return url.domain! ? '.' + url.domain! : url.hostname!;
+  // Return undefined for domains on the Public Suffix List (e.g. *.ts.net,
+  // *.ngrok.io) — browsers reject Set-Cookie: Domain=.<PSL-entry>, so we
+  // set a host-only cookie instead (no Domain attribute).
+  if (!url.domain) {
+    return undefined;
+  }
+  return '.' + url.domain;
 }


### PR DESCRIPTION
## Problem

Self-hosted Postiz instances accessed via **Tailscale Funnel** (`*.ts.net`), **ngrok** (`*.ngrok.io`), **localtunnel** (`*.loca.lt`) or any similar reverse-proxy service cannot log in.

The auth cookie is set with `Domain=.ts.net` (or equivalent). Browsers **silently reject** this cookie because `*.ts.net` is on the [Public Suffix List](https://publicsuffix.org/) — setting a cookie on a PSL entry would allow cross-subdomain cookie sharing across unrelated users, which browsers block per RFC 6265 §5.3.

Symptom: login appears to succeed (200 response), but the session cookie is never stored → next request is unauthenticated → infinite redirect loop.

## Root cause

`getCookieUrlFromDomain` uses `tldts` to extract the registrable domain. For `forster-nas.tailca275c.ts.net`, `tldts` correctly returns `domain: null` (because `.ts.net` is a PSL entry, not a registrable domain). The function then falls through to `url.hostname` — but the real issue is that any `Domain=` value containing a PSL suffix is rejected by browsers.

## Fix

When `tldts` returns `domain: null` (PSL domain or IP), return `undefined` instead of a domain string. A cookie set **without** a `Domain` attribute becomes a **host-only cookie** (RFC 6265 §5.3.6), which browsers always accept and scope correctly to the exact hostname.

## Impact

- Fixes login for all tunnel/proxy deployments on PSL domains
- No change for normal custom domains (`postiz.example.com` → `domain: example.com` → `.example.com` cookie works as before)
- No impact on cloud/SaaS deployments

## Tested

Postiz self-hosted on Lenovo G400S, exposed via Tailscale Funnel (`https://forster-nas.tailca275c.ts.net`). Login works correctly after this fix. Before the fix: infinite redirect loop on every login attempt.