### PR TITLE
fix(social): guard Context.current() in this.fetch (regression from fb26a046)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -189,14 +189,24 @@ export abstract class SocialAbstract {
     ignoreConcurrency = false,
     message = ''
   ): Promise<Response> {
-    const ctx = Context.current();
+    // `this.fetch` is called both inside Temporal activities (posting flow) and
+    // from plain HTTP requests (OAuth connect via `authenticate`, analytics
+    // endpoints, token refresh, etc.). `Context.current()` throws "Activity
+    // context not initialized" when there is no activity, so guard it — otherwise
+    // every non-activity caller fails before the request is even made.
+    let ctx: ReturnType<typeof Context.current> | undefined;
+    try {
+      ctx = Context.current();
+    } catch {
+      ctx = undefined;
+    }
     // Providers fetch user-supplied URLs (WordPress domain, Mastodon/Lemmy
     // instance, Listmonk URL, etc.). Route through the SSRF guard so those
     // requests can't be pointed at internal/private IPs (cloud metadata,
     // localhost services, the internal network). Opt-out via env for
     // self-hosters on a trusted private network. A caller may still pass its
     // own dispatcher explicitly.
-    ctx.heartbeat(url);
+    ctx?.heartbeat(url);
     const request = await fetch(url, {
       ...options,
       // @ts-ignore - undici-only option, not in the lib.dom RequestInit type


### PR DESCRIPTION
## Summary

`this.fetch` (`SocialAbstract.fetch`) throws **`Error: Activity context not initialized`** whenever it's called **outside a Temporal activity**. This is a regression from **`fb26a046` ("feat: show heartbeat")**, which added `const ctx = Context.current(); ctx.heartbeat(url)` to the top of the method. `Context.current()` (from `@temporalio/activity`) only works inside a running activity — but `this.fetch` is also used from plain HTTP request paths.

## Impact (started when `fb26a046` shipped)

Every `this.fetch` caller that runs outside an activity now fails before the HTTP request is even made:

- **Channel connect (OAuth)** — Threads and Mastodon `authenticate()` use `this.fetch`, so connecting fails with `{"msg":"Authentication failed"}` (409). The connect callback catches the thrown error and reports it generically, which is why **no provider-side error was ever logged** — it never reached the provider.
- **Analytics** — the `/analytics/*` endpoints call provider analytics methods (which use `this.fetch`) from HTTP, producing log spam across providers:
  ```
  Error fetching TikTok post analytics: Error: Activity context not initialized
  Error fetching Instagram post analytics: Error: Activity context not initialized
  Error fetching Pinterest post analytics: Error: Activity context not initialized
  Error fetching Threads post analytics: Error: Activity context not initialized
  ```
- **Other non-activity callers** (e.g. token refresh) — bare `Error: Activity context not initialized`.

Posting is unaffected because it runs **inside** Temporal activities, where `Context.current()` is valid.

## Fix

Guard `Context.current()` in a try/catch and optional-chain the heartbeat:

```ts
let ctx: ReturnType<typeof Context.current> | undefined;
try { ctx = Context.current(); } catch { ctx = undefined; }
ctx?.heartbeat(url);
```

- **Inside an activity** (posting flow): heartbeats exactly as before — no behavior change.
- **Outside an activity** (connect / analytics / refresh): skips the heartbeat and proceeds with the request.

Skipping the heartbeat outside an activity is correct — heartbeating only means anything within an activity, and `this.fetch` never heartbeated at all before `fb26a046`.

## Note on follow-up

Once deployed, the pre-existing analytics errors that this regression was *masking* (real API errors: rate limits, permissions, missing release IDs, etc.) will resurface. Those are separate, pre-existing issues — this change just stops hiding them behind the "Activity context not initialized" throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)