### PR TITLE
fix: duplicate "Are you sure?" dialogs after connecting a WordPress channel

### DIFF
--- a/apps/frontend/src/components/layout/new-modal.tsx
+++ b/apps/frontend/src/components/layout/new-modal.tsx
@@ -388,7 +388,16 @@ export const areYouSure = ({
 export const DecisionEverywhere: FC = () => {
   const decision = useDecisionModal();
   useEffect(() => {
-    decisionModalEmitter.on('open', decision.open);
+    // Remove this exact listener on unmount. MantineWrapper (and therefore
+    // this component) unmounts/remounts on some navigations - e.g. returning
+    // from the bare /integrations/social callback route via router.push during
+    // a WordPress connect - and without cleanup each remount left a stale
+    // listener subscribed, so one areYouSure() opened several stacked dialogs.
+    const handler = decision.open;
+    decisionModalEmitter.on('open', handler);
+    return () => {
+      decisionModalEmitter.off('open', handler);
+    };
   }, []);
   return null;
 };


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, modals). `DecisionEverywhere` now removes its own `decisionModalEmitter` `'open'` listener on unmount (`apps/frontend/src/components/layout/new-modal.tsx`). `MantineWrapper`, and therefore this component, unmounts and remounts on some navigations - notably returning from the bare `/integrations/social` callback route via `router.push` during a WordPress connect - and each remount added another listener while the previous one stayed subscribed, so a single `areYouSure()` call opened several stacked confirmation dialogs. The emitter API, the `areYouSure` signature and the dialog contents are unchanged.

## What

After connecting a **WordPress** channel, the **"Are you sure?"** confirmation dialog (e.g. when deleting a channel) started appearing **twice**. Clicking *Yes* or *No* only dismissed one copy, leaving a duplicate stuck on screen. It affected **every channel**, not just WordPress, and only cleared after a full page refresh.

## Why this matters

This is a confusing, broken-feeling UX on a common, destructive action (deleting channels). A user could think their click "didn't work", and a leftover dialog blocking the screen looks like the app is stuck — all triggered simply by having connected WordPress earlier in the session.

## Why it only showed up after WordPress

Most channels finish connecting with a full page reload, which resets everything. WordPress finishes with an in-app navigation (no reload), and that difference left the confirmation dialog's internal listener subscribed twice, so it opened a duplicate. Full technical root-cause is in the commit message.

## The fix

The confirmation dialog is opened by a component (`DecisionEverywhere`) that subscribed to an event emitter in a `useEffect` **without cleanup**, so it leaked a listener on every unmount/remount. This adds the missing cleanup, so exactly one listener is ever subscribed and only one dialog opens. Minimal change, preserves the existing design; per-dialog close behaviour is unchanged.

There is a documented known limitation in the commit message (this assumes a single mounted modal wrapper, which holds today); it's intentionally out of scope here.

# QA

1. [ ] Log in and go to the Channels / Launches screen
2. [ ] Connect a WordPress channel and complete the callback flow so you return through `/integrations/social`
3. [ ] Trigger any confirmation dialog, for example deleting a channel or a post
4. [ ] Exactly one "Are you sure?" dialog appears - before this change you get two or more stacked on top of each other
5. [ ] Repeat the connect flow twice more, then trigger a confirmation dialog again - still exactly one dialog
6. [ ] Confirm and cancel both still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
