### PR TITLE
fix: surface real WordPress connect errors and normalize domain

### DIFF
--- a/apps/frontend/src/components/launches/add.provider.component.tsx
+++ b/apps/frontend/src/components/launches/add.provider.component.tsx
@@ -165,6 +165,7 @@ export const CustomVariables: FC<{
     defaultValue?: string;
     validation: string;
     type: 'text' | 'password';
+    hint?: string;
   }>;
   close?: () => void;
   identifier: string;
@@ -236,11 +237,31 @@ export const CustomVariables: FC<{
         >
           {variables.map((variable) => (
             <div key={variable.key}>
-              <Input
-                label={variable.label}
-                name={variable.key}
-                type={variable.type == 'text' ? 'text' : 'password'}
-              />
+              {variable.hint ? (
+                <div className="flex flex-col gap-[6px]">
+                  <div className="text-[14px] flex items-center gap-[6px]">
+                    <span>{variable.label}</span>
+                    <span
+                      data-tooltip-id="tooltip"
+                      data-tooltip-content={variable.hint}
+                      className="w-[16px] h-[16px] rounded-full border border-textColor/60 text-textColor/60 flex items-center justify-center text-[11px] leading-none cursor-help select-none"
+                    >
+                      i
+                    </span>
+                  </div>
+                  <Input
+                    label=""
+                    name={variable.key}
+                    type={variable.type == 'text' ? 'text' : 'password'}
+                  />
+                </div>
+              ) : (
+                <Input
+                  label={variable.label}
+                  name={variable.key}
+                  type={variable.type == 'text' ? 'text' : 'password'}
+                />
+              )}
             </div>
           ))}
           <div>
@@ -372,6 +393,7 @@ export const AddProviderComponent: FC<{
       label: string;
       validation: string;
       type: 'text' | 'password';
+      hint?: string;
     }>;
   }>;
   article: Array<{
@@ -402,6 +424,7 @@ export const AddProviderComponent: FC<{
           validation: string;
           defaultValue?: string;
           type: 'text' | 'password';
+          hint?: string;
         }>
       ) =>
       async () => {

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -161,6 +161,7 @@ export interface SocialProvider
       defaultValue?: string;
       validation: string;
       type: 'text' | 'password';
+      hint?: string;
     }[]
   >;
   name: string;

--- a/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
@@ -83,6 +83,7 @@ export class WordpressProvider
         label: 'Password',
         validation: `/.+/`,
         type: 'password' as const,
+        hint: 'Application password, create in User->Profile',
       },
     ];
   }
@@ -97,45 +98,97 @@ export class WordpressProvider
       username: string;
       password: string;
     };
