### PR TITLE
fix: harden URL media uploads (agent tool + public API) against fetch failures & oversized files

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -103,10 +103,17 @@ export class PublicIntegrationsController {
     @Body() body: UploadDto
   ) {
     Sentry.metrics.count('public_api-request', 1);
-    const response = await fetch(body.url, {
-      // @ts-ignore — undici option, not in lib.dom fetch types
-      dispatcher: ssrfSafeDispatcher,
-    });
+    let response: globalThis.Response;
+    try {
+      response = await fetch(body.url, {
+        // @ts-ignore — undici option, not in lib.dom fetch types
+        dispatcher: ssrfSafeDispatcher,
+      });
+    } catch {
+      // Network-level failure (DNS, connection refused, SSRF block, etc.) —
+      // fetch rejects rather than returning a non-ok response.
+      throw new HttpException({ msg: 'Failed to fetch URL' }, 400);
+    }
     if (!response.ok) {
       throw new HttpException({ msg: 'Failed to fetch URL' }, 400);
     }

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -12,7 +12,10 @@ import {
   UseInterceptors,
   UsePipes,
 } from '@nestjs/common';
-import { CustomFileValidationPipe } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
+import {
+  CustomFileValidationPipe,
+  getMaxSize,
+} from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { ApiTags } from '@nestjs/swagger';
 import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.request';
 import { Organization } from '@prisma/client';
@@ -107,11 +110,27 @@ export class PublicIntegrationsController {
     if (!response.ok) {
       throw new HttpException({ msg: 'Failed to fetch URL' }, 400);
     }
+
+    // Guard against OOM: bail out before buffering the whole body into memory.
+    // Content-Length may be absent or wrong, so we re-check the real size after
+    // download too. The type isn't known yet (sniffed below), so the pre-check
+    // uses the largest allowed cap (video).
+    const maxDownloadSize = getMaxSize('video/mp4');
+    const declaredSize = Number(response.headers.get('content-length'));
+    if (declaredSize && declaredSize > maxDownloadSize) {
+      throw new HttpException({ msg: 'File is too large.' }, 400);
+    }
+
     const buffer = Buffer.from(await response.arrayBuffer());
     const detected = await fromBuffer(buffer);
     if (!detected || !PUBLIC_API_ALLOWED_MIME.has(detected.mime)) {
       throw new HttpException({ msg: 'Unsupported file type.' }, 400);
     }
+
+    if (buffer.length > getMaxSize(detected.mime)) {
+      throw new HttpException({ msg: 'File is too large.' }, 400);
+    }
+
     const mimetype = detected.mime;
     const ext = detected.ext;
 

--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -34,7 +34,7 @@ export class UploadFromUrlTool implements AgentToolInterface {
       id: 'uploadFromUrlTool',
       description: `Upload a remote image or video into the media library from a public URL.
 Use this before scheduling a post when the user provides an external media URL (not already hosted on our domain),
-so the attachment passes the upload-domain validation. Returns the hosted media { id, path } to use as an attachment.`,
+so the attachment passes the upload-domain validation. Returns the hosted media { id, path } to use as an attachment, or { error } on failure.`,
       mcp: {
         annotations: {
           title: 'Upload Media From URL',
@@ -50,49 +50,63 @@ so the attachment passes the upload-domain validation. Returns the hosted media 
           .url()
           .describe('The public URL of the image or video to upload'),
       }),
+      // Mastra validates a tool's return against this schema, so it must also
+      // allow the graceful { error } shape. Fields are optional (rather than
+      // wrapping everything in an `output` union) to keep the change minimal:
+      // the existing { id, path } success return and the new { error } return
+      // both validate without rewriting every return statement.
       outputSchema: z.object({
-        id: z.string(),
-        path: z.string(),
+        id: z.string().optional(),
+        path: z.string().optional(),
+        error: z.string().optional(),
       }),
       execute: async (inputData, context) => {
         checkAuth(inputData, context);
-        const org = JSON.parse(
-          (context?.requestContext as any)?.get('organization') as string
-        );
+        try {
+          const org = JSON.parse(
+            (context?.requestContext as any)?.get('organization') as string
+          );
 
-        const response = await fetch(inputData.url, {
-          // @ts-ignore — undici option, not in lib.dom fetch types
-          dispatcher: ssrfSafeDispatcher,
-        });
+          const response = await fetch(inputData.url, {
+            // @ts-ignore — undici option, not in lib.dom fetch types
+            dispatcher: ssrfSafeDispatcher,
+          });
 
-        if (!response.ok) {
-          throw new Error('Failed to fetch URL');
+          if (!response.ok) {
+            return { error: 'Failed to fetch URL' };
+          }
+
+          const buffer = Buffer.from(await response.arrayBuffer());
+          const detected = await fromBuffer(buffer);
+          if (!detected || !ALLOWED_MIME.has(detected.mime)) {
+            return { error: 'Unsupported file type.' };
+          }
+
+          const getFile = await this.storage.uploadFile({
+            buffer,
+            mimetype: detected.mime,
+            size: buffer.length,
+            path: '',
+            fieldname: '',
+            destination: '',
+            stream: new Readable(),
+            filename: '',
+            originalname: `upload.${detected.ext}`,
+            encoding: '',
+          });
+
+          return await this._mediaService.saveFile(
+            org.id,
+            getFile.originalname,
+            getFile.path
+          );
+        } catch (err) {
+          return {
+            error: `Failed to upload media from URL: ${
+              err instanceof Error ? err.message : 'Unexpected error'
+            }`,
+          };
         }
-
-        const buffer = Buffer.from(await response.arrayBuffer());
-        const detected = await fromBuffer(buffer);
-        if (!detected || !ALLOWED_MIME.has(detected.mime)) {
-          throw new Error('Unsupported file type.');
-        }
-
-        const getFile = await this.storage.uploadFile({
-          buffer,
-          mimetype: detected.mime,
-          size: buffer.length,
-          path: '',
-          fieldname: '',
-          destination: '',
-          stream: new Readable(),
-          filename: '',
-          originalname: `upload.${detected.ext}`,
-          encoding: '',
-        });
-
-        return this._mediaService.saveFile(
-          org.id,
-          getFile.originalname,
-          getFile.path
-        );
       },
     });
   }

--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
+import { getMaxSize } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
 import { ssrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import { Readable } from 'stream';
@@ -76,10 +77,29 @@ so the attachment passes the upload-domain validation. Returns the hosted media 
             return { error: 'Failed to fetch URL' };
           }
 
+          // Guard against OOM: bail out before buffering the whole body into
+          // memory. Content-Length may be absent or wrong, so we re-check the
+          // real size after download too. The type isn't known yet (sniffed
+          // below), so the pre-check uses the largest allowed cap (video).
+          const maxDownloadSize = getMaxSize('video/mp4');
+          const declaredSize = Number(response.headers.get('content-length'));
+          if (declaredSize && declaredSize > maxDownloadSize) {
+            return {
+              error: `File is too large: ${declaredSize} bytes (max ${maxDownloadSize} bytes).`,
+            };
+          }
+
           const buffer = Buffer.from(await response.arrayBuffer());
           const detected = await fromBuffer(buffer);
           if (!detected || !ALLOWED_MIME.has(detected.mime)) {
             return { error: 'Unsupported file type.' };
+          }
+
+          const maxSize = getMaxSize(detected.mime);
+          if (buffer.length > maxSize) {
+            return {
+              error: `File is too large: ${buffer.length} bytes (max ${maxSize} bytes).`,
+            };
           }
 
           const getFile = await this.storage.uploadFile({

--- a/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
+++ b/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
@@ -38,7 +38,7 @@ export class CustomFileValidationPipe implements PipeTransform {
       throw new BadRequestException('Unsupported file type.');
     }
 
-    const maxSize = this.getMaxSize(detected.mime);
+    const maxSize = getMaxSize(detected.mime);
     if (value.size > maxSize) {
       throw new BadRequestException(
         `File size exceeds the maximum allowed size of ${maxSize} bytes.`
@@ -55,13 +55,14 @@ export class CustomFileValidationPipe implements PipeTransform {
     return value;
   }
 
-  private getMaxSize(mimeType: string): number {
-    if (mimeType.startsWith('image/')) {
-      return 10 * 1024 * 1024; // 10 MB
-    } else if (mimeType.startsWith('video/')) {
-      return 1024 * 1024 * 1024; // 1 GB
-    } else {
-      throw new BadRequestException('Unsupported file type.');
-    }
+}
+
+export function getMaxSize(mimeType: string): number {
+  if (mimeType.startsWith('image/')) {
+    return 10 * 1024 * 1024; // 10 MB
+  } else if (mimeType.startsWith('video/')) {
+    return 1024 * 1024 * 1024; // 1 GB
+  } else {
+    throw new BadRequestException('Unsupported file type.');
   }
 }


### PR DESCRIPTION
## Why this was needed

A self-hosted user reported the built-in agent (MCP) "crashing" when asked to attach media from an external URL that returns a 404. Investigation showed that `uploadFromUrlTool` — and its sibling, the public `/upload-from-url` API used by external clients (n8n, etc.) — **threw** on any fetch failure. Mastra caught the throw and surfaced it as a loud `TOOL_EXECUTION_FAILED` MastraError stack in the MCP deployment logs, which *read* like a crash even though the process never actually exited.

While hardening that path, two adjacent gaps in the same URL-upload code surfaced: there was **no size limit** (an unbounded remote file could OOM the process), and on the public API a **network-level fetch failure became a 500** instead of a clean client error.

This PR hardens **both** URL-upload entry points (the agent tool and the public API endpoint) with three small, independently-reviewable fixes — each reproduced before and validated after.

## Why all three commits exist

Each commit is a distinct concern, spanning the two entry points, and each carries its own reproduction + validation in its commit message:

1. **`fix: make uploadFromUrl tool fail gracefully`** — return a structured `{ error }` instead of throwing, so the agent relays a clean message and the logs stay quiet. We confirmed Mastra validates a tool's return against its `outputSchema`, so the schema declares the error shape (via optional fields, to keep the change minimal). *Reproduced the noisy MastraError pre-fix; verified the clean `{ error }` (`isError: false`) after.*

2. **`fix: cap media size on URL uploads to prevent OOM`** — check `Content-Length` before buffering the body, and re-check the real size after, reusing `getMaxSize` (exported for the purpose). Applied to both the agent tool and the public endpoint. *Verified the guard fires on both paths by temporarily shrinking the cap and uploading a normal photo.*

3. **`fix: return 400 on fetch rejection in public /upload-from-url`** — wrap the fetch so a network/TLS/SSRF rejection returns a clean 400 instead of propagating to a 500. *Reproduced the 500 pre-fix (a TLS-error host); verified the 400 after.*

Keeping them separate makes each fix (error surfacing / resource limit / HTTP-status correctness) easy to review and revert independently.

## Intentionally out of scope

- Aligning **other agent tools'** output schemas to the same `{ error }` protection — they currently rely on Mastra's leniency, and their corresponding error cases are unlikely compared to a routinely-failing remote fetch here.
- A **fetch timeout**, and an **SSRF review** of publish-time `readOrFetch` fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
