### PR TITLE
fix: generic OAuth callback misclassified as GOOGLE when scope contains googleapis.com

### DIFF
--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -89,7 +89,9 @@ export async function proxy(request: NextRequest) {
   const org = nextUrl.searchParams.get('org');
   const url = new URL(nextUrl).search;
   if (!nextUrl.pathname.startsWith('/auth') && !authCookie) {
-    const providers = ['google', 'settings'];
+    // Check settings before google because generic OAuth callbacks use
+    // /settings, and Google OIDC can return googleapis.com in the scope query.
+    const providers = ['settings', 'google'];
     const findIndex = providers.find((p) => nextUrl.href.indexOf(p) > -1);
     const additional = !findIndex
       ? ''


### PR DESCRIPTION
## Summary

Fixes #1633.

When a user configures Google OIDC as a generic OAuth provider (`POSTIZ_GENERIC_OAUTH=true`), Google's callback URL includes `googleapis.com` in the `scope` query parameter:

```
/settings?code=...&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+...
```

The proxy was scanning the **entire URL** (including query params) and checking `google` before `settings`. Because `google` appears inside `googleapis.com` in the scope, it matched first — sending `provider=GOOGLE` to the auth endpoint instead of `provider=GENERIC`. The backend then tried to exchange the code via `GoogleProvider.getToken`, which fails with `invalid_request` because the code was issued for the generic OIDC client.

## Fix

Reorder the `providers` array in `apps/frontend/src/proxy.ts` so `settings` is checked before `google`:

```diff
-const providers = ['google', 'settings'];
+const providers = ['settings', 'google'];
```

The `/settings` pathname is now matched first, so the generic OAuth flow correctly resolves to `provider=GENERIC`. The native Google social integration is unaffected — those callbacks go through `/integrations/social/...` paths, which are caught by an earlier guard and never reach this code.

## Verification

Curl against a running dev server (with `POSTIZ_GENERIC_OAUTH=true` and Google OIDC endpoints configured):

```bash
curl -si "http://localhost:4200/settings?code=4%2F0AfJohXk&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+openid" \
  | grep -E "HTTP/|location:"
```

**Before fix:** `location: /auth?...&provider=GOOGLE`
**After fix:** `location: /auth?...&provider=GENERIC`