### PR TITLE
feat(nostr): add profile mention autocomplete

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -7,7 +7,14 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
 import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
-import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
+import {
+  getPublicKey,
+  Relay,
+  finalizeEvent,
+  SimplePool,
+  nip19,
+  type Event as NostrEvent,
+} from 'nostr-tools';
 
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
@@ -25,6 +32,15 @@ const list = [
 ];
 
 const pool = new SimplePool();
+const PROFILE_SEARCH_LIMIT = 40;
+const PROFILE_SEARCH_WAIT_MS = 2500;
+
+type MentionResult = {
+  id: string;
+  label: string;
+  image: string;
+  doNotCache?: boolean;
+};
 
 export class NostrProvider extends SocialAbstract implements SocialProvider {
   override maxConcurrentJob = 5;
@@ -33,7 +49,8 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
   isBetweenSteps = false;
   scopes = [] as string[];
   editor = 'normal' as const;
-  toolTip = 'Make sure you private a HEX key of your Nostr private key, you can get it from websites like iris.to'
+  toolTip =
+    'Make sure you private a HEX key of your Nostr private key, you can get it from websites like iris.to';
 
   maxLength() {
     return 100000;
@@ -94,6 +111,166 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     }
 
     return {};
+  }
+
+  private decodePublicKey(value: string) {
+    const candidate = value.trim().replace(/^nostr:/i, '');
+
+    if (/^[a-f0-9]{64}$/i.test(candidate)) {
+      return candidate.toLowerCase();
+    }
+
+    if (!candidate.toLowerCase().startsWith('npub1')) {
+      return undefined;
+    }
+
+    try {
+      const decoded = nip19.decode(candidate);
+      return decoded.type === 'npub' ? decoded.data : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseProfile(event: NostrEvent) {
+    try {
+      return JSON.parse(event.content || '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  private profileMatches(profile: any, query: string, pubkey: string) {
+    const npub = nip19.npubEncode(pubkey);
+    const searchable = [
+      npub,
+      pubkey,
+      profile.name,
+      profile.displayName,
+      profile.display_name,
+      profile.username,
+      profile.nip05,
+      profile.about,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+
+    return searchable.includes(query.toLowerCase());
+  }
+
+  private profileToMention(event: NostrEvent): MentionResult {
+    const profile = this.parseProfile(event);
+    const npub = nip19.npubEncode(event.pubkey);
+    const label =
+      profile.display_name ||
+      profile.displayName ||
+      profile.name ||
+      profile.username ||
+      profile.nip05 ||
+      `${npub.slice(0, 12)}...`;
+
+    return {
+      id: npub,
+      label,
+      image: profile.picture || profile.image || '',
+    };
+  }
+
+  private extractMentionTags(content: string) {
+    const tags = new Map<string, string[]>();
+    const matches = content.match(/(?:nostr:)?npub1[0-9a-z]+/gi) || [];
+
+    for (const match of matches) {
+      const pubkey = this.decodePublicKey(match);
+      if (pubkey) {
+        tags.set(pubkey, ['p', pubkey]);
+      }
+    }
+
+    return Array.from(tags.values());
+  }
+
+  private dedupeTags(tags: string[][]) {
+    const seen = new Set<string>();
+
+    return tags.filter((tag) => {
+      const key = tag.join(':');
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }
+
+  override async mention(_token: string, d: { query: string }) {
+    const query = (d?.query || '').trim();
+
+    if (query.length < 2) {
+      return [];
+    }
+
+    const exactPubkey = this.decodePublicKey(query);
+
+    try {
+      const events = exactPubkey
+        ? [
+            await pool.get(
+              list,
+              {
+                kinds: [0],
+                authors: [exactPubkey],
+                limit: 1,
+              },
+              { maxWait: PROFILE_SEARCH_WAIT_MS }
+            ),
+          ].filter(Boolean)
+        : await pool.querySync(
+            list,
+            {
+              kinds: [0],
+              search: query,
+              limit: PROFILE_SEARCH_LIMIT,
+            },
+            { maxWait: PROFILE_SEARCH_WAIT_MS }
+          );
+
+      const mentions = new Map<string, MentionResult>();
+
+      for (const event of events as NostrEvent[]) {
+        const profile = this.parseProfile(event);
+        if (exactPubkey || this.profileMatches(profile, query, event.pubkey)) {
+          const mention = this.profileToMention(event);
+          mentions.set(mention.id, mention);
+        }
+      }
+
+      if (exactPubkey && !mentions.size) {
+        const npub = nip19.npubEncode(exactPubkey);
+        mentions.set(npub, {
+          id: npub,
+          label: `${npub.slice(0, 12)}...`,
+          image: '',
+          doNotCache: true,
+        });
+      }
+
+      return Array.from(mentions.values()).slice(0, 10);
+    } catch (err) {
+      console.log(err);
+      return [];
+    }
+  }
+
+  mentionFormat(idOrHandle: string) {
+    const pubkey = this.decodePublicKey(idOrHandle);
+
+    if (!pubkey) {
+      return `nostr:${idOrHandle}`;
+    }
+
+    return `nostr:${nip19.npubEncode(pubkey)}`;
   }
 
   private async publish(pubkey: string, event: any) {
@@ -174,12 +351,13 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
   ): Promise<PostResponse[]> {
     const { password } = AuthService.verifyJWT(accessToken) as any;
     const [firstPost] = postDetails;
+    const content = this.buildContent(firstPost);
 
     const textEvent = finalizeEvent(
       {
         kind: 1, // Text note
-        content: this.buildContent(firstPost),
-        tags: [],
+        content,
+        tags: this.extractMentionTags(content),
         created_at: Math.floor(Date.now() / 1000),
       },
       password
@@ -208,15 +386,17 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     const { password } = AuthService.verifyJWT(accessToken) as any;
     const [commentPost] = postDetails;
     const replyToId = lastCommentId || postId;
+    const content = this.buildContent(commentPost);
 
     const textEvent = finalizeEvent(
       {
         kind: 1, // Text note
-        content: this.buildContent(commentPost),
-        tags: [
+        content,
+        tags: this.dedupeTags([
           ['e', replyToId, '', 'reply'],
           ['p', id],
-        ],
+          ...this.extractMentionTags(content),
+        ]),
         created_at: Math.floor(Date.now() / 1000),
       },
       password


### PR DESCRIPTION
Fixes #1603.

## Summary
- Adds Nostr profile mention lookup for composer autocomplete using npub/hex exact matches and relay metadata search.
- Formats selected Nostr mentions as `nostr:npub...` references.
- Adds `p` tags for selected profile mentions when publishing posts and comments.

## Testing
- `pnpm@10.6.1 run prisma-generate`
- `pnpm@10.6.1 --filter ./apps/backend run build`

Note: local validation used Node v24.16.0, so pnpm printed the repository engine warning (`>=22.12.0 <23.0.0`), but the backend build completed successfully.