### PR TITLE
fix: gracefully handle AI generation provider errors (OpenAI safety rejections)

### DIFF
--- a/apps/backend/src/api/routes/posts.controller.ts
+++ b/apps/backend/src/api/routes/posts.controller.ts
@@ -240,8 +240,21 @@ export class PostsController {
     @Res({ passthrough: false }) res: Response
   ) {
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
-    for await (const event of this._agentGraphService.start(org.id, body)) {
-      res.write(JSON.stringify(event) + '\n');
+    try {
+      for await (const event of this._agentGraphService.start(org.id, body)) {
+        res.write(JSON.stringify(event) + '\n');
+      }
+    } catch (err) {
+      // The stream has already started, so we cannot surface a normal HTTP
+      // error here. Emit a final error event on the open stream instead, so the
+      // client can stop and show the message rather than hang on a truncated
+      // stream. HttpExceptions carry a curated, user-facing message (e.g. the
+      // AI safety rejection); anything else gets a generic message.
+      const message =
+        err instanceof HttpException
+          ? err.message
+          : 'Something went wrong while generating your posts, please try again.';
+      res.write(JSON.stringify({ name: 'error', error: true, message }) + '\n');
     }
 
     res.end();

--- a/apps/frontend/src/components/launches/generator/generator.tsx
+++ b/apps/frontend/src/components/launches/generator/generator.tsx
@@ -21,11 +21,13 @@ import dayjs from 'dayjs';
 import { Select } from '@gitroom/react/form/select';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
+import { useToaster } from '@gitroom/react/toaster/toaster';
 
 const FirstStep: FC = (props) => {
   const { integrations, reloadCalendarView } = useCalendar();
   const modal = useModals();
   const fetch = useFetch();
+  const toaster = useToaster();
   const [loading, setLoading] = useState(false);
   const [showStep, setShowStep] = useState('');
   const t = useT();
@@ -59,8 +61,23 @@ const FirstStep: FC = (props) => {
         for (const chunk of chunkStr
           .split('\n')
           .filter((f) => f && f.indexOf('{') > -1)) {
+          let data: any;
           try {
-            const data = JSON.parse(chunk);
+            data = JSON.parse(chunk);
+          } catch (e) {
+            /** ignore partial / unparseable chunks **/
+            continue;
+          }
+
+          // Server emits this when a node in the generation graph throws.
+          if (data?.error) {
+            throw new Error(
+              data.message ||
+                t('generation_failed', 'Failed to generate posts, please try again.')
+            );
+          }
+
+          {
             switch (data.name) {
               case 'agent':
                 setShowStep(t('agent_starting', 'Agent starting'));
@@ -108,8 +125,6 @@ const FirstStep: FC = (props) => {
                 break;
             }
             lastResponse = data;
-          } catch (e) {
-            /** don't do anything **/
           }
         }
       }
@@ -121,66 +136,83 @@ const FirstStep: FC = (props) => {
   }> = useCallback(
     async (value) => {
       setLoading(true);
-      const response = await fetch('/posts/generator', {
-        method: 'POST',
-        body: JSON.stringify(value),
-      });
-      if (!response.body) {
-        return;
-      }
-      const reader = response.body.getReader();
-      const load = await generateStep(reader);
-      const messages = load.content.map((p: any, index: number) => {
-        if (index === 0) {
+      try {
+        const response = await fetch('/posts/generator', {
+          method: 'POST',
+          body: JSON.stringify(value),
+        });
+        if (!response.body) {
+          throw new Error(
+            t('generation_failed', 'Failed to generate posts, please try again.')
+          );
+        }
+        const reader = response.body.getReader();
+        const load = await generateStep(reader);
+        if (!load?.content) {
+          throw new Error(
+            t('generation_failed', 'Failed to generate posts, please try again.')
+          );
+        }
+        const messages = load.content.map((p: any, index: number) => {
+          if (index === 0) {
+            return {
+              content: load.hook + '\n' + p.content,
+              ...(p?.image?.path
+                ? {
+                    image: [p.image],
+                  }
+                : {}),
+            };
+          }
           return {
-            content: load.hook + '\n' + p.content,
+            content: p.content,
             ...(p?.image?.path
               ? {
                   image: [p.image],
                 }
               : {}),
           };
-        }
-        return {
-          content: p.content,
-          ...(p?.image?.path
-            ? {
-                image: [p.image],
-              }
-            : {}),
-        };
-      });
-      setShowStep('');
-      modal.openModal({
-        id: 'add-edit-modal',
-        closeOnClickOutside: false,
-        removeLayout: true,
-        closeOnEscape: false,
-        withCloseButton: false,
-        askClose: true,
-        fullScreen: true,
-        classNames: {
-          modal: 'w-[100%] max-w-[1400px] text-textColor',
-        },
-        children: (
-          <AddEditModal
-            allIntegrations={integrations.map((p) => ({
-              ...p,
-            }))}
-            integrations={integrations.slice(0).map((p) => ({
-              ...p,
-            }))}
-            mutate={reloadCalendarView}
-            date={dayjs.utc(load.date).local()}
-            reopenModal={() => ({})}
-            onlyValues={messages}
-          />
-        ),
-        size: '80%',
-      });
-      setLoading(false);
+        });
+        setShowStep('');
+        modal.openModal({
+          id: 'add-edit-modal',
+          closeOnClickOutside: false,
+          removeLayout: true,
+          closeOnEscape: false,
+          withCloseButton: false,
+          askClose: true,
+          fullScreen: true,
+          classNames: {
+            modal: 'w-[100%] max-w-[1400px] text-textColor',
+          },
+          children: (
+            <AddEditModal
+              allIntegrations={integrations.map((p) => ({
+                ...p,
+              }))}
+              integrations={integrations.slice(0).map((p) => ({
+                ...p,
+              }))}
+              mutate={reloadCalendarView}
+              date={dayjs.utc(load.date).local()}
+              reopenModal={() => ({})}
+              onlyValues={messages}
+            />
+          ),
+          size: '80%',
+        });
+      } catch (e: any) {
+        toaster.show(
+          e?.message ||
+            t('generation_failed', 'Failed to generate posts, please try again.'),
+          'warning'
+        );
+      } finally {
+        setShowStep('');
+        setLoading(false);
+      }
     },
-    [integrations, reloadCalendarView]
+    [integrations, reloadCalendarView, fetch, generateStep, modal, toaster, t]
   );
   return (
     <form

--- a/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { GeneratorDto } from '@gitroom/nestjs-libraries/dtos/generator/generator.dto';
+import { generationError } from '@gitroom/nestjs-libraries/openai/generation.error';
 
 const tools = !process.env.TAVILY_API_KEY
   ? []
@@ -318,19 +319,23 @@ export class AgentGraphService {
       return {};
     }
 
-    const newContent = await Promise.all(
-      (state.content || []).map(async (p) => {
-        const image = await dalle.invoke(p.prompt!);
-        return {
-          ...p,
-          image,
-        };
-      })
-    );
+    try {
+      const newContent = await Promise.all(
+        (state.content || []).map(async (p) => {
+          const image = await dalle.invoke(p.prompt!);
+          return {
+            ...p,
+            image,
+          };
+        })
+      );
 
-    return {
-      content: newContent,
-    };
+      return {
+        content: newContent,
+      };
+    } catch (err) {
+      throw generationError(err);
+    }
   }
 
   async uploadPictures(state: WorkflowChannelsState) {

--- a/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
@@ -1,6 +1,7 @@
 import { HttpException, Injectable } from '@nestjs/common';
 import { MediaRepository } from '@gitroom/nestjs-libraries/database/prisma/media/media.repository';
 import { OpenaiService } from '@gitroom/nestjs-libraries/openai/openai.service';
+import { generationError } from '@gitroom/nestjs-libraries/openai/generation.error';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
 import { Organization } from '@prisma/client';
 import { SaveMediaInformationDto } from '@gitroom/nestjs-libraries/dtos/media/save.media.information.dto';
@@ -37,19 +38,23 @@ export class MediaService {
     org: Organization,
     generatePromptFirst?: boolean
   ) {
-    const generating = await this._subscriptionService.useCredit(
-      org,
-      'ai_images',
-      async () => {
-        if (generatePromptFirst) {
-          prompt = await this._openAi.generatePromptForPicture(prompt);
-          console.log('Prompt:', prompt);
+    try {
+      const generating = await this._subscriptionService.useCredit(
+        org,
+        'ai_images',
+        async () => {
+          if (generatePromptFirst) {
+            prompt = await this._openAi.generatePromptForPicture(prompt);
+            console.log('Prompt:', prompt);
+          }
+          return this._openAi.generateImage(prompt);
         }
-        return this._openAi.generateImage(prompt);
-      }
-    );
+      );
 
-    return generating;
+      return generating;
+    } catch (err) {
+      throw generationError(err);
+    }
   }
 
   saveFile(org: string, fileName: string, filePath: string, originalName?: string) {
@@ -82,44 +87,51 @@ export class MediaService {
   }
 
   async generateVideo(org: Organization, body: VideoDto) {
-    const totalCredits = await this._subscriptionService.checkCredits(
-      org,
-      'ai_videos'
-    );
+    try {
+      const totalCredits = await this._subscriptionService.checkCredits(
+        org,
+        'ai_videos'
+      );
 
-    if (totalCredits.credits <= 0) {
-      throw new SubscriptionException({
-        action: AuthorizationActions.Create,
-        section: Sections.VIDEOS_PER_MONTH,
-      });
-    }
-
-    const video = this._videoManager.getVideoByName(body.type);
-    if (!video) {
-      throw new Error(`Video type ${body.type} not found`);
-    }
-
-    if (!video.trial && org.isTrailing) {
-      throw new HttpException('This video is not available in trial mode', 406);
-    }
-
-    console.log(body.customParams);
-    await video.instance.processAndValidate(body.customParams);
-    console.log('no err');
-
-    return await this._subscriptionService.useCredit(
-      org,
-      'ai_videos',
-      async () => {
-        const loadedData = await video.instance.process(
-          body.output,
-          body.customParams
-        );
-
-        const file = await this.storage.uploadSimple(loadedData);
-        return this.saveFile(org.id, file.split('/').pop(), file);
+      if (totalCredits.credits <= 0) {
+        throw new SubscriptionException({
+          action: AuthorizationActions.Create,
+          section: Sections.VIDEOS_PER_MONTH,
+        });
       }
-    );
+
+      const video = this._videoManager.getVideoByName(body.type);
+      if (!video) {
+        throw new Error(`Video type ${body.type} not found`);
+      }
+
+      if (!video.trial && org.isTrailing) {
+        throw new HttpException(
+          'This video is not available in trial mode',
+          406
+        );
+      }
+
+      console.log(body.customParams);
+      await video.instance.processAndValidate(body.customParams);
+      console.log('no err');
+
+      return await this._subscriptionService.useCredit(
+        org,
+        'ai_videos',
+        async () => {
+          const loadedData = await video.instance.process(
+            body.output,
+            body.customParams
+          );
+
+          const file = await this.storage.uploadSimple(loadedData);
+          return this.saveFile(org.id, file.split('/').pop(), file);
+        }
+      );
+    } catch (err) {
+      throw generationError(err);
+    }
   }
 
   async videoFunction(identifier: string, functionName: string, body: any) {

--- a/libraries/nestjs-libraries/src/openai/generation.error.ts
+++ b/libraries/nestjs-libraries/src/openai/generation.error.ts
@@ -1,0 +1,42 @@
+import { HttpException } from '@nestjs/common';
+
+// e.g. "400 Your request was rejected by the safety system, safety_violations=[sexual]"
+const SAFETY_VIOLATIONS_REGEX = /safety_violations=\[([^\]]*)\]/i;
+
+// Match genuine content-safety rejections by message, NOT by a bare 400 status:
+// a 400 can just as easily be an invalid-parameter error, which must not be
+// reported to the user as a safety violation.
+const SAFETY_MESSAGE_REGEX =
+  /safety system|safety_violations|content[ _]policy|rejected as a result of our safety|moderation/i;
+
+/**
+ * Normalizes errors thrown by AI generation providers (OpenAI image/chat,
+ * LangChain DALL-E, Fal, Veo3, HeyGen, ElevenLabs, ...) into a clean
+ * HttpException so a provider rejection (most notably an OpenAI safety
+ * violation) returns a proper response instead of crashing the backend.
+ *
+ * When the provider reports a content-safety rejection, the flagged
+ * category/categories are surfaced back to the user.
+ */
+export function generationError(err: any): HttpException {
+  // Preserve errors we already raised intentionally (e.g. SubscriptionException).
+  if (err instanceof HttpException) {
+    return err;
+  }
+
+  const message: string =
+    err?.error?.message || err?.message || String(err || '');
+
+  if (SAFETY_MESSAGE_REGEX.test(message)) {
+    const categories = message.match(SAFETY_VIOLATIONS_REGEX)?.[1]?.trim();
+    const detail = categories ? ` Flagged categories: ${categories}.` : '';
+    return new HttpException(
+      `Your request was rejected by the AI safety system.${detail} Please adjust your prompt and try again.`,
+      422
+    );
+  }
+
+  // Not a recognized safety rejection (e.g. an invalid-parameter 400) — return
+  // a generic message rather than mislabeling it as a content-safety issue.
+  return new HttpException('AI generation failed, please try again later.', 500);
+}


### PR DESCRIPTION
## Why this is needed

An OpenAI image-generation **safety rejection** (`400 ... safety_violations=[sexual]`) propagated unhandled and broke the request — for the streaming post-generator it truncated the response and hung the frontend. This makes every AI generation path fail gracefully with a clear, user-facing message instead:

- **Direct endpoints** (`/media/generate-image`, `/generate-image-with-prompt`, `/media` + public `/generate-video`) → clean **422** with the flagged safety category.
- **Chat agent tools** (`generateImageTool` / `generateVideoTool`) → same translation via the shared `MediaService` chokepoint.
- **Post generator stream** (`/posts/generator`) → the error is delivered as a stream event and shown as a toaster, instead of a silently truncated stream + infinite spinner.

## Why two commits

The split is intentional and ordered as a prerequisite → layer:

1. **`handle errors gracefully in the post-generator streaming path`** — *foundational.* The streaming endpoint could already be broken today by any node failure (rate-limit, network blip, parse error), independent of safety errors: the throw escaped the loop after the response had started, so the stream truncated and the frontend hung. This commit makes the stream able to deliver *any* error to the client (backend emits a final error event; frontend surfaces it + always clears loading).
2. **`translate AI generation provider errors into clean responses`** — layers the specific provider-error translation on top of that fixed flow: a `generationError()` helper that detects safety rejections **by message content** (not a bare 400, which can be an invalid-parameter error), surfaces the violation category, and preserves existing `HttpException`s. Wrapped at `MediaService.generateImage/generateVideo` and `AgentGraphService.generatePictures`.

## Validation (end-to-end, real LLM calls)

- Real safety prompt → **422** `"…Flagged categories: sexual…"` (was unhandled); benign prompt still returns the image (201).
- Generator stream: forced failure → before = silent truncation + hung spinner; after = clean error event, toaster, backend stays up (HTTP 200).
- A non-safety 400 (`unknown_parameter`) is classified as a **generic** error, **not** mislabeled as safety.

Each commit message documents its reproduction + post-fix validation.

## Known follow-up (NOT in this PR)

Testing surfaced a **pre-existing** bug: the generator's image step uses `DallEAPIWrapper(model: 'chatgpt-image-latest')`, which 400s on the `response_format` param it sends (`unknown_parameter`) — so generator image generation has never worked with this model. This PR makes it fail *gracefully*; the actual fix (drop `response_format` / route through the working `OpenaiService.generateImage`) should be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)