### PR TITLE
feat: WordPress post tags, categories, and status

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.provider.tsx
@@ -6,8 +6,10 @@ import {
   withProvider,
 } from '@gitroom/frontend/components/new-launch/providers/high.order.provider';
 import { Input } from '@gitroom/react/form/input';
+import { Select } from '@gitroom/react/form/select';
 import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
 import { WordpressPostType } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.post.type';
+import { WordpressTerms } from '@gitroom/frontend/components/new-launch/providers/wordpress/wordpress.terms';
 import { MediaComponent } from '@gitroom/frontend/components/media/media.component';
 import { WordpressDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/wordpress.dto';
 
@@ -17,6 +19,22 @@ const WordpressSettings: FC = () => {
     <>
       <Input label="Title" {...form.register('title')} />
       <WordpressPostType {...form.register('type')} />
+      <Select label="Status" {...form.register('status', { value: 'publish' })}>
+        <option value="publish">Publish</option>
+        <option value="draft">Draft</option>
+        <option value="pending">Pending</option>
+        <option value="private">Private</option>
+      </Select>
+      <WordpressTerms
+        label="Categories"
+        func="categoriesList"
+        {...form.register('categories')}
+      />
+      <WordpressTerms
+        label="WordPress Tags"
+        func="tagsList"
+        {...form.register('tags')}
+      />
       <MediaComponent
         label="Cover picture"
         description="Add a cover picture"

--- a/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.terms.tsx
+++ b/apps/frontend/src/components/new-launch/providers/wordpress/wordpress.terms.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+import { MultiSelect } from '@gitroom/react/form/multi.select';
+import { useCustomProviderFunction } from '@gitroom/frontend/components/launches/helpers/use.custom.provider.function';
+import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+
+// Fetches WordPress terms (categories or tags) for the connected site and wires
+// the reusable MultiSelect primitive into the post settings form. Both fields
+// are optional - selecting nothing leaves the value as an empty array, which
+// the provider omits from the request entirely.
+export const WordpressTerms: FC<{
+  name: string;
+  label: string;
+  func: string;
+  onChange: (event: {
+    target: {
+      value: number[];
+      name: string;
+    };
+  }) => void;
+}> = (props) => {
+  const { name, label, func, onChange } = props;
+  const customFunc = useCustomProviderFunction();
+  const form = useSettings();
+  const { getValues } = form;
+  const [terms, setTerms] = useState<Array<{ id: number; name: string }>>([]);
+  const [selected, setSelected] = useState<Array<string | number>>([]);
+
+  useEffect(() => {
+    customFunc.get(func).then((data) => setTerms(data || []));
+    const settings = getValues()[name];
+    if (Array.isArray(settings)) {
+      setSelected(settings.map((value: any) => Number(value)));
+    }
+  }, []);
+
+  const onChangeInner = (value: Array<string | number>) => {
+    const numbers = value.map((current) => Number(current));
+    setSelected(numbers);
+    form.setValue(name, numbers, { shouldValidate: true });
+    onChange?.({ target: { name, value: numbers } });
+  };
+
+  if (!terms.length) {
+    return null;
+  }
+
+  return (
+    <MultiSelect
+      name={name}
+      label={label}
+      value={selected}
+      onChange={onChangeInner}
+      options={terms.map((term) => ({ label: term.name, value: term.id }))}
+    />
+  );
+};

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/wordpress.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/wordpress.dto.ts
@@ -1,5 +1,8 @@
 import {
+  IsArray,
   IsDefined,
+  IsIn,
+  IsNumber,
   IsOptional,
   IsString,
   MinLength,
@@ -22,4 +25,19 @@ export class WordpressDto {
   @IsString()
   @IsDefined()
   type: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  categories?: number[];
+
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  tags?: number[];
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['publish', 'draft', 'pending', 'private'])
+  status?: string;
 }

--- a/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/wordpress.provider.ts
@@ -194,11 +194,12 @@ export class WordpressProvider
     };
   }
 
-  @Tool({
-    description: 'Get list of post types',
-    dataSchema: [],
-  })
-  async postTypes(token: string) {
+  // Custom provider functions below are invoked from the backend HTTP endpoint
+  // (`/integrations/function`) - which is NOT a Temporal activity - so they must
+  // use a plain `fetch` (with the SSRF guard) rather than `this.fetch`, which
+  // calls `Context.current()` and throws outside an activity. This mirrors how
+  // `authenticate` issues its request.
+  private async wpGet(token: string, path: string) {
     const body = JSON.parse(Buffer.from(token, 'base64').toString()) as {
       domain: string;
       username: string;
@@ -209,13 +210,23 @@ export class WordpressProvider
       'base64'
     );
 
-    const postTypes = await (
-      await this.fetch(`${body.domain}/wp-json/wp/v2/types`, {
-        headers: {
-          Authorization: `Basic ${auth}`,
-        },
-      })
-    ).json();
+    const response = await fetch(`${body.domain}${path}`, {
+      headers: {
+        Authorization: `Basic ${auth}`,
+      },
+      // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+      dispatcher: getSsrfSafeDispatcher(),
+    });
+
+    return response.json();
+  }
+
+  @Tool({
+    description: 'Get list of post types',
+    dataSchema: [],
+  })
+  async postTypes(token: string) {
+    const postTypes = await this.wpGet(token, '/wp-json/wp/v2/types');
 
     return Object.entries<any>(postTypes).reduce((all, [key, value]) => {
       if (
@@ -233,6 +244,37 @@ export class WordpressProvider
 
       return all;
     }, []);
+  }
+
+  @Tool({
+    description: 'Get list of categories',
+    dataSchema: [],
+  })
+  async categoriesList(token: string) {
+    const categories = await this.wpGet(
+      token,
+      '/wp-json/wp/v2/categories?per_page=100'
+    );
+
+    return (Array.isArray(categories) ? categories : []).map(
+      (category: any) => ({
+        id: category.id,
+        name: category.name,
+      })
+    );
+  }
+
+  @Tool({
+    description: 'Get list of tags',
+    dataSchema: [],
+  })
+  async tagsList(token: string) {
+    const tags = await this.wpGet(token, '/wp-json/wp/v2/tags?per_page=100');
+
+    return (Array.isArray(tags) ? tags : []).map((tag: any) => ({
+      id: tag.id,
+      name: tag.name,
+    }));
   }
 
   async post(
@@ -279,6 +321,13 @@ export class WordpressProvider
       mediaId = mediaResponse.id;
     }
 
+    const categories = (postDetails?.[0]?.settings?.categories || [])
+      .map((category) => Number(category))
+      .filter((category) => !isNaN(category));
+    const tags = (postDetails?.[0]?.settings?.tags || [])
+      .map((tag) => Number(tag))
+      .filter((tag) => !isNaN(tag));
+
     const submit = await (
       await this.fetch(
         `${body.domain}/wp-json/wp/v2/${postDetails?.[0]?.settings?.type}`,
@@ -296,7 +345,9 @@ export class WordpressProvider
               strict: true,
               trim: true,
             }),
-            status: 'publish',
+            status: postDetails?.[0]?.settings?.status || 'publish',
+            ...(categories.length ? { categories } : {}),
+            ...(tags.length ? { tags } : {}),
             ...(mediaId ? { featured_media: mediaId } : {}),
           }),
         }

