### PR TITLE
fix: include name field in getTeam query

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -338,13 +338,14 @@ export class OrganizationRepository {
             role: true,
             user: {
               select: {
+                name: true,
                 email: true,
                 id: true,
                 sendSuccessEmails: true,
                 sendFailureEmails: true,
                 sendStreakEmails: true,
+                },
               },
-            },
           },
         },
       },


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## Why was this change needed?
The team members list in Settings shows the email prefix (e.g. "Info" for info@example.com) instead of the user's name. Two fixes:

1. `organization.repository.ts` — the `getTeam` query did not select the `name` field from the User table.
2. `teams.component.tsx` — the display now uses `p.user.name` with a fallback to the email prefix.

## Checklist:
- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the CLA
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue