### PR TITLE
fix(oauth): detect provider from pathname only to prevent googleapis.…

### DIFF
--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -90,7 +90,7 @@ export async function proxy(request: NextRequest) {
   const url = new URL(nextUrl).search;
   if (!nextUrl.pathname.startsWith('/auth') && !authCookie) {
     const providers = ['google', 'settings'];
-    const findIndex = providers.find((p) => nextUrl.href.indexOf(p) > -1);
+    cconst findIndex = providers.find((p) => nextUrl.pathname.indexOf(p) > -1);
     const additional = !findIndex
       ? ''
       : (url.indexOf('?') > -1 ? '&' : '?') +


### PR DESCRIPTION
# What kind of change does this PR introduce?
Bug fix

# Why was this change needed?
Fixes #1633

Provider detection in proxy.ts was checking the full href instead of just the pathname. Google's callback includes googleapis.com in the scope query param, which falsely matched `google` and set `provider=GOOGLE` instead of `provider=GENERIC` — breaking generic OAuth for self-hosted setups.

Changing `href` → `pathname` fixes it.

# Other information:
One line change. No existing Google login flow affected.

# Checklist:
- [X] I have read the CONTRIBUTING guide.
- [X] I have signed the CLA.
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue