### PR TITLE
Fix/issue 1616: Make max upload size configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ STORAGE_PROVIDER="local"
 # Your upload directory path if you host your files locally, otherwise Cloudflare will be used.
 #NEXT_PUBLIC_UPLOAD_STATIC_DIRECTORY=""
 
+# Upload size limits for videos/files (Default is 1024 MB / 1GB)
+#MAX_FILE_SIZE_MB="1024"
+#NEXT_PUBLIC_MAX_FILE_SIZE_MB="1024"
+
 # Social Media API Settings
 X_URL=""
 X_API_KEY=""

--- a/apps/frontend/src/components/media/media.component.tsx
+++ b/apps/frontend/src/components/media/media.component.tsx
@@ -199,7 +199,7 @@ export const showMediaBox = (
   showModalEmitter.emit('show-modal', callback);
 };
 const CHUNK_SIZE = 1024 * 1024;
-const MAX_UPLOAD_SIZE = 1024 * 1024 * 1024; // 1 GB
+const MAX_UPLOAD_SIZE = (process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB ? Number(process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB) : 1024) * 1024 * 1024; // Default 1 GB
 export const MediaBox: FC<{
   setMedia: (params: { id: string; path: string }[]) => void;
   standalone?: boolean;
@@ -285,7 +285,7 @@ export const MediaBox: FC<{
         toaster.show(
           t(
             'upload_size_limit_exceeded',
-            'Upload size limit exceeded. Maximum 1 GB per upload session.'
+            `Upload size limit exceeded. Maximum ${MAX_UPLOAD_SIZE / (1024 * 1024)} MB per upload session.`
           ),
           'warning'
         );
@@ -328,7 +328,7 @@ export const MediaBox: FC<{
         toaster.show(
           t(
             'upload_size_limit_exceeded',
-            'Upload size limit exceeded. Maximum 1 GB per upload session.'
+            `Upload size limit exceeded. Maximum ${MAX_UPLOAD_SIZE / (1024 * 1024)} MB per upload session.`
           ),
           'warning'
         );
@@ -495,7 +495,7 @@ export const MediaBox: FC<{
                 <div className="whitespace-pre-line text-newTextColor/[0.6] text-center">
                   {t(
                     'select_or_upload_pictures_max_1gb',
-                    'Select or upload pictures (maximum 1 GB per upload).'
+                    `Select or upload pictures (maximum ${MAX_UPLOAD_SIZE / (1024 * 1024)} MB per upload).`
                   )}{' '}
                   {'\n'}
                   {t(

--- a/apps/frontend/src/components/media/new.uploader.tsx
+++ b/apps/frontend/src/components/media/new.uploader.tsx
@@ -57,7 +57,7 @@ export function useUppyUploader(props: {
       restrictions: {
         // maxNumberOfFiles: 5,
         // allowedFileTypes: allowedFileTypes.split(','),
-        maxFileSize: 1000000000, // Default 1GB, but we'll override with custom validation
+        maxFileSize: process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB ? Number(process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB) * 1024 * 1024 : 1000000000, // Default 1GB, but we'll override with custom validation
       },
     });
 
@@ -133,7 +133,7 @@ export function useUppyUploader(props: {
             const isVideo = file.type?.startsWith('video/');
 
             const maxImageSize = 30 * 1024 * 1024; // 30MB
-            const maxVideoSize = 1000 * 1024 * 1024; // 1GB
+            const maxVideoSize = process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB ? Number(process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB) * 1024 * 1024 : 1000 * 1024 * 1024; // 1GB
 
             if (isImage && file.size > maxImageSize) {
               const error = new Error(
@@ -150,12 +150,12 @@ export function useUppyUploader(props: {
 
             if (isVideo && file.size > maxVideoSize) {
               const error = new Error(
-                `Video file "${file.name}" is too large. Maximum size allowed is 1GB.`
+                `Video file "${file.name}" is too large. Maximum size allowed is ${maxVideoSize / (1024 * 1024)}MB.`
               );
               uppy2.log(error.message, 'error');
               uppy2.info(error.message, 'error', 5000);
               toast.show(
-                `Video file is too large. Maximum size allowed is 1GB.`
+                `Video file is too large. Maximum size allowed is ${maxVideoSize / (1024 * 1024)}MB.`
               );
               uppy2.removeFile(file.id); // Remove file from queue
               return reject(error);

--- a/apps/frontend/src/components/new-launch/editor.tsx
+++ b/apps/frontend/src/components/new-launch/editor.tsx
@@ -68,7 +68,7 @@ import {
 } from '@gitroom/frontend/components/ui/icons';
 import { DelayComponent } from '@gitroom/frontend/components/new-launch/delay.component';
 
-const MAX_UPLOAD_SIZE = 1024 * 1024 * 1024; // 1 GB
+const MAX_UPLOAD_SIZE = (process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB ? Number(process.env.NEXT_PUBLIC_MAX_FILE_SIZE_MB) : 1024) * 1024 * 1024; // Default 1 GB
 
 const InterceptBoldShortcut = Extension.create({
   name: 'preventBoldWithUnderline',
@@ -583,7 +583,7 @@ export const Editor: FC<{
         toaster.show(
           t(
             'upload_size_limit_exceeded',
-            'Upload size limit exceeded. Maximum 1 GB per upload session.'
+            `Upload size limit exceeded. Maximum ${MAX_UPLOAD_SIZE / (1024 * 1024)} MB per upload session.`
           ),
           'warning'
         );
@@ -627,7 +627,7 @@ export const Editor: FC<{
         toaster.show(
           t(
             'upload_size_limit_exceeded',
-            'Upload size limit exceeded. Maximum 1 GB per upload session.'
+            `Upload size limit exceeded. Maximum ${MAX_UPLOAD_SIZE / (1024 * 1024)} MB per upload session.`
           ),
           'warning'
         );

--- a/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
+++ b/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
@@ -59,7 +59,8 @@ export class CustomFileValidationPipe implements PipeTransform {
     if (mimeType.startsWith('image/')) {
       return 10 * 1024 * 1024; // 10 MB
     } else if (mimeType.startsWith('video/')) {
-      return 1024 * 1024 * 1024; // 1 GB
+      const maxMb = process.env.MAX_FILE_SIZE_MB ? Number(process.env.MAX_FILE_SIZE_MB) : 1024;
+      return maxMb * 1024 * 1024; // Default 1 GB
     } else {
       throw new BadRequestException('Unsupported file type.');
     }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature / Bug fix

# Why was this change needed?

Resolves #1616.

This change is needed to allow self-hosted instances to support larger and longer video uploads. Previously, the system was restricted by a hardcoded 1GB limit, which restricted users to about 15 minutes of video. By introducing configurable environment variables (NEXT_PUBLIC_MAX_FILE_SIZE_MB and MAX_FILE_SIZE_MB), self-hosted users can now dynamically configure these limits for their own instances without being blocked by the default size constraints.

# Other information:

I have safely added fallbacks so that if these new environment variables are omitted, the application will default to the previous 1GB limit. The environment example file was also updated to document these new options for users.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
