### PR TITLE
Stop LinkedIn from resizing images to 1000px and flattening PNGs to JPEG

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -623,9 +623,15 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     const isVideo = hasExtension(mediaUrl, 'mp4');
     const isGif = lookup(mediaUrl) === 'image/gif';
 
+    // GIFs and videos pass through untouched (sharp would break animation).
     if (isVideo || isGif) {
       return Buffer.from(await readOrFetch(mediaUrl));
     }
+
+    const mime = lookup(mediaUrl);
+    // PNG and JPEG (covers both .jpg and .jpeg) keep their original format;
+    // anything else (webp, tiff, ...) is converted to jpeg for compatibility.
+    const keepFormat = mime === 'image/png' || mime === 'image/jpeg';
 
     // Always downscale to stay under LinkedIn's 36,152,320-pixel cap: fit within
     // a 6000x6000 box (max 36,000,000 px for any aspect ratio) while preserving
@@ -634,10 +640,14 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     // DISABLE_IMAGE_COMPRESSION=true, where the frontend no longer shrinks
     // uploads and full-size images reach LinkedIn directly. Do not remove it on
     // the assumption that the frontend compression already caps dimensions.
-    return await sharp(await readOrFetch(mediaUrl), { animated: false })
-      .resize({ width: 6000, height: 6000, fit: 'inside', withoutEnlargement: true })
-      .toFormat('jpeg')
-      .toBuffer();
+    const pipeline = sharp(await readOrFetch(mediaUrl), { animated: false }).resize({
+      width: 6000,
+      height: 6000,
+      fit: 'inside',
+      withoutEnlargement: true,
+    });
+
+    return await (keepFormat ? pipeline : pipeline.toFormat('jpeg')).toBuffer();
   }
 
   private buildPostContent(isPdf: boolean, mediaIds: string[], pdfTitle?: string) {

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -627,9 +627,16 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       return Buffer.from(await readOrFetch(mediaUrl));
     }
 
+    // Always downscale to stay under LinkedIn's 36,152,320-pixel cap: fit within
+    // a 6000x6000 box (max 36,000,000 px for any aspect ratio) while preserving
+    // the aspect ratio and never enlarging smaller images (downscale-only).
+    // NOTE: this guard is required for self-hosted instances running with
+    // DISABLE_IMAGE_COMPRESSION=true, where the frontend no longer shrinks
+    // uploads and full-size images reach LinkedIn directly. Do not remove it on
+    // the assumption that the frontend compression already caps dimensions.
     return await sharp(await readOrFetch(mediaUrl), { animated: false })
+      .resize({ width: 6000, height: 6000, fit: 'inside', withoutEnlargement: true })
       .toFormat('jpeg')
-      .resize({ width: 1000 })
       .toBuffer();
   }
 


### PR DESCRIPTION
## Why

The LinkedIn provider unconditionally resized every image to **1000px wide** and converted every still image to **JPEG** before posting. Both transforms degraded image quality for no good reason:

- **The 1000px resize** was redundant with the frontend Uppy compressor (which already fits uploads within 1000×1000), and worse, `sharp`'s resize *enlarges* by default — so images smaller than 1000px were upscaled. It also meant that self-hosted instances running with `DISABLE_IMAGE_COMPRESSION=true` (frontend compression off, full-size images expected) still got their images shrunk to 1000px in the provider.
- **The PNG→JPEG conversion** flattened PNG transparency onto a black background and added lossy artifacts to graphics/screenshots — exactly the content people upload as PNG to keep crisp and transparent.

## Approach

**1. Replace the fixed 1000px resize with a downscale-only cap guard.** We can't just delete the resize: with `DISABLE_IMAGE_COMPRESSION=true`, full-size images reach LinkedIn directly, and LinkedIn's Images API rejects anything above **36,152,320 pixels**. So instead we downscale *only when needed*, fitting within a 6000×6000 box (max 36,000,000 px for any aspect ratio — a width-only cap wouldn't be safe for tall/portrait images), aspect-preserving and never enlarging. Normal-sized images now pass through untouched at full resolution. The guard stays in place specifically for the `DISABLE_IMAGE_COMPRESSION=true` path and is documented as such in the code.

**2. Stop converting PNGs to JPEG.** The sharp pipeline is split into resize → optional conversion → output, and PNG/JPEG keep their original format (PNGs stay lossless with alpha intact). We only exclude **PNG and JPEG** because those are the only still image formats LinkedIn supports (JPG, GIF, PNG per their [Images API docs](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api)) — GIFs already bypass sharp, and any other format (webp, tiff, …) is still converted to JPEG since LinkedIn would otherwise reject it.

## Reproduction & validation

Both changes were reproduced and validated end-to-end with `DISABLE_IMAGE_COMPRESSION=true` against real LinkedIn posts (oversized JPEG/PNG failing before and posting after the cap guard; esoteric PNGs — 16-bit, Display-P3 ICC, interlaced — posting cleanly). Full details are in the individual commit messages.

## Commits

- `fix: cap LinkedIn images under the 36MP limit instead of forcing 1000px`
- `feat: stop converting LinkedIn PNGs to JPEG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)