### PR TITLE
feat(nostr): add repost plug with NIP-18 support

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -185,13 +185,13 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       password
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
 
     return [
       {
         id: firstPost.id,
-        postId: String(eventId),
-        releaseURL: `https://primal.net/e/${eventId}`,
+        postId: String(textEvent.id),
+        releaseURL: `https://primal.net/e/${textEvent.id}`,
         status: 'completed',
       },
     ];
@@ -208,16 +208,16 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     integration: Integration,
     originalIntegration: Integration,
     postId: string,
-    information: any
+    _information: any
   ) {
     const { password } = AuthService.verifyJWT(integration.token) as any;
 
     const repostEvent = finalizeEvent(
       {
-        kind: 6, // Repost
+        kind: 6, // NIP-18 Repost
         content: '',
         tags: [
-          ['e', postId],
+          ['e', postId, list[0]], // event-id + relay hint
           ['p', originalIntegration.internalId],
         ],
         created_at: Math.floor(Date.now() / 1000),
@@ -253,13 +253,13 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       password
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
 
     return [
       {
         id: commentPost.id,
-        postId: String(eventId),
-        releaseURL: `https://primal.net/e/${eventId}`,
+        postId: String(textEvent.id),
+        releaseURL: `https://primal.net/e/${textEvent.id}`,
         status: 'completed',
       },
     ];

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -12,6 +12,7 @@ import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { Integration } from '@prisma/client';
+import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
 
 // @ts-ignore
 global.WebSocket = WebSocket;
@@ -33,7 +34,8 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
   isBetweenSteps = false;
   scopes = [] as string[];
   editor = 'normal' as const;
-  toolTip = 'Make sure you private a HEX key of your Nostr private key, you can get it from websites like iris.to'
+  toolTip =
+    'Make sure you private a HEX key of your Nostr private key, you can get it from websites like iris.to';
 
   maxLength() {
     return 100000;
@@ -162,9 +164,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
 
   private buildContent(post: PostDetails): string {
     const mediaContent = post.media?.map((m) => m.path).join('\n\n') || '';
-    return mediaContent
-      ? `${post.message}\n\n${mediaContent}`
-      : post.message;
+    return mediaContent ? `${post.message}\n\n${mediaContent}` : post.message;
   }
 
   async post(
@@ -195,6 +195,37 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         status: 'completed',
       },
     ];
+  }
+
+  @PostPlug({
+    identifier: 'nostr-repost-post-users',
+    title: 'Add Re-posters',
+    description: 'Add accounts to repost your post',
+    pickIntegration: ['nostr'],
+    fields: [],
+  })
+  async repostPostUsers(
+    integration: Integration,
+    originalIntegration: Integration,
+    postId: string,
+    information: any
+  ) {
+    const { password } = AuthService.verifyJWT(integration.token) as any;
+
+    const repostEvent = finalizeEvent(
+      {
+        kind: 6, // Repost
+        content: '',
+        tags: [
+          ['e', postId],
+          ['p', originalIntegration.internalId],
+        ],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      password
+    );
+
+    await this.publish(integration.internalId, repostEvent);
   }
 
   async comment(


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature + Bug Fix. Adds the existing "Add Re-posters" internal post plug for Nostr accounts, and fixes a bug in the existing Nostr provider where `post()` and `comment()` used an unreliable event ID.

# Why was this change needed?

Fixes #1586.

Postiz already supports selecting additional accounts to repost a published post for providers like X and LinkedIn via the `@PostPlug` mechanism. Nostr accounts did not expose the same plug, so users with multiple Nostr accounts had to repost manually in another Nostr client.

## Changes

### 1. Add `repostPostUsers` PostPlug (fixes #1586)

Adds a `@PostPlug`-decorated `repostPostUsers` method that signs and publishes a NIP-18 repost event (`kind: 6`) from the selected Nostr integration. The repost event includes:

- an `e` tag pointing to the original Nostr event id + relay hint (NIP-18)
- a `p` tag pointing to the original Nostr author pubkey

### 2. Fix `post()` and `comment()` — use `textEvent.id` for `postId`

The existing `publish()` helper subscribes to `kinds: [1]` events to retrieve the published event's ID. However it resolves with `{}` via `oneose` when no matching events arrive within 6 seconds, returning an empty string. This caused `repostPostUsers()` to emit an `e` tag with an empty value, which relays reject:

```
invalid: unexpected size for fixed-size tag: e
```

`finalizeEvent()` already computes the event ID deterministically. Using `textEvent.id` directly is correct and removes the unreliable relay round-trip.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla)
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue