### PR TITLE
fix(linkedin): personal connect fails (remove prompt=none + CMA-only scopes)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -35,10 +35,6 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     'openid',
     'profile',
     'w_member_social',
-    'r_basicprofile',
-    'rw_organization_admin',
-    'w_organization_social',
-    'r_organization_social',
   ];
   override maxConcurrentJob = 2;
   refreshWait = true;
@@ -151,7 +147,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     const codeVerifier = makeId(30);
     const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${
       process.env.LINKEDIN_CLIENT_ID
-    }&prompt=none&redirect_uri=${encodeURIComponent(
+    }&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin`
     )}&state=${state}&scope=${encodeURIComponent(this.scopes.join(' '))}`;
     return {


### PR DESCRIPTION
Fixes #1582. Related: #1580.

## Problem

Personal LinkedIn cannot be connected on a self-hosted instance. There are two independent causes in `linkedin.provider.ts`:

1. **`prompt=none`** in `generateAuthUrl()`. prompt=none requests a silent authorization that only succeeds when the user has already granted consent. On a first-time connect there is no prior grant, so LinkedIn returns "Bummer, something went wrong" instead of showing the consent screen (and when it does redirect back, the token is missing the requested scopes, which is the "Not enough scopes" symptom in #1580).

2. **Organization scopes** in the `scopes` array (`rw_organization_admin`, `w_organization_social`, `r_organization_social`, plus `r_basicprofile`). The org scopes require the Community Management API product, which cannot coexist with "Share on LinkedIn" or "Sign In with OpenID Connect" on the same app. A standard personal app can never be granted them, so LinkedIn rejects the whole request.

## Change

- Remove `&prompt=none` so first-time consent works.
- Reduce scopes to `openid`, `profile`, `w_member_social`. The profile is read via `/v2/userinfo` (OpenID), so `r_basicprofile` is not needed, and `checkScopes` then only requires what a personal app can actually be granted.

## Relationship to #1244 (please read, to avoid confusion about duplication)

#1244 already removes the org scopes, and credit to its author for that. However, #1244 alone does not fix the connect: it leaves `&prompt=none` in place, so first-time authorization still fails with "Bummer, something went wrong". No open PR removes `prompt=none` (I checked the open LinkedIn PRs; #1332 reformats that line but keeps the parameter).

This PR is intentionally self-contained so it fully resolves #1582 and #1580 on its own and can be verified end to end: it removes `prompt=none` (the missing piece) and also drops the org scopes. If you would rather land #1244 for the scope change, I am happy to rebase this down to just the `prompt=none` removal. Both changes are required together; removing the scopes alone is not enough while `prompt=none` still suppresses consent.

The LinkedIn Page provider has the same `prompt=none` pattern, but page posting legitimately needs the org scopes (CMA), so it is left out of this change to keep the scope tight.

## Testing

Tested on a self-hosted v2.21.10 instance with a LinkedIn app that has only "Sign In with LinkedIn using OpenID Connect" and "Share on LinkedIn" products.

- Before: Add Channel -> LinkedIn produced "Bummer, something went wrong".
- After: LinkedIn shows the normal consent flow with `scope=openid profile w_member_social`, redirects back, and the personal LinkedIn channel is added successfully.
