### PR TITLE
fix: duplicate "Are you sure?" dialogs after connecting a WordPress channel

### DIFF
--- a/apps/frontend/src/components/layout/new-modal.tsx
+++ b/apps/frontend/src/components/layout/new-modal.tsx
@@ -366,31 +366,31 @@ export const DecisionModal: FC<{
   );
 };
 
-export const decisionModalEmitter = new EventEmitter();
-
 export const areYouSure = ({
   title = 'Are you sure?',
   description = 'Are you sure you want to close this modal?' as any,
   approveLabel = 'Yes',
   cancelLabel = 'No',
+  onlyApprove = false,
 } = {}): Promise<boolean> => {
-  return new Promise<boolean>((newRes) => {
-    decisionModalEmitter.emit('open', {
+  // Open directly on the store instead of via a React-component listener,
+  // which leaked on every mount/unmount and opened duplicate dialogs.
+  return new Promise<boolean>((res) => {
+    useModalStore.getState().openModal({
       title,
-      description,
-      approveLabel,
-      cancelLabel,
-      newRes,
+      askClose: false,
+      onClose: () => res(false),
+      children: (
+        <DecisionModal
+          onlyApprove={onlyApprove}
+          resolution={res}
+          description={description}
+          approveLabel={approveLabel}
+          cancelLabel={cancelLabel}
+        />
+      ),
     });
   });
-};
-
-export const DecisionEverywhere: FC = () => {
-  const decision = useDecisionModal();
-  useEffect(() => {
-    decisionModalEmitter.on('open', decision.open);
-  }, []);
-  return null;
 };
 
 export const useDecisionModal = () => {
@@ -402,7 +402,6 @@ export const useDecisionModal = () => {
       onlyApprove = false,
       approveLabel = 'Yes',
       cancelLabel = 'No',
-      newRes = undefined as any,
     } = {}) => {
       return new Promise<boolean>((res) => {
         modals.openModal({
@@ -412,7 +411,7 @@ export const useDecisionModal = () => {
           children: (
             <DecisionModal
               onlyApprove={onlyApprove}
-              resolution={(value) => (newRes ? newRes(value) : res(value))}
+              resolution={res}
               description={description}
               approveLabel={approveLabel}
               cancelLabel={cancelLabel}

--- a/libraries/react-shared-libraries/src/helpers/mantine.wrapper.tsx
+++ b/libraries/react-shared-libraries/src/helpers/mantine.wrapper.tsx
@@ -2,13 +2,11 @@
 
 import { ReactNode } from 'react';
 import {
-  DecisionEverywhere,
   ModalManager,
 } from '@gitroom/frontend/components/layout/new-modal';
 export const MantineWrapper = (props: { children: ReactNode }) => {
   return (
     <ModalManager>
-      <DecisionEverywhere />
       {props.children}
     </ModalManager>
   );


### PR DESCRIPTION
## What

After connecting a **WordPress** channel, the **"Are you sure?"** confirmation dialog (e.g. when deleting a channel) started appearing **twice**. Clicking *Yes* or *No* only dismissed one copy, leaving a duplicate stuck on screen. The breakage affected **every channel**, not just WordPress, and only cleared after a full page refresh.

## Why this matters

This is a confusing, broken-feeling UX on a common, destructive action (deleting channels and similar confirmations). A user could think their click "didn't work", and a leftover dialog blocking the screen looks like the app is stuck — all triggered simply by having connected WordPress earlier in the session.

## Why it only showed up after WordPress

Most channels finish connecting with a full page reload, which resets everything. WordPress finishes with an in-app navigation (no reload), and that difference was enough to leave the confirmation dialog's internal wiring in a bad state, so it opened more than one copy. Full technical root-cause is in the commit message.

## The fix

The confirmation dialog is now opened **directly**, so exactly one dialog appears no matter how a channel was connected. This is a targeted fix that removes the fragile mechanism causing the duplication, rather than a blanket workaround that papers over it. Clicking a button still closes only that dialog.

Replaces #1639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)