### PR TITLE
fix(plugs): list actual plug-supported channels in empty state

### DIFF
--- a/apps/frontend/src/components/plugs/plugs.tsx
+++ b/apps/frontend/src/components/plugs/plugs.tsx
@@ -105,8 +105,8 @@ export const Plugs = () => {
           )}
           <br />
           {t(
-            'you_have_to_add_x_or_linkedin_or_threads',
-            'You have to add: X or LinkedIn or Threads'
+            'you_have_to_add_x_linkedin_page_threads_or_bluesky',
+            'You have to add: X, LinkedIn Page, Threads or Bluesky'
           )}
         </div>
         <Button onClick={() => router.push('/launches')}>

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Login / Register to add comments",
   "status": "Status:",
   "there_are_not_plugs_matching_your_channels": "There are not plugs matching your channels",
-  "you_have_to_add_x_or_linkedin_or_threads": "You have to add: X or LinkedIn or Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "You have to add: X, LinkedIn Page, Threads or Bluesky",
   "go_to_the_calendar_to_add_channels": "Go to the calendar to add channels",
   "channels": "Channels",
   "activate": "Activate",


### PR DESCRIPTION
## What

The plugs page empty state told users to add "X or LinkedIn or Threads". This was inaccurate:

- Plugs are only defined for **LinkedIn Page** (`linkedin.page.provider.ts`), not personal LinkedIn — so a user with a private LinkedIn channel connected still sees the empty state and the message pointed them at the wrong channel type.
- **Bluesky** has plugs (`bluesky.provider.ts`) but wasn't listed.

The message now reads: "You have to add: X, LinkedIn Page, Threads or Bluesky".

## Why the translation key was renamed

16 locales carry translations of the old string. Renaming `you_have_to_add_x_or_linkedin_or_threads` → `you_have_to_add_x_linkedin_page_threads_or_bluesky` makes non-English locales fall back to the corrected English default instead of showing a stale (inaccurate) translated channel list until locales are re-translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)