-    try {
-      const auth = Buffer.from(`${body.username}:${body.password}`).toString(
-        'base64'
-      );
-      const { id, name, avatar_urls, code } = await (
-        await fetch(`${body.domain}/wp-json/wp/v2/users/me`, {
-          headers: {
-            Authorization: `Basic ${auth}`,
-          },
-        })
-      ).json();
 
-      if (code) {
-        throw "Invalid credentials";
+    // Normalize the domain - users often paste it with surrounding whitespace
+    // or a trailing slash, which would otherwise build `https://site.com//wp-json/...`.
+    const domain = body.domain.trim().replace(/\/+$/, '');
+
+    const auth = Buffer.from(`${body.username}:${body.password}`).toString(
+      'base64'
+    );
+
+    // Direct fetch (not `this.fetch`) so we can branch on the HTTP status and
+    // return a specific message instead of throwing a generic error.
+    let response: Response;
+    try {
+      response = await fetch(`${domain}/wp-json/wp/v2/users/me`, {
+        headers: {
+          Authorization: `Basic ${auth}`,
+        },
+      });
+    } catch (err) {
+      // DNS failure, connection refused, TLS error, site unreachable, etc.
+      console.log(err);
+      return 'Could not reach your WordPress site. Check the Domain URL and that the site is publicly accessible.';
+    }
+
+    // A security plugin (e.g. Wordfence), a WAF, or the server config commonly
+    // strips the Authorization header or locks down the REST API. We don't try
+    // to work around that - surface a distinct, actionable message instead.
+    if (!response.ok) {
+      // Log what WordPress actually returned (REST errors carry a `code` and
+      // `message`) so failures can be diagnosed without guessing.
+      const errorBody = await response.text().catch(() => '');
+      let wpCode = '';
+      let wpMessage = '';
+      try {
+        const parsed = JSON.parse(errorBody);
+        wpCode = parsed?.code || '';
+        wpMessage = parsed?.message || '';
+      } catch (err) {
+        // Non-JSON error body (e.g. an HTML page from a security plugin).
+      }
+      console.log(
+        `WordPress auth failed for ${domain} (HTTP ${response.status})`,
+        JSON.stringify({
+          code: wpCode,
+          message: wpMessage,
+          ...(wpCode ? {} : { body: errorBody.slice(0, 500) }),
+        })
+      );
+
+      if (response.status === 401 || response.status === 403) {
+        return 'WordPress rejected the login. A security plugin or server setting may be blocking the REST API or stripping the Authorization header, or the username / Application Password is incorrect.';
       }
 
-      const biggestImage = Object.entries(avatar_urls || {}).reduce(
-        (all, current) => {
-          if (all > Number(current[0])) {
-            return all;
-          }
-          return Number(current[0]);
-        },
-        0
-      );
+      return `WordPress returned an unexpected error (HTTP ${response.status}). Make sure the REST API is enabled and Application Passwords are available.`;
+    }
 
-      return {
-        refreshToken: '',
-        expiresIn: dayjs().add(100, 'years').unix() - dayjs().unix(),
-        accessToken: params.code,
-        id: body.domain + '_' + id,
-        name,
-        picture: avatar_urls?.[String(biggestImage)] || '',
-        username: body.username,
-      };
+    // Even on a 200, a security plugin / maintenance page can return HTML
+    // instead of JSON, which would otherwise throw on `.json()`.
+    let data: any;
+    try {
+      data = await response.json();
     } catch (err) {
       console.log(err);
+      return 'WordPress did not return a valid response. The REST API may be disabled or blocked by a security plugin.';
+    }
+
+    const { id, name, avatar_urls, code } = data || {};
+
+    if (code) {
       return 'Invalid credentials';
     }
+
+    const biggestImage = Object.entries(avatar_urls || {}).reduce(
+      (all, current) => {
+        if (all > Number(current[0])) {
+          return all;
+        }
+        return Number(current[0]);
+      },
+      0
+    );
+
+    return {
+      refreshToken: '',
+      expiresIn: dayjs().add(100, 'years').unix() - dayjs().unix(),
+      accessToken: params.code,
+      id: body.domain + '_' + id,
+      name,
+      picture: avatar_urls?.[String(biggestImage)] || '',
+      username: body.username,
+    };
   }
 
   @Tool({


### PR DESCRIPTION
## Context
A user reported they couldn't connect their WordPress site (it appeared to work in a normal window but not in incognito). After investigation, the **root cause was a usage error, not a bug**: they were entering their **wp-admin account password** instead of a WordPress **Application Password**. This was confirmed end-to-end:

- Even **without** any code change, connecting **fails** with the wp-admin password and **succeeds** with an Application Password.
- The "incognito-only" symptom was a red herring — `authenticate()` runs server-side, and the auth cookie was confirmed present on the request (not a third-party-cookie issue). In a normal window the password manager auto-filled the saved Application Password; in incognito it was typed by hand (the wrong one).

So this PR does **not** change connection behavior. It's about **visibility, clarity, and hygiene** so the next user can self-diagnose instead of filing a ticket.

## Changes
- **Clearer errors (visibility).** `authenticate()` previously collapsed every failure into a generic `Invalid credentials`. It now checks the HTTP status and returns distinct messages for an unreachable site, 401/403 (wrong/standard-password vs Application Password, or a security plugin / server stripping the `Authorization` header), other non-2xx, and non-JSON responses. It also logs the WordPress error `code`/`message` so failures can be diagnosed from the logs.
- **Guidance (clarity).** An info ("i") tooltip next to the **Password** field in the connect modal tells users to use an **Application Password** (User → Profile), not their wp-admin password. It's data-driven via an optional `hint` on the custom field, so it only appears for WordPress.
- **Domain sanitizing (best practice).** Trim whitespace / trailing slash before building the REST URL. Note: WordPress itself tolerates the resulting `//wp-json` double slash (verified), so this is defensive normalization for stricter servers (nginx/Apache), not a functional fix.

## Testing
- Confirmed connect **fails with the wp-admin password and succeeds with an Application Password**, both with and without this change — i.e. the change does not alter connection success/failure.
- Verified the new logging surfaced the real WordPress response (`HTTP 401 rest_not_logged_in`) from a Hostinger-hosted test site.
- Confirmed the auth cookie was present on the request in incognito (ruling out a third-party-cookie / URL issue).
- Verified a trailing slash in the domain still connects (WordPress tolerates the double slash); the trim is kept as defensive normalization.
- Connected a WordPress channel successfully in both incognito and non-incognito windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)