### PR TITLE
fix: handle upload_complete status in Facebook video story polling loop

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -506,7 +506,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
             if (videoStatus === 'error') {
               throw new Error('Video processing failed');
             }
-            if (videoStatus !== 'upload_complete' &&videoStatus !== 'ready') {
+            if (videoStatus !== 'upload_complete' && videoStatus !== 'ready') {
               await timer(10000);
             }
           }

--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -492,7 +492,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
           );
 
           let videoStatus = 'in_progress';
-          while (videoStatus !== 'ready') {
+          while (videoStatus !== 'upload_complete' && videoStatus !== 'ready') {
             const { status } = await (
               await this.fetch(
                 `https://graph.facebook.com/v20.0/${video_id}?fields=status&access_token=${accessToken}`,
@@ -506,7 +506,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
             if (videoStatus === 'error') {
               throw new Error('Video processing failed');
             }
-            if (videoStatus !== 'ready') {
+            if (videoStatus !== 'upload_complete' &&videoStatus !== 'ready') {
               await timer(10000);
             }
           }


### PR DESCRIPTION
## Summary

- The video status polling loop for Facebook video stories only exited on `ready`, missing the intermediate `upload_complete` state that Facebook returns
- This caused the loop to keep polling unnecessarily after the upload was done, wasting time and risking the 10-minute Temporal activity `startToCloseTimeout`

## Test plan

- [ ] Post a video story to a Facebook page and verify it publishes successfully without timeout
- [ ] Confirm the polling loop exits as soon as Facebook returns `upload_complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)