### PR TITLE
fix(customer-modal): replace Mantine Autocomplete with native input (React 19 ref warning)

### DIFF
--- a/apps/frontend/src/components/launches/customer.modal.tsx
+++ b/apps/frontend/src/components/launches/customer.modal.tsx
@@ -3,7 +3,6 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 import { Integration } from '@prisma/client';
-import { Autocomplete } from '@mantine/core';
 import useSWR from 'swr';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { Button } from '@gitroom/react/form/button';
@@ -50,17 +49,24 @@ export const CustomerModal: FC<{
   const { data } = useSWR('/customers', loadCustomers);
   return (
     <div className="relative w-full">
-      <div className="mb-[80px]">
-        <Autocomplete
-          value={customer}
-          onChange={setCustomer}
-          classNames={{
-            label: 'text-white',
-          }}
-          label={t('select_customer_label', 'Select Customer')}
+      <div className="mb-[80px] flex flex-col gap-[6px]">
+        <label htmlFor="customer-name" className="text-[14px] text-white">
+          {t('select_customer_label', 'Select Customer')}
+        </label>
+        <input
+          id="customer-name"
+          list="customer-name-options"
+          value={customer ?? ''}
+          onChange={(e) => setCustomer(e.target.value)}
           placeholder={t('start_typing', 'Start typing...')}
-          data={data?.map((p: any) => p.name) || []}
+          autoComplete="off"
+          className="bg-newBgColorInner h-[42px] border-newTableBorder border rounded-[8px] text-textColor placeholder-textColor px-[16px] text-[14px] outline-none"
         />
+        <datalist id="customer-name-options">
+          {(data?.map((p: any) => p.name) || []).map((name: string) => (
+            <option key={name} value={name} />
+          ))}
+        </datalist>
       </div>
 
       <div className="my-[16px] flex gap-[10px]">


### PR DESCRIPTION
## Why this change (the problem)

Opening the **Customer** modal — e.g. when adding a channel into a new group — throws a React 19 console error:

> Accessing element.ref was removed in React 19. ref is now a regular prop. It will be removed from the JSX Element type in a future release.

Origin: `src/components/launches/customer.modal.tsx` rendering `@mantine/core`'s `<Autocomplete>`. The real cause is **`@mantine/core@5.10.5` (Mantine v5, built for React 17/18) running under React 19.2.4** — the library internally accesses the now-removed `element.ref`. It's a console error (not a hard crash), but it's noisy and user-visible in dev.

## The fix

Replace the single `<Autocomplete>` with a **native `<input>` + `<datalist>`**, styled to match the app's existing inputs. Preserves the important behaviors:
- **Free-text entry** (needed to create a *new* customer/group by typing a new name)
- **Existing-name suggestions** from `GET /integrations/customers`

Save/remove logic and the `PUT /integrations/:id/customer-name` endpoint are untouched.

## Why this solution (and not upgrading Mantine)

The alternative was to bump `@mantine/core` to a React 19-compatible major (v8). That was **clearly unfavorable**:
- Mantine is used in **only two files** in the frontend — it's a vestigial dependency.
- Project convention is to **prefer native components over npm UI libraries**.
- A **v5 → v8** bump is a large breaking change (both files would need reworking) carrying far more risk than removing one component.

So we removed the component instead of dragging in a major dependency upgrade.

## Scope & risk

- Changed **one file** (`customer.modal.tsx`). `@mantine/core` stays in `package.json` (still used by `layout/language.component.tsx`), so no dependency/build impact elsewhere.
- Main trade-off: the suggestion dropdown is now browser-native (styling differs across Chrome/Safari/Firefox) rather than Mantine-themed.
- Note: the same React 19 `element.ref` warning can still originate from `language.component.tsx` (also Mantine v5); fully removing Mantine is out of scope here.

## Testing

Verified manually: the console error is gone; typing shows existing customer suggestions; typing a new name + Save creates/assigns the group and persists; opening for an already-assigned channel pre-fills the name and "Remove from customer" works; empty save is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)