### PR TITLE
feat: extend team invite link expiry from 1 hour to 2 days (temporary)

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
@@ -78,7 +78,7 @@ export class OrganizationService {
   }
 
   async inviteTeamMember(orgId: string, body: AddTeamMemberDto) {
-    const timeLimit = dayjs().add(1, 'hour').format('YYYY-MM-DD HH:mm:ss');
+    const timeLimit = dayjs().add(2, 'day').format('YYYY-MM-DD HH:mm:ss');
     const id = makeId(5);
     const url =
       process.env.FRONTEND_URL +
@@ -87,7 +87,7 @@ export class OrganizationService {
       await this._notificationsService.sendEmail(
         body.email,
         'You have been invited to join an organization',
-        `You have been invited to join an organization. Click <a href="${url}">here</a> to join.<br />The link will expire in 1 hour.`
+        `You have been invited to join an organization. Click <a href="${url}">here</a> to join.<br />The link will expire in 2 days.`
       );
     }
     return { url };


### PR DESCRIPTION
## What

Extend the team invitation link expiry from **1 hour → 2 days**, and update the invitation email copy to match ("The link will expire in 2 days.").

One change, in `OrganizationService.inviteTeamMember`:
- `timeLimit` baked into the invite JWT: `dayjs().add(1, 'hour')` → `dayjs().add(2, 'day')`
- email wording updated accordingly

## Why

The 1-hour window is too short in practice — invitees frequently don't act within the hour (they skim the email, get to it later, etc.), so the link is already dead when they click it and they silently fail to join.

## ⚠️ Temporary change

This is a deliberate stop-gap, not the final design. We're likely to rework the whole invite + join flow — e.g. add the invited user to the org as **pending** and resolve membership when they accept, rather than relying on a short-lived signed link. That redesign would supersede a fixed expiry window, at which point this value may change or go away entirely.

## Notes

- No schema/migration changes; only the in-token `timeLimit` and the email string.
- Independent of the related "invitation expired" message work (that's a separate branch/PR) — this just widens the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
