### PR TITLE
fix(auth): parse NOT_SECURED explicitly

### DIFF
--- a/apps/backend/src/api/routes/auth.controller.ts
+++ b/apps/backend/src/api/routes/auth.controller.ts
@@ -18,6 +18,7 @@ import { ForgotPasswordDto } from '@gitroom/nestjs-libraries/dtos/auth/forgot.pa
 import { ResendActivationDto } from '@gitroom/nestjs-libraries/dtos/auth/resend-activation.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.management';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 import { EmailService } from '@gitroom/nestjs-libraries/services/email.service';
 import { RealIP } from 'nestjs-real-ip';
 import { UserAgent } from '@gitroom/nestjs-libraries/user/user.agent';
@@ -27,6 +28,7 @@ import * as Sentry from '@sentry/nestjs';
 @ApiTags('Auth')
 @Controller('/auth')
 export class AuthController {
+  private readonly _isNotSecured = isEnvTrue(process.env.NOT_SECURED);
   constructor(
     private _authService: AuthService,
     private _emailService: EmailService
@@ -71,7 +73,7 @@ export class AuthController {
 
       response.cookie('auth', jwt, {
         domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-        ...(!process.env.NOT_SECURED
+        ...(!this._isNotSecured
           ? {
               secure: true,
               httpOnly: true,
@@ -81,14 +83,14 @@ export class AuthController {
         expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
       });
 
-      if (process.env.NOT_SECURED) {
+      if (this._isNotSecured) {
         response.header('auth', jwt);
       }
 
       if (typeof addedOrg !== 'boolean' && addedOrg?.organizationId) {
         response.cookie('showorg', addedOrg.organizationId, {
           domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-          ...(!process.env.NOT_SECURED
+          ...(!this._isNotSecured
             ? {
                 secure: true,
                 httpOnly: true,
@@ -98,7 +100,7 @@ export class AuthController {
           expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
         });
 
-        if (process.env.NOT_SECURED) {
+        if (this._isNotSecured) {
           response.header('showorg', addedOrg.organizationId);
         }
       }
@@ -136,7 +138,7 @@ export class AuthController {
 
       response.cookie('auth', jwt, {
         domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-        ...(!process.env.NOT_SECURED
+        ...(!this._isNotSecured
           ? {
               secure: true,
               httpOnly: true,
@@ -146,14 +148,14 @@ export class AuthController {
         expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
       });
 
-      if (process.env.NOT_SECURED) {
+      if (this._isNotSecured) {
         response.header('auth', jwt);
       }
 
       if (typeof addedOrg !== 'boolean' && addedOrg?.organizationId) {
         response.cookie('showorg', addedOrg.organizationId, {
           domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-          ...(!process.env.NOT_SECURED
+          ...(!this._isNotSecured
             ? {
                 secure: true,
                 httpOnly: true,
@@ -163,7 +165,7 @@ export class AuthController {
           expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
         });
 
-        if (process.env.NOT_SECURED) {
+        if (this._isNotSecured) {
           response.header('showorg', addedOrg.organizationId);
         }
       }
@@ -233,7 +235,7 @@ export class AuthController {
 
     response.cookie('auth', activate, {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -243,7 +245,7 @@ export class AuthController {
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
     });
 
-    if (process.env.NOT_SECURED) {
+    if (this._isNotSecured) {
       response.header('auth', activate);
     }
 
@@ -286,7 +288,7 @@ export class AuthController {
 
     response.cookie('auth', jwt, {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -296,7 +298,7 @@ export class AuthController {
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
     });
 
-    if (process.env.NOT_SECURED) {
+    if (this._isNotSecured) {
       response.header('auth', jwt);
     }
 

--- a/apps/backend/src/api/routes/public.controller.ts
+++ b/apps/backend/src/api/routes/public.controller.ts
@@ -18,6 +18,7 @@ import { TrackEnum } from '@gitroom/nestjs-libraries/user/track.enum';
 import { Request, Response } from 'express';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.management';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 import { AgentGraphInsertService } from '@gitroom/nestjs-libraries/agent/agent.graph.insert.service';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
@@ -33,6 +34,7 @@ const pump = promisify(pipeline);
 @ApiTags('Public')
 @Controller('/public')
 export class PublicController {
+  private readonly _isNotSecured = isEnvTrue(process.env.NOT_SECURED);
   constructor(
     private _trackService: TrackService,
     private _agentGraphInsertService: AgentGraphInsertService,
@@ -98,7 +100,7 @@ export class PublicController {
     if (!req.cookies.track) {
       res.cookie('track', uniqueId, {
         domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-        ...(!process.env.NOT_SECURED
+        ...(!this._isNotSecured
           ? {
               secure: true,
               httpOnly: true,
@@ -112,7 +114,7 @@ export class PublicController {
     if (body.fbclid && !req.cookies.fbclid) {
       res.cookie('fbclid', body.fbclid, {
         domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-        ...(!process.env.NOT_SECURED
+        ...(!this._isNotSecured
           ? {
               secure: true,
               httpOnly: true,

--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -19,6 +19,7 @@ import { AuthService } from '@gitroom/backend/services/auth/auth.service';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { CheckPolicies } from '@gitroom/backend/services/auth/permissions/permissions.ability';
 import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.management';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 import { pricing } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/pricing';
 import { ApiTags } from '@nestjs/swagger';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
@@ -38,6 +39,7 @@ import {
 @ApiTags('User')
 @Controller('/user')
 export class UsersController {
+  private readonly _isNotSecured = isEnvTrue(process.env.NOT_SECURED);
   constructor(
     private _subscriptionService: SubscriptionService,
     private _stripeService: StripeService,
@@ -168,7 +170,7 @@ export class UsersController {
 
     response.cookie('impersonate', id, {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -178,7 +180,7 @@ export class UsersController {
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
     });
 
-    if (process.env.NOT_SECURED) {
+    if (this._isNotSecured) {
       response.header('impersonate', id);
     }
   }
@@ -265,7 +267,7 @@ export class UsersController {
   ) {
     response.cookie('showorg', id, {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -275,7 +277,7 @@ export class UsersController {
       expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
     });
 
-    if (process.env.NOT_SECURED) {
+    if (this._isNotSecured) {
       response.header('showorg', id);
     }
 
@@ -287,7 +289,7 @@ export class UsersController {
     response.header('logout', 'true');
     response.cookie('auth', '', {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -300,7 +302,7 @@ export class UsersController {
 
     response.cookie('showorg', '', {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -313,7 +315,7 @@ export class UsersController {
 
     response.cookie('impersonate', '', {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-      ...(!process.env.NOT_SECURED
+      ...(!this._isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -351,7 +353,7 @@ export class UsersController {
     if (!req.cookies.track) {
       res.cookie('track', uniqueId, {
         domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-        ...(!process.env.NOT_SECURED
+        ...(!this._isNotSecured
           ? {
               secure: true,
               httpOnly: true,

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -19,12 +19,14 @@ import { PostValidationExceptionFilter } from '@gitroom/backend/api/routes/posts
 import { HttpExceptionFilter } from '@gitroom/nestjs-libraries/services/exception.filter';
 import { ConfigurationChecker } from '@gitroom/helpers/configuration/configuration.checker';
 import { startMcp } from '@gitroom/nestjs-libraries/chat/start.mcp';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 
 async function start() {
+  const isNotSecured = isEnvTrue(process.env.NOT_SECURED);
   const app = await NestFactory.create(AppModule, {
     rawBody: true,
     cors: {
-      ...(!process.env.NOT_SECURED ? { credentials: true } : {}),
+      ...(!isNotSecured ? { credentials: true } : {}),
       allowedHeaders: [
         'Content-Type',
         'Authorization',
@@ -38,7 +40,7 @@ async function start() {
         'onboarding',
         'activate',
         'x-copilotkit-runtime-client-gql-version',
-        ...(process.env.NOT_SECURED ? ['auth', 'showorg', 'impersonate'] : []),
+        ...(isNotSecured ? ['auth', 'showorg', 'impersonate'] : []),
       ],
       origin: [
         process.env.FRONTEND_URL,

--- a/apps/backend/src/services/auth/auth.middleware.ts
+++ b/apps/backend/src/services/auth/auth.middleware.ts
@@ -5,13 +5,15 @@ import { User } from '@prisma/client';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
 import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.management';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 import { HttpForbiddenException } from '@gitroom/nestjs-libraries/services/exception.filter';
 import { MastraService } from '@gitroom/nestjs-libraries/chat/mastra.service';
 
 export const removeAuth = (res: Response) => {
+  const isNotSecured = isEnvTrue(process.env.NOT_SECURED);
   res.cookie('auth', '', {
     domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
-    ...(!process.env.NOT_SECURED
+    ...(!isNotSecured
       ? {
           secure: true,
           httpOnly: true,

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import { SentryComponent } from '@gitroom/frontend/components/layout/sentry.component';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 
 export const dynamic = 'force-dynamic';
 import '../global.scss';
@@ -78,7 +79,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           facebookPixel={process.env.NEXT_PUBLIC_FACEBOOK_PIXEL!}
           telegramBotName={process.env.TELEGRAM_BOT_NAME!}
           neynarClientId={process.env.NEYNAR_CLIENT_ID!}
-          isSecured={!process.env.NOT_SECURED}
+          isSecured={!isEnvTrue(process.env.NOT_SECURED)}
           disableImageCompression={!!process.env.DISABLE_IMAGE_COMPRESSION}
           disableXAnalytics={!!process.env.DISABLE_X_ANALYTICS}
           sentryDsn={process.env.NEXT_PUBLIC_SENTRY_DSN!}

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -1,3 +1,4 @@
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 export const dynamic = 'force-dynamic';
 import '../global.scss';
 import 'react-tooltip/dist/react-tooltip.css';
@@ -48,7 +49,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           facebookPixel={process.env.NEXT_PUBLIC_FACEBOOK_PIXEL!}
           telegramBotName={process.env.TELEGRAM_BOT_NAME!}
           neynarClientId={process.env.NEYNAR_CLIENT_ID!}
-          isSecured={!process.env.NOT_SECURED}
+          isSecured={!isEnvTrue(process.env.NOT_SECURED)}
           isChatBase={false}
           disableImageCompression={!!process.env.DISABLE_IMAGE_COMPRESSION}
           disableXAnalytics={!!process.env.DISABLE_X_ANALYTICS}

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -1,4 +1,5 @@
 import { MantineWrapper } from '@gitroom/react/helpers/mantine.wrapper';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 
 export const dynamic = 'force-dynamic';
 import '../global.scss';
@@ -50,7 +51,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           facebookPixel={process.env.NEXT_PUBLIC_FACEBOOK_PIXEL!}
           telegramBotName={process.env.TELEGRAM_BOT_NAME!}
           neynarClientId={process.env.NEYNAR_CLIENT_ID!}
-          isSecured={!process.env.NOT_SECURED}
+          isSecured={!isEnvTrue(process.env.NOT_SECURED)}
           isChatBase={false}
           disableImageCompression={!!process.env.DISABLE_IMAGE_COMPRESSION}
           disableXAnalytics={!!process.env.DISABLE_X_ANALYTICS}

--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.management';
+import { isEnvTrue } from '@gitroom/helpers/utils/env.bool';
 import { internalFetch } from '@gitroom/helpers/utils/internal.fetch';
 import acceptLanguage from 'accept-language';
 import {
@@ -12,6 +13,7 @@ acceptLanguage.languages(languages);
 
 // This function can be marked `async` if using `await` inside
 export async function proxy(request: NextRequest) {
+  const isNotSecured = isEnvTrue(process.env.NOT_SECURED);
   const nextUrl = request.nextUrl;
   const authCookie =
     request.cookies.get('auth') ||
@@ -66,7 +68,7 @@ export async function proxy(request: NextRequest) {
     );
     response.cookies.set('auth', '', {
       path: '/',
-      ...(!process.env.NOT_SECURED
+      ...(!isNotSecured
         ? {
             secure: true,
             httpOnly: true,
@@ -113,7 +115,7 @@ export async function proxy(request: NextRequest) {
     if (org) {
       const redirect = NextResponse.redirect(new URL(`/`, nextUrl.href));
       redirect.cookies.set('org', org, {
-        ...(!process.env.NOT_SECURED
+        ...(!isNotSecured
           ? {
               path: '/',
               secure: true,
@@ -143,7 +145,7 @@ export async function proxy(request: NextRequest) {
       );
       if (id) {
         redirect.cookies.set('showorg', id, {
-          ...(!process.env.NOT_SECURED
+          ...(!isNotSecured
             ? {
                 path: '/',
                 secure: true,

--- a/libraries/helpers/src/utils/env.bool.ts
+++ b/libraries/helpers/src/utils/env.bool.ts
@@ -1,0 +1,5 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export function isEnvTrue(value?: string | null) {
+  return typeof value === 'string' && TRUE_VALUES.has(value.trim().toLowerCase());
+}


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) and sign the [CLA](https://contribute.postiz.com/p/postiz/cla) before submitting a PR. -->

    fix(auth): parse NOT_SECURED explicitly
    
# Summary
    This PR replaces raw NOT_SECURED env truthiness checks with explicit boolean parsing.
    
# Why was this change needed?
    process.env values are strings, so NOT_SECURED=false is still truthy if consumed directly. That can accidentally enable the non-secured auth path in self-hosted deployments.
    
 # Changes
    - add a shared boolean env parser
    - treat only true / 1 / yes / on as enabled
    - update frontend and backend NOT_SECURED checks accordingly
    
# Validation
    - frontend build passed
    - backend build passed



Please link to related issues when possible, and explain WHY you changed things, not WHAT you changed.

# Other information:

eg: Did you discuss this change with anybody before working on it (not required, but can be a good idea for bigger changes). Any plans for the future, etc?

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
