### PR TITLE
feat: add S3-compatible storage provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ CLOUDFLARE_BUCKETNAME="your-bucket-name"
 CLOUDFLARE_BUCKET_URL="https://your-bucket-url.r2.cloudflarestorage.com/"
 CLOUDFLARE_REGION="auto"
 
+## S3 / S3-compatible storage (AWS S3, MinIO, DigitalOcean Spaces, Backblaze B2)
+## Set STORAGE_PROVIDER=s3 to use this instead of Cloudflare R2.
+# S3_ACCESS_KEY=""
+# S3_SECRET_KEY=""
+# S3_BUCKET=""
+# S3_REGION="us-east-1"
+# S3_BUCKET_URL="https://your-bucket.s3.amazonaws.com"
+# S3_ENDPOINT=
+
 # === Common optional Settings
 
 ## This is a dummy key, you must create your own from Resend.

--- a/apps/backend/src/api/routes/media.controller.ts
+++ b/apps/backend/src/api/routes/media.controller.ts
@@ -18,6 +18,7 @@ import { Organization } from '@prisma/client';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { ApiTags } from '@nestjs/swagger';
 import handleR2Upload from '@gitroom/nestjs-libraries/upload/r2.uploader';
+import handleS3Upload from '@gitroom/nestjs-libraries/upload/s3.uploader';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { CustomFileValidationPipe } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
@@ -158,7 +159,8 @@ export class MediaController {
     @Res() res: Response,
     @Param('endpoint') endpoint: string
   ) {
-    const upload = await handleR2Upload(endpoint, req, res);
+    const storageProvider = process.env.STORAGE_PROVIDER || 'local';
+    const upload = await (storageProvider === 's3' ? handleS3Upload : handleR2Upload)(endpoint, req, res);
     if (endpoint !== 'complete-multipart-upload') {
       return upload;
     }

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -56,7 +56,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
       >
         <VariableContextComponent
           storageProvider={
-            process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare'
+            process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare' | 's3'
           }
           environment={process.env.NODE_ENV!}
           backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!}
@@ -71,7 +71,13 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           oauthLogoUrl={process.env.NEXT_PUBLIC_POSTIZ_OAUTH_LOGO_URL!}
           oauthDisplayName={process.env.NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME!}
           uploadDirectory={process.env.NEXT_PUBLIC_UPLOAD_STATIC_DIRECTORY!}
-          cloudflareUrl={process.env.CLOUDFLARE_BUCKET_URL || ''}
+          cloudflareUrl={
+            process.env.STORAGE_PROVIDER === 's3'
+              ? process.env.S3_BUCKET_URL || ''
+              : process.env.STORAGE_PROVIDER === 'cloudflare'
+              ? process.env.CLOUDFLARE_BUCKET_URL || ''
+              : ''
+          }
           mainUrl={process.env.MAIN_URL || ''}
           mcpUrl={process.env.MCP_URL}
           dub={!!process.env.STRIPE_PUBLISHABLE_KEY}

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -27,7 +27,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         <VariableContextComponent
           language="en"
           storageProvider={
-            process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare'
+            process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare' | 's3'
           }
           stripeClient=""
           environment={process.env.NODE_ENV!}
@@ -41,7 +41,13 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           oauthLogoUrl={process.env.NEXT_PUBLIC_POSTIZ_OAUTH_LOGO_URL!}
           oauthDisplayName={process.env.NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME!}
           uploadDirectory={process.env.NEXT_PUBLIC_UPLOAD_STATIC_DIRECTORY!}
-          cloudflareUrl={process.env.CLOUDFLARE_BUCKET_URL || ''}
+          cloudflareUrl={
+            process.env.STORAGE_PROVIDER === 's3'
+              ? process.env.S3_BUCKET_URL || ''
+              : process.env.STORAGE_PROVIDER === 'cloudflare'
+              ? process.env.CLOUDFLARE_BUCKET_URL || ''
+              : ''
+          }
           mainUrl={process.env.MAIN_URL || ''}
           mcpUrl={process.env.MCP_URL}
           dub={false}

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -29,7 +29,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         <VariableContextComponent
           language="en"
           storageProvider={
-            process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare'
+            process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare' | 's3'
           }
           stripeClient=""
           environment={process.env.NODE_ENV!}
