### PR TITLE
fix(pinterest): keep analytics within the 90-day window

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -122,6 +122,12 @@ export class PinterestProvider
           'When uploading a video, you must add also an image to be used as a cover image.',
       };
     }
+    if (body.indexOf('only get data from the last 90 days') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value: 'Pinterest analytics are only available for the last 90 days.',
+      };
+    }
 
     return undefined;
   }
@@ -391,7 +397,12 @@ export class PinterestProvider
     date: number
   ): Promise<AnalyticsData[]> {
     const until = dayjs().format('YYYY-MM-DD');
-    const since = dayjs().subtract(date, 'day').format('YYYY-MM-DD');
+    // Pinterest analytics only cover the last 90 days; clamp so a longer
+    // requested period doesn't fail with "You can only get data from the last
+    // 90 days" (89 for a UTC-boundary safety margin).
+    const since = dayjs()
+      .subtract(Math.min(date, 89), 'day')
+      .format('YYYY-MM-DD');
 
     const {
       all: { daily_metrics },
@@ -456,8 +467,11 @@ export class PinterestProvider
     date: number
   ): Promise<AnalyticsData[]> {
     const today = dayjs().format('YYYY-MM-DD');
-    // Use a very long date range (2 years) to capture lifetime metrics for older posts
-    const since = dayjs().subtract(2, 'year').format('YYYY-MM-DD');
+    // Pinterest only serves pin analytics for the last 90 days; an older
+    // start_date fails with "You can only get data from the last 90 days".
+    // Use 89 to stay safely inside the window (Pinterest evaluates it in UTC,
+    // so exactly 90 can trip an off-by-one when the server's local date is ahead).
+    const since = dayjs().subtract(89, 'day').format('YYYY-MM-DD');
 
     try {
       // Fetch pin analytics from Pinterest API


### PR DESCRIPTION
## Problem

Production logs show, for every Pinterest post:

```
Error fetching Pinterest post analytics: ApplicationFailure: Unknown Error
```

with Pinterest's underlying message: **"You can only get data from the last 90 days."**

Pinterest's analytics endpoints (`/v5/pins/{pin_id}/analytics`, `/v5/user_account/analytics`) only serve the **last 90 days** (evaluated in UTC). But `postAnalytics()` requested `start_date` **2 years** ago (`dayjs().subtract(2, 'year')`), so the call failed every time. The generic `Unknown Error` is just `BadBody`'s default message — Pinterest's real reason was in the failure details.

Introduced in `5cca81e0` ("feat: post analytics").

## Changes

- **`postAnalytics`** — `start_date` is now **89 days** back instead of 2 years. Pinterest doesn't expose pin metrics older than 90 days, so 89 days is the maximum obtainable. Using **89 rather than 90** avoids an off-by-one when the server's local date leads UTC.
- **`analytics`** (account level) — clamps the requested period to `Math.min(date, 89)` so a longer UI selection can't trip the same error.
- **`handleErrors`** — maps `"only get data from the last 90 days"` to a clear, user-facing message instead of the generic `Unknown Error`.

## Note / trade-off

This is a Pinterest limitation, not something we can widen: pin metrics older than ~90 days simply aren't available from their API. Posts older than that will return only the recent-window data — expected behavior. After this change the error logs stop and analytics populate for in-window posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)