### PR TITLE
fix: close the "Are you sure?" dialog on the first button click

### DIFF
--- a/apps/frontend/src/components/layout/new-modal.tsx
+++ b/apps/frontend/src/components/layout/new-modal.tsx
@@ -388,7 +388,15 @@ export const areYouSure = ({
 export const DecisionEverywhere: FC = () => {
   const decision = useDecisionModal();
   useEffect(() => {
+    // Mirror ModalManagerEmitter: this component mounts in several layouts
+    // (MantineWrapper), so without removing the listener on unmount the
+    // module-level emitter accumulates stale handlers. A single areYouSure()
+    // would then open multiple stacked dialogs and a button click would only
+    // close the top one, leaving the duplicates on screen.
     decisionModalEmitter.on('open', decision.open);
+    return () => {
+      decisionModalEmitter.removeAllListeners('open');
+    };
   }, []);
   return null;
 };


### PR DESCRIPTION
## Summary
The channel delete (and other `areYouSure`) confirmation dialog stayed open after clicking **Yes** or **No** — it took multiple clicks to clear it.

**Root cause:** `DecisionEverywhere` registered its `'open'` handler on the module-level `decisionModalEmitter` with no cleanup, unlike its sibling `ModalManagerEmitter`. Since `MantineWrapper` mounts/remounts across layouts (and React StrictMode double-mounts in dev), stale listeners accumulated. A single `areYouSure()` then opened several stacked identical dialogs, and a button click (`closeCurrent`) only closed the top one — leaving the duplicates on screen.

**Fix:** add the `removeAllListeners('open')` cleanup on unmount, mirroring `ModalManagerEmitter`. Exactly one listener exists at a time, so one click closes the dialog. The close logic itself was already correct.

## Testing
- Verified the channel delete "Are you sure?" dialog now closes on the first click of either **Yes** or **No**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)