@@ -43,7 +43,13 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           oauthLogoUrl={process.env.NEXT_PUBLIC_POSTIZ_OAUTH_LOGO_URL!}
           oauthDisplayName={process.env.NEXT_PUBLIC_POSTIZ_OAUTH_DISPLAY_NAME!}
           uploadDirectory={process.env.NEXT_PUBLIC_UPLOAD_STATIC_DIRECTORY!}
-          cloudflareUrl={process.env.CLOUDFLARE_BUCKET_URL || ''}
+          cloudflareUrl={
+            process.env.STORAGE_PROVIDER === 's3'
+              ? process.env.S3_BUCKET_URL || ''
+              : process.env.STORAGE_PROVIDER === 'cloudflare'
+              ? process.env.CLOUDFLARE_BUCKET_URL || ''
+              : ''
+          }
           mainUrl={process.env.MAIN_URL || ''}
           mcpUrl={process.env.MCP_URL}
           dub={false}

--- a/apps/frontend/src/components/media/new.uploader.tsx
+++ b/apps/frontend/src/components/media/new.uploader.tsx
@@ -187,7 +187,10 @@ export function useUppyUploader(props: {
     uppy2.on('file-added', (file) => {
       setLocked(true);
       uppy2.setFileMeta(file.id, {
-        useCloudflare: storageProvider === 'cloudflare' ? 'true' : 'false', // Example of adding a custom field
+        useCloudflare:
+          storageProvider === 'cloudflare' || storageProvider === 's3'
+            ? 'true'
+            : 'false', // Example of adding a custom field
         addedOrder: fileOrderIndex++, // Track original order for sorting after upload
         // Add more fields as needed
       });
@@ -225,7 +228,11 @@ export function useUppyUploader(props: {
       if (transloadit.length > 0) {
         // @ts-ignore
         const allRes = result.transloadit[0].results;
-        const toSave = uniqBy<{ name: string; originalName: string; order: number }>(
+        const toSave = uniqBy<{
+          name: string;
+          originalName: string;
+          order: number;
+        }>(
           // @ts-ignore
           Object.values(allRes).flatMap((p: any[]) => {
             return p.flatMap((item) => ({

--- a/libraries/nestjs-libraries/src/upload/s3.storage.ts
+++ b/libraries/nestjs-libraries/src/upload/s3.storage.ts
@@ -1,0 +1,130 @@
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import 'multer';
+import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
+import { IUploadProvider } from './upload.interface';
+import { isSafePublicHttpsUrl } from '@gitroom/nestjs-libraries/dtos/webhooks/webhook.url.validator';
+import { ssrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
+import { parseDataUrl } from '@gitroom/nestjs-libraries/upload/data.url';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { fromBuffer } = require('file-type');
+
+const ALLOWED_MIME_TYPES = new Set<string>([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+  'image/bmp',
+  'image/tiff',
+  'video/mp4',
+  'audio/mpeg',
+  'audio/mp4',
+  'audio/wav',
+  'audio/ogg',
+]);
+
+class S3Storage implements IUploadProvider {
+  private _client: S3Client;
+
+  constructor(
+    accessKey: string,
+    secretKey: string,
+    private region: string,
+    private _bucketName: string,
+    private _uploadUrl: string,
+    endpoint?: string
+  ) {
+    this._client = new S3Client({
+      region,
+      credentials: {
+        accessKeyId: accessKey,
+        secretAccessKey: secretKey,
+      },
+      ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+    });
+  }
+
+  async uploadSimple(path: string) {
+    const dataUrl = path.startsWith('data:') ? parseDataUrl(path) : null;
+
+    let body: Buffer;
+    if (dataUrl) {
+      body = dataUrl.buffer;
+    } else {
+      if (!(await isSafePublicHttpsUrl(path))) {
+        throw new Error('Unsafe URL');
+      }
+      const loadImage = await fetch(path, {
+        // @ts-ignore — undici option, not in lib.dom fetch types
+        dispatcher: ssrfSafeDispatcher,
+      });
+      body = Buffer.from(await loadImage.arrayBuffer());
+    }
+    const detected = await fromBuffer(body);
+    if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
+      throw new Error('Unsupported file type.');
+    }
+    const extension = detected.ext;
+    const safeContentType = detected.mime;
+    const id = makeId(10);
+
+    const command = new PutObjectCommand({
+      Bucket: this._bucketName,
+      Key: `${id}.${extension}`,
+      Body: body,
+      ContentType: safeContentType,
+    });
+    await this._client.send(command);
+
+    return `${this._uploadUrl}/${id}.${extension}`;
+  }
+
+  async uploadFile(file: Express.Multer.File): Promise<any> {
+    try {
+      const detected = await fromBuffer(file.buffer);
+      if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
+        throw new Error('Unsupported file type.');
+      }
+      const id = makeId(10);
+      const extension = detected.ext;
+      const safeContentType = detected.mime;
+
+      const command = new PutObjectCommand({
+        Bucket: this._bucketName,
+        ACL: 'public-read',
+        Key: `${id}.${extension}`,
+        Body: file.buffer,
+        ContentType: safeContentType,
+      });
+      await this._client.send(command);
+
+      return {
+        filename: `${id}.${extension}`,
+        mimetype: file.mimetype,
+        size: file.size,
+        buffer: file.buffer,
+        originalname: `${id}.${extension}`,
+        fieldname: 'file',
+        path: `${this._uploadUrl}/${id}.${extension}`,
+        destination: `${this._uploadUrl}/${id}.${extension}`,
+        encoding: '7bit',
+        stream: file.buffer as any,
+      };
+    } catch (err) {
+      console.error('Error uploading file to S3:', err);
+      throw err;
+    }
+  }
+
+  async removeFile(filePath: string): Promise<void> {
+    const key = filePath.replace(`${this._uploadUrl}/`, '');
+    const command = new DeleteObjectCommand({
+      Bucket: this._bucketName,
+      Key: key,
+    });
+    await this._client.send(command);
+  }
+}
+
+export { S3Storage };
+export default S3Storage;

--- a/libraries/nestjs-libraries/src/upload/s3.uploader.ts
+++ b/libraries/nestjs-libraries/src/upload/s3.uploader.ts
@@ -11,7 +11,6 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Request, Response } from 'express';
-import crypto from 'crypto';
 import path from 'path';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -35,29 +34,33 @@ function normalizeExtension(filename: string): string | null {
   return ALLOWED_EXT_TO_MIME[ext] ? ext : null;
 }
 
-const {
-  CLOUDFLARE_ACCOUNT_ID,
-  CLOUDFLARE_ACCESS_KEY,
-  CLOUDFLARE_SECRET_ACCESS_KEY,
-  CLOUDFLARE_BUCKETNAME,
-  CLOUDFLARE_BUCKET_URL,
-} = process.env;
+let _s3Client: S3Client | null = null;
 
-const R2 = new S3Client({
-  region: 'auto',
-  endpoint: `https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-  credentials: {
-    accessKeyId: CLOUDFLARE_ACCESS_KEY!,
-    secretAccessKey: CLOUDFLARE_SECRET_ACCESS_KEY!,
-  },
-});
+function getS3Client(): S3Client {
+  if (!_s3Client) {
+    _s3Client = new S3Client({
+      region: process.env.S3_REGION || 'us-east-1',
+      credentials: {
+        accessKeyId: process.env.S3_ACCESS_KEY!,
+        secretAccessKey: process.env.S3_SECRET_KEY!,
+      },
+      ...(process.env.S3_ENDPOINT
+        ? { endpoint: process.env.S3_ENDPOINT, forcePathStyle: true }
+        : {}),
+    });
+  }
+  return _s3Client;
+}
 
-// Function to generate a random string
 function generateRandomString() {
   return makeId(20);
 }
 
-export default async function handleR2Upload(
+function getPublicUrl(key: string) {
+  return `${process.env.S3_BUCKET_URL?.replace(/\/+$/, '')}/${key}`;
+}
+
+export default async function handleS3Upload(
   endpoint: string,
   req: Request,
   res: Response
@@ -92,17 +95,16 @@ export async function simpleUpload(
   const safeContentType = detected.mime;
   const randomFilename = generateRandomString() + fileExtension;
 
-  const params = {
-    Bucket: CLOUDFLARE_BUCKETNAME,
+  const command = new PutObjectCommand({
+    Bucket: process.env.S3_BUCKET,
     Key: randomFilename,
     Body: data,
     ContentType: safeContentType,
-  };
+  });
 
-  const command = new PutObjectCommand({ ...params });
-  await R2.send(command);
+  await getS3Client().send(command);
 
-  return CLOUDFLARE_BUCKET_URL + '/' + randomFilename;
+  return getPublicUrl(randomFilename);
 }
 
 export async function createMultipartUpload(req: Request, res: Response) {
@@ -115,17 +117,15 @@ export async function createMultipartUpload(req: Request, res: Response) {
   const randomFilename = generateRandomString() + safeExt;
 
   try {
-    const params = {
-      Bucket: CLOUDFLARE_BUCKETNAME,
-      Key: `${randomFilename}`,
+    const command = new CreateMultipartUploadCommand({
+      Bucket: process.env.S3_BUCKET,
+      Key: randomFilename,
       ContentType: safeContentType,
       Metadata: {
         'x-amz-meta-file-hash': fileHash,
       },
-    };
-
-    const command = new CreateMultipartUploadCommand({ ...params });
-    const response = await R2.send(command);
+    });
+    const response = await getS3Client().send(command);
     return res.status(200).json({
       uploadId: response.UploadId,
       key: response.Key,
@@ -138,24 +138,18 @@ export async function createMultipartUpload(req: Request, res: Response) {
 
 export async function prepareUploadParts(req: Request, res: Response) {
   const { partData } = req.body;
-
   const parts = partData.parts;
-
-  const response = {
-    presignedUrls: {},
-  };
+  const response = { presignedUrls: {} };
 
   for (const part of parts) {
     try {
-      const params = {
-        Bucket: CLOUDFLARE_BUCKETNAME,
+      const command = new UploadPartCommand({
+        Bucket: process.env.S3_BUCKET,
         Key: partData.key,
         PartNumber: part.number,
         UploadId: partData.uploadId,
-      };
-      const command = new UploadPartCommand({ ...params });
-      const url = await getSignedUrl(R2, command, { expiresIn: 3600 });
-
+      });
+      const url = await getSignedUrl(getS3Client(), command, { expiresIn: 3600 });
       // @ts-ignore
       response.presignedUrls[part.number] = url;
     } catch (err) {
@@ -171,14 +165,12 @@ export async function listParts(req: Request, res: Response) {
   const { key, uploadId } = req.body;
 
   try {
-    const params = {
-      Bucket: CLOUDFLARE_BUCKETNAME,
+    const command = new ListPartsCommand({
+      Bucket: process.env.S3_BUCKET,
       Key: key,
       UploadId: uploadId,
-    };
-    const command = new ListPartsCommand({ ...params });
-    const response = await R2.send(command);
-
+    });
+    const response = await getS3Client().send(command);
     return res.status(200).json(response['Parts']);
   } catch (err) {
     console.log('Error', err);
@@ -191,25 +183,23 @@ export async function completeMultipartUpload(req: Request, res: Response) {
 
   try {
     const command = new CompleteMultipartUploadCommand({
-      Bucket: CLOUDFLARE_BUCKETNAME,
+      Bucket: process.env.S3_BUCKET,
       Key: key,
       UploadId: uploadId,
       MultipartUpload: { Parts: parts },
     });
-    const response = await R2.send(command);
+    const response = await getS3Client().send(command);
 
     const safeExt = normalizeExtension(key || '');
     if (!safeExt) {
-      await R2.send(
-        new DeleteObjectCommand({ Bucket: CLOUDFLARE_BUCKETNAME, Key: key })
-      );
+      await getS3Client().send(new DeleteObjectCommand({ Bucket: process.env.S3_BUCKET, Key: key }));
       return res.status(400).json({ message: 'Unsupported file type.' });
     }
     const expectedMime = ALLOWED_EXT_TO_MIME[safeExt];
 
-    const head = await R2.send(
+    const head = await getS3Client().send(
       new GetObjectCommand({
-        Bucket: CLOUDFLARE_BUCKETNAME,
+        Bucket: process.env.S3_BUCKET,
         Key: key,
         Range: 'bytes=0-4100',
       })
@@ -223,18 +213,13 @@ export async function completeMultipartUpload(req: Request, res: Response) {
     const detected = await fromBuffer(prefix);
 
     if (!detected || detected.mime !== expectedMime) {
-      await R2.send(
-        new DeleteObjectCommand({ Bucket: CLOUDFLARE_BUCKETNAME, Key: key })
-      );
+      await getS3Client().send(new DeleteObjectCommand({ Bucket: process.env.S3_BUCKET, Key: key }));
       return res
         .status(400)
         .json({ message: 'File contents do not match declared type.' });
     }
 
-    response.Location =
-      process.env.CLOUDFLARE_BUCKET_URL +
-      '/' +
-      response?.Location?.split('/').at(-1);
+    response.Location = getPublicUrl(key);
     return response;
   } catch (err) {
     console.log('Error', err);
@@ -246,14 +231,12 @@ export async function abortMultipartUpload(req: Request, res: Response) {
   const { key, uploadId } = req.body;
 
   try {
-    const params = {
-      Bucket: CLOUDFLARE_BUCKETNAME,
+    const command = new AbortMultipartUploadCommand({
+      Bucket: process.env.S3_BUCKET,
       Key: key,
       UploadId: uploadId,
-    };
-    const command = new AbortMultipartUploadCommand({ ...params });
-    const response = await R2.send(command);
-
+    });
+    const response = await getS3Client().send(command);
     return res.status(200).json(response);
   } catch (err) {
     console.log('Error', err);
@@ -265,17 +248,13 @@ export async function signPart(req: Request, res: Response) {
   const { key, uploadId } = req.body;
   const partNumber = parseInt(req.body.partNumber);
 
-  const params = {
-    Bucket: CLOUDFLARE_BUCKETNAME,
+  const command = new UploadPartCommand({
+    Bucket: process.env.S3_BUCKET,
     Key: key,
     PartNumber: partNumber,
     UploadId: uploadId,
-  };
-
-  const command = new UploadPartCommand({ ...params });
-  const url = await getSignedUrl(R2, command, { expiresIn: 3600 });
-
-  return res.status(200).json({
-    url: url,
   });
+  const url = await getSignedUrl(getS3Client(), command, { expiresIn: 3600 });
+
+  return res.status(200).json({ url });
 }

--- a/libraries/nestjs-libraries/src/upload/upload.factory.ts
+++ b/libraries/nestjs-libraries/src/upload/upload.factory.ts
@@ -1,6 +1,7 @@
 import { CloudflareStorage } from './cloudflare.storage';
 import { IUploadProvider } from './upload.interface';
 import { LocalStorage } from './local.storage';
+import { S3Storage } from './s3.storage';
 
 export class UploadFactory {
   static createStorage(): IUploadProvider {
@@ -17,6 +18,15 @@ export class UploadFactory {
           process.env.CLOUDFLARE_REGION!,
           process.env.CLOUDFLARE_BUCKETNAME!,
           process.env.CLOUDFLARE_BUCKET_URL!
+        );
+      case 's3':
+        return new S3Storage(
+          process.env.S3_ACCESS_KEY!,
+          process.env.S3_SECRET_KEY!,
+          process.env.S3_REGION!,
+          process.env.S3_BUCKET!,
+          process.env.S3_BUCKET_URL!,
+          process.env.S3_ENDPOINT
         );
       default:
         throw new Error(`Invalid storage type ${storageProvider}`);

--- a/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
+++ b/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
@@ -40,6 +40,7 @@ export const getUppyUploadPlugin = (
           },
         },
       };
+    case 's3':
     case 'cloudflare':
       return {
         plugin: AwsS3Multipart,

--- a/libraries/react-shared-libraries/src/helpers/use.media.directory.ts
+++ b/libraries/react-shared-libraries/src/helpers/use.media.directory.ts
@@ -1,8 +1,40 @@
 import { useCallback } from 'react';
+import { useVariables } from '@gitroom/react/helpers/variable.context';
+
+const isKnownStorageHost = (hostname: string, storageHostname: string) => {
+  return (
+    hostname === storageHostname ||
+    hostname.endsWith('.r2.cloudflarestorage.com') ||
+    /(^|\.)s3([.-][a-z0-9-]+)?\.amazonaws\.com$/.test(hostname)
+  );
+};
+
 export const useMediaDirectory = () => {
+  const { storageProvider, cloudflareUrl } = useVariables();
+
   const set = useCallback((path: string) => {
-    return path;
-  }, []);
+    if (
+      !path ||
+      (storageProvider !== 'cloudflare' && storageProvider !== 's3') ||
+      !cloudflareUrl
+    ) {
+      return path;
+    }
+
+    try {
+      const currentUrl = new URL(path);
+      const storageUrl = new URL(cloudflareUrl);
+      if (!isKnownStorageHost(currentUrl.hostname, storageUrl.hostname)) {
+        return path;
+      }
+      currentUrl.protocol = storageUrl.protocol;
+      currentUrl.host = storageUrl.host;
+      return currentUrl.toString();
+    } catch {
+      return path;
+    }
+  }, [cloudflareUrl, storageProvider]);
+
   return {
     set,
   };

--- a/libraries/react-shared-libraries/src/helpers/variable.context.tsx
+++ b/libraries/react-shared-libraries/src/helpers/variable.context.tsx
@@ -14,7 +14,7 @@ interface VariableContextInterface {
   mainUrl: string;
   frontEndUrl: string;
   plontoKey: string;
-  storageProvider: 'local' | 'cloudflare';
+  storageProvider: 'local' | 'cloudflare' | 's3';
   backendUrl: string;
   environment: string;
   discordUrl: string;

--- a/libraries/react-shared-libraries/tsconfig.json
+++ b/libraries/react-shared-libraries/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
+    "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature.

Adds AWS S3 and S3-compatible storage provider support, including MinIO-compatible endpoint configuration.

# Why was this change needed?

Fixes #1124.

Postiz already supports local and Cloudflare R2 storage, but self-hosted deployments may use AWS S3 or S3-compatible providers such as MinIO, DigitalOcean Spaces, or Backblaze B2. This change adds an `s3` storage provider so those deployments can upload, save, preview, and serve media through S3-compatible object storage.

This PR adds:

- S3 storage provider implementation for simple/server-side uploads.
- S3 multipart upload support using Uppy’s existing S3-compatible multipart flow.
- `S3_ENDPOINT` support with path-style requests for MinIO/S3-compatible providers.
- Frontend storage-provider wiring so `STORAGE_PROVIDER=s3` uses S3 upload and preview URLs.
- Example S3 environment variables in `.env.example`.

# Other information:

Validated locally with AWS S3 media uploads and preview rendering.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue