### PR TITLE
fix: TikTok photo title truncation (UPLOAD mode) and branded content key props

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
@@ -305,6 +305,7 @@ const TikTokSettings: FC<{
             {[
               brand_organic_toggle || brand_content_toggle ? (
                 <a
+                  key="music-usage"
                   target="_blank"
                   className="text-[#B69DEC] hover:underline"
                   href="https://www.tiktok.com/legal/page/global/music-usage-confirmation/en"
@@ -312,9 +313,10 @@ const TikTokSettings: FC<{
                   {t('music_usage_confirmation', 'Music Usage Confirmation')}
                 </a>
               ) : undefined,
-              brand_content_toggle ? <> {t('and', 'and')} </> : undefined,
+              brand_content_toggle ? <span key="and"> {t('and', 'and')} </span> : undefined,
               brand_content_toggle ? (
                 <a
+                  key="bc-policy"
                   target="_blank"
                   className="text-[#B69DEC] hover:underline"
                   href="https://www.tiktok.com/legal/page/global/bc-policy/en"

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -521,7 +521,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     return {
       post_info: {
         ...(isPhoto && firstPost.settings.title
-          ? { title: firstPost.settings.title }
+          ? { title: firstPost.settings.title.slice(0, 90) }
           : {}),
         ...(!isPhoto && firstPost.message ? { title: firstPost.message } : {}),
         ...(isPhoto ? { description: firstPost.message } : {}),


### PR DESCRIPTION
## Summary

- **Photo title truncation**: The UPLOAD (non-direct-post) path in `tiktok.provider.ts` was sending photo titles with no length cap, causing `invalid_params` errors from TikTok. Completes f7f5899d which already applied `.slice(0, 90)` for the DIRECT_POST path. TikTok enforces a 90 UTF-16 rune limit on photo titles across both posting modes. [API ref](https://developers.tiktok.com/doc/content-posting-api-reference-photo-post)
- **Key props**: React console error when importing a user's TikTok post — `"Each child in a list should have a unique key prop"` from `TikTokSettings` (tiktok.provider.tsx:307). The three conditional elements in the branded content links array were missing `key` props. Also replaced a `<>` fragment with `<span>` since fragments cannot receive a `key`. Error was gone and the post published successfully after the fix.

## Test plan

- [ ] Post a TikTok photo via UPLOAD mode with a title longer than 90 characters — confirm it posts without `invalid_params`
- [ ] Open TikTok post composer with Brand Organic or Brand Content toggles enabled — confirm no React `key` prop console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)