--- a/libraries/react-shared-libraries/src/form/multi.select.tsx
+++ b/libraries/react-shared-libraries/src/form/multi.select.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { FC, useMemo } from 'react';
+import { clsx } from 'clsx';
+import { useFormContext } from 'react-hook-form';
+import { TranslatedLabel } from '../translation/translated-label';
+
+export interface MultiSelectOption {
+  label: string;
+  value: string | number;
+}
+
+// Controlled multi-select primitive: renders a scrollable checkbox list and
+// reports the full selected array via `onChange`. Selection state is owned by
+// the caller (pair it with react-hook-form's `setValue`), keeping this purely
+// presentational so any provider/form can reuse it.
+export const MultiSelect: FC<{
+  label: string;
+  name?: string;
+  options: MultiSelectOption[];
+  value: Array<string | number>;
+  onChange: (value: Array<string | number>) => void;
+  className?: string;
+  error?: any;
+  hideErrors?: boolean;
+  translationKey?: string;
+  translationParams?: Record<string, string | number>;
+}> = (props) => {
+  const {
+    label,
+    name,
+    options,
+    value,
+    onChange,
+    className,
+    error,
+    hideErrors,
+    translationKey,
+    translationParams,
+  } = props;
+  const form = useFormContext();
+  const err = useMemo(() => {
+    if (error) return error;
+    if (!form || !name || !form.formState.errors[name]) return;
+    return form?.formState?.errors?.[name]?.message as string;
+  }, [form?.formState?.errors?.[name!]?.message, error, name]);
+
+  const isSelected = (optionValue: string | number) =>
+    value.some((current) => String(current) === String(optionValue));
+
+  const toggle = (optionValue: string | number) => {
+    const next = isSelected(optionValue)
+      ? value.filter((current) => String(current) !== String(optionValue))
+      : [...value, optionValue];
+    onChange(next);
+  };
+
+  return (
+    <div className="flex flex-col gap-[6px]">
+      <div className="text-[14px]">
+        <TranslatedLabel
+          label={label}
+          translationKey={translationKey}
+          translationParams={translationParams}
+        />
+      </div>
+      <div
+        className={clsx(
+          'bg-newBgColorInner border border-newTableBorder rounded-[8px] max-h-[160px] overflow-auto p-[12px] flex flex-col gap-[8px]',
+          className
+        )}
+      >
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className="flex items-center gap-[8px] cursor-pointer text-[14px]"
+          >
+            <input
+              type="checkbox"
+              checked={isSelected(option.value)}
+              onChange={() => toggle(option.value)}
+            />
+            <span>{option.label}</span>
+          </label>
+        ))}
+      </div>
+      {!hideErrors && (
+        <div className="text-red-400 text-[12px]">{err || <>&nbsp;</>}</div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Adds optional per-post **categories**, **tags**, and **status** to the WordPress integration, plus a reusable multi-select form primitive used to build it.

All three WordPress fields are **optional** with safe defaults — no categories, no tags, `status: 'publish'` — so existing scheduled posts (whose settings JSON predates these fields) keep validating and posting exactly as before.

## Commits

1. **`feat: add reusable MultiSelect form primitive`** — a controlled, presentational multi-select (scrollable checkbox list) in the shared react form library, alongside the existing `Select`. The app previously had no general multi-select (only single `Select` and the npm `react-tag-autocomplete`–based `*.tags.tsx` inputs).
2. **`feat: WordPress post tags, categories, and status`** — DTO fields, provider custom functions + POST body, and the settings UI that consumes the primitive.

## Changes

- **DTO** (`wordpress.dto.ts`): optional `categories?: number[]`, `tags?: number[]`, `status?: string` (arrays of numbers; status `@IsIn(['publish','draft','pending','private'])`). `title`/`type` validators untouched.
- **Provider** (`wordpress.provider.ts`): new `categoriesList`/`tagsList` `@Tool` functions; POST body uses `status || 'publish'` and spreads `categories`/`tags` only when non-empty (IDs coerced to numbers). `featured_media` logic untouched.
- **Frontend**: Status `Select` + Categories and "WordPress Tags" multi-selects (the latter labelled to distinguish from Postiz's own tags), built on the new `MultiSelect`.

### Incidental fix
The provider's custom functions now use a plain `fetch` + SSRF dispatcher (via a small `wpGet` helper) instead of `this.fetch`. `this.fetch` calls `Context.current()` from `@temporalio/activity`, which throws outside a Temporal activity — and these functions run on the backend HTTP `/integrations/function` endpoint, not in an activity. This had silently broken the existing **postTypes** selector too (it hides itself when its list is empty). `authenticate()` already fetches this way for the same reason.

## Testing

Against a live WordPress site (after a clean backend restart):

- Selected a status, **multiple** categories, and **multiple** tags → the created WordPress post had the chosen status with the selected categories and tags attached (term IDs sent as numbers).
- Verified the new `MultiSelect` primitive end-to-end here — selecting several options in both Categories and Tags persisted and posted correctly. Newly-created WordPress tags (not yet attached to any post) appear, since the REST `hide_empty` param defaults to `false`.
- Selecting nothing leaves the fields empty/undefined (omitted from the request) — unchanged behavior. New optional DTO fields keep existing fieldless posts valid.
- `tsc --noEmit` passes for both frontend and backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)