### PR TITLE
fix: join existing users to the inviting org on login/OAuth sign-in

### DIFF
--- a/apps/backend/src/api/routes/auth.controller.ts
+++ b/apps/backend/src/api/routes/auth.controller.ts
@@ -269,15 +269,24 @@ export class AuthController {
 
   @Post('/oauth/:provider/exists')
   async oauthExists(
+    @Req() req: Request,
     @Body('code') code: string,
     @Body('redirect_uri') redirect_uri: string,
     @Param('provider') provider: string,
     @Res({ passthrough: false }) response: Response
   ) {
-    const { jwt, token } = await this._authService.checkExists(
+    // Existing-user OAuth login: this path doesn't run routeAuth, so read the
+    // org invite cookie and join the org here too (when the invite is valid).
+    // See register/login for the same logic.
+    const getOrgFromCookie = this._authService.getOrgFromCookie(
+      req?.cookies?.org
+    );
+
+    const { jwt, token, addedOrg } = await this._authService.checkExists(
       provider,
       code,
-      redirect_uri
+      redirect_uri,
+      getOrgFromCookie
     );
 
     if (token) {
@@ -298,6 +307,27 @@ export class AuthController {
 
     if (process.env.NOT_SECURED) {
       response.header('auth', jwt);
+    }
+
+    // Joined a new org via the invite: tell the frontend to switch the active
+    // org to it (mirrors register/login). showorg is also a header so the
+    // NOT_SECURED setup, which can't set cross-site cookies, still works.
+    if (typeof addedOrg !== 'boolean' && addedOrg?.organizationId) {
+      response.cookie('showorg', addedOrg.organizationId, {
+        domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
+        ...(!process.env.NOT_SECURED
+          ? {
+              secure: true,
+              httpOnly: true,
+              sameSite: 'none',
+            }
+          : {}),
+        expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+      });
+
+      if (process.env.NOT_SECURED) {
+        response.header('showorg', addedOrg.organizationId);
+      }
     }
 
     response.header('reload', 'true');

--- a/apps/backend/src/services/auth/auth.service.ts
+++ b/apps/backend/src/services/auth/auth.service.ts
@@ -86,11 +86,28 @@ export class AuthService {
         throw new Error('Invalid user name or password');
       }
 
+      // Existing user logging in with a valid team invite: join the inviting
+      // org. Done BEFORE the activation gate on purpose, so a not-yet-activated
+      // user still gets the membership recorded -- the same model as a brand-new
+      // signup via invite, which is also added to the org while still
+      // unactivated. Activation remains required to actually use it: the throw
+      // below (and the auth middleware) keep an unactivated user out until they
+      // verify their email.
+      const addedOrg =
+        addToOrg && typeof addToOrg !== 'boolean'
+          ? await this._organizationService.addUserToOrg(
+              user.id,
+              addToOrg.id,
+              addToOrg.orgId,
+              addToOrg.role
+            )
+          : false;
+
       if (!user.activated) {
         throw new Error('User is not activated');
       }
 
-      return { addedOrg: false, jwt: await this.jwt(user) };
+      return { addedOrg, jwt: await this.jwt(user) };
     }
 
     const user = await this.loginOrRegisterProvider(
@@ -293,7 +310,12 @@ export class AuthService {
     return providerInstance.generateLink(query);
   }
 
-  async checkExists(provider: string, code: string, redirectUri?: string) {
+  async checkExists(
+    provider: string,
+    code: string,
+    redirectUri?: string,
+    addToOrg?: boolean | { orgId: string; role: 'USER' | 'ADMIN'; id: string }
+  ) {
     const providerInstance = this._providerManager.getProvider(provider);
     const token = await providerInstance.getToken(code, redirectUri);
     const user = await providerInstance.getUser(token);
@@ -305,7 +327,19 @@ export class AuthService {
       provider as Provider
     );
     if (checkExists) {
-      return { jwt: await this.jwt(checkExists) };
+      // Existing user signing in via OAuth while holding a valid team invite.
+      // This path bypasses routeAuth, so join the inviting org here too (OAuth
+      // accounts are always activated, so there is no activation gate to clear).
+      const addedOrg =
+        addToOrg && typeof addToOrg !== 'boolean'
+          ? await this._organizationService.addUserToOrg(
+              checkExists.id,
+              addToOrg.id,
+              addToOrg.orgId,
+              addToOrg.role
+            )
+          : false;
+      return { jwt: await this.jwt(checkExists), addedOrg };
     }
 
     return { token };


### PR DESCRIPTION
## What

Existing users who accepted a team invitation by **authenticating while logged out** (signing in with OAuth or email/password) were silently **not added** to the inviting org — they landed in their own org with no error.

Only the **logged-out** acceptance path was broken. The already-logged-in path (proxy → `/user/join-org`) joins correctly and is **untouched**.

## Why it happened

The logged-out invite is carried as the `org` cookie and consumed at the auth backend, but two branches ignored it:

- **OAuth sign-in:** `oauthExists` → `checkExists` returned only `{ jwt }` and never read the invite (this path bypasses `routeAuth`, where the join logic lived).
- **Email/password login:** `routeAuth`'s local-login branch hard-coded `addedOrg: false`.

## The fix

- `checkExists` now accepts the decoded invite and joins the existing OAuth user, returning `addedOrg`; `oauthExists` reads the invite cookie, passes it in, and sets the `showorg` cookie/header so the frontend switches to the newly joined org (mirrors register/login).
- `routeAuth`'s local-login branch joins the existing user too, **before** the activation gate — so an unactivated email/password user still gets the membership recorded. This makes unactivated invitees consistent: both brand-new signups and existing accounts are added to the org while still unactivated, and activation remains required to actually use it.

## Behavior summary (logged-out acceptance)

| User + valid invite | Joins | Usable session before activation |
|---|---|---|
| New unactivated (register) | yes (unchanged) | no — must activate |
| Existing unactivated (login) | yes (new) | no — must activate |
| Existing activated (login / OAuth) | yes (new) | yes |

## Testing

- **OAuth existing user:** logged out → click an org A invite link → sign in with Google → joined org A and switched to it. ✅
- **Email/password existing user:** logged out → click invite → log in → joined org A. ✅
- **Repro before the fix (OAuth):** same steps → logged into own org, never added to org A, no error.
- Backend `tsc` type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)