### PR TITLE
fix(plugs): translate renamed empty-state key across locales

### DIFF
--- a/i18n.lock
+++ b/i18n.lock
@@ -55,7 +55,7 @@ checksums:
     login_register_to_add_comments: 8b98241e411b5c47f0e09f885f179a93
     status: 6eddeb13a4e7ccb25e21ec3f665dbcdf
     there_are_not_plugs_matching_your_channels: a99ff920bf2870338410bd1a79bca452
-    you_have_to_add_x_or_linkedin_or_threads: 247a8c61ea1231e4c7b3b48a34af936b
+    you_have_to_add_x_linkedin_page_threads_or_bluesky: afeb117fd39062b0885cc40cf86bbe7d
     go_to_the_calendar_to_add_channels: b08c0b31e38b95e3a67344ba861dd26a
     channels: 5c713eb23708abb6541e0ac88a4e75b6
     activate: cbe3629cad32c63dd160e5250f8a283f

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "تسجيل الدخول / التسجيل لإضافة تعليقات",
   "status": "الحالة:",
   "there_are_not_plugs_matching_your_channels": "لا توجد ملحقات مطابقة لقنواتك",
-  "you_have_to_add_x_or_linkedin_or_threads": "يجب عليك إضافة: X أو LinkedIn أو Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "يجب عليك إضافة: X أو صفحة لينكدإن أو Threads أو Bluesky",
   "go_to_the_calendar_to_add_channels": "اذهب إلى التقويم لإضافة القنوات",
   "channels": "القنوات",
   "activate": "تفعيل",

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "মন্তব্য যোগ করতে লগইন / নিবন্ধন করুন",
   "status": "অবস্থা:",
   "there_are_not_plugs_matching_your_channels": "আপনার চ্যানেলের সাথে মিলে এমন কোনো প্লাগ নেই",
-  "you_have_to_add_x_or_linkedin_or_threads": "আপনাকে যোগ করতে হবে: X বা LinkedIn বা Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "আপনাকে যোগ করতে হবে: X, LinkedIn পেজ, Threads অথবা Bluesky",
   "go_to_the_calendar_to_add_channels": "চ্যানেল যোগ করতে ক্যালেন্ডারে যান",
   "channels": "চ্যানেল",
   "activate": "সক্রিয় করুন",

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Anmelden / Registrieren, um Kommentare hinzuzufügen",
   "status": "Status:",
   "there_are_not_plugs_matching_your_channels": "Es gibt keine Plugs, die zu Ihren Kanälen passen",
-  "you_have_to_add_x_or_linkedin_or_threads": "Sie müssen eines hinzufügen: X, LinkedIn oder Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Sie müssen Folgendes hinzufügen: X, LinkedIn-Seite, Threads oder Bluesky",
   "go_to_the_calendar_to_add_channels": "Gehen Sie zum Kalender, um Kanäle hinzuzufügen",
   "channels": "Kanäle",
   "activate": "Aktivieren",

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Inicia sesión / Regístrate para agregar comentarios",
   "status": "Estado:",
   "there_are_not_plugs_matching_your_channels": "No hay conectores que coincidan con tus canales",
-  "you_have_to_add_x_or_linkedin_or_threads": "Debes agregar: X o LinkedIn o Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Tienes que añadir: X, Página de LinkedIn, Threads o Bluesky",
   "go_to_the_calendar_to_add_channels": "Ve al calendario para agregar canales",
   "channels": "Canales",
   "activate": "Activar",

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Connectez-vous / Inscrivez-vous pour ajouter des commentaires",
   "status": "Statut :",
   "there_are_not_plugs_matching_your_channels": "Il n'y a pas de connecteurs correspondant à vos canaux",
-  "you_have_to_add_x_or_linkedin_or_threads": "Vous devez ajouter : X ou LinkedIn ou Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Vous devez ajouter : X, page LinkedIn, Threads ou Bluesky",
   "go_to_the_calendar_to_add_channels": "Allez dans le calendrier pour ajouter des canaux",
   "channels": "Canaux",
   "activate": "Activer",

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "התחבר / הירשם כדי להוסיף תגובות",
   "status": "סטטוס:",
   "there_are_not_plugs_matching_your_channels": "אין פלאגים התואמים לערוצים שלך",
-  "you_have_to_add_x_or_linkedin_or_threads": "עליך להוסיף: X או LinkedIn או Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "עליך להוסיף: X, עמוד לינקדאין, Threads או Bluesky",
   "go_to_the_calendar_to_add_channels": "עבור ללוח השנה כדי להוסיף ערוצים",
   "channels": "ערוצים",
   "activate": "הפעל",

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Accedi / Registrati per aggiungere commenti",
   "status": "Stato:",
   "there_are_not_plugs_matching_your_channels": "Non ci sono plug compatibili con i tuoi canali",
-  "you_have_to_add_x_or_linkedin_or_threads": "Devi aggiungere: X oppure LinkedIn oppure Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Devi aggiungere: X, pagina LinkedIn, Threads o Bluesky",
   "go_to_the_calendar_to_add_channels": "Vai al calendario per aggiungere canali",
   "channels": "Canali",
   "activate": "Attiva",

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "コメントを追加するにはログイン／登録してください",
   "status": "ステータス：",
   "there_are_not_plugs_matching_your_channels": "あなたのチャンネルに一致するプラグはありません",
-  "you_have_to_add_x_or_linkedin_or_threads": "XまたはLinkedInまたはThreadsを追加する必要があります",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "X、LinkedInページ、Threads、またはBlueskyを追加する必要があります",
   "go_to_the_calendar_to_add_channels": "チャンネルを追加するにはカレンダーに移動してください",
   "channels": "チャンネル",
   "activate": "有効化",

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "댓글을 추가하려면 로그인/회원가입하세요",
   "status": "상태:",
   "there_are_not_plugs_matching_your_channels": "채널에 맞는 플러그가 없습니다",
-  "you_have_to_add_x_or_linkedin_or_threads": "X 또는 LinkedIn 또는 Threads를 추가해야 합니다",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "다음을 추가해야 합니다: X, LinkedIn 페이지, Threads 또는 Bluesky",
   "go_to_the_calendar_to_add_channels": "채널을 추가하려면 캘린더로 이동하세요",
   "channels": "채널",
   "activate": "활성화",

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Faça login / Cadastre-se para adicionar comentários",
   "status": "Status:",
   "there_are_not_plugs_matching_your_channels": "Não há plugs compatíveis com seus canais",
-  "you_have_to_add_x_or_linkedin_or_threads": "Você precisa adicionar: X ou LinkedIn ou Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Você precisa adicionar: X, Página do LinkedIn, Threads ou Bluesky",
   "go_to_the_calendar_to_add_channels": "Vá ao calendário para adicionar canais",
   "channels": "Canais",
   "activate": "Ativar",

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Войдите или зарегистрируйтесь, чтобы добавить комментарии",
   "status": "Статус:",
   "there_are_not_plugs_matching_your_channels": "Нет плагинов, соответствующих вашим каналам",
-  "you_have_to_add_x_or_linkedin_or_threads": "Вам нужно добавить: X, LinkedIn или Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Вы должны добавить: X, LinkedIn Page, Threads или Bluesky",
   "go_to_the_calendar_to_add_channels": "Перейдите в календарь, чтобы добавить каналы",
   "channels": "Каналы",
   "activate": "Активировать",

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Yorum eklemek için Giriş Yap / Kayıt Ol",
   "status": "Durum:",
   "there_are_not_plugs_matching_your_channels": "Kanallarınızla eşleşen eklenti yok",
-  "you_have_to_add_x_or_linkedin_or_threads": "Şunlardan birini eklemelisiniz: X veya LinkedIn veya Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Şunları eklemeniz gerekiyor: X, LinkedIn Sayfası, Threads veya Bluesky",
   "go_to_the_calendar_to_add_channels": "Kanalları eklemek için takvime gidin",
   "channels": "Kanallar",
   "activate": "Aktifleştir",

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "Đăng nhập / Đăng ký để thêm bình luận",
   "status": "Trạng thái:",
   "there_are_not_plugs_matching_your_channels": "Không có plug nào phù hợp với kênh của bạn",
-  "you_have_to_add_x_or_linkedin_or_threads": "Bạn cần thêm: X hoặc LinkedIn hoặc Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "Bạn phải thêm: X, Trang LinkedIn, Threads hoặc Bluesky",
   "go_to_the_calendar_to_add_channels": "Đi tới lịch để thêm kênh",
   "channels": "Kênh",
   "activate": "Kích hoạt",

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -51,7 +51,7 @@
   "login_register_to_add_comments": "登录/注册以添加评论",
   "status": "状态：",
   "there_are_not_plugs_matching_your_channels": "没有与您的频道匹配的插件",
-  "you_have_to_add_x_or_linkedin_or_threads": "你需要添加：X或LinkedIn或Threads",
+  "you_have_to_add_x_linkedin_page_threads_or_bluesky": "你必须添加：X、LinkedIn 页面、Threads 或 Bluesky",
   "go_to_the_calendar_to_add_channels": "前往日历添加频道",
   "channels": "频道",
   "activate": "激活",


### PR DESCRIPTION
Follow-up to #1666, which renamed `you_have_to_add_x_or_linkedin_or_threads` → `you_have_to_add_x_linkedin_page_threads_or_bluesky` ("You have to add: X, LinkedIn Page, Threads or Bluesky") but only updated the English locale.

This runs `npx lingo.dev@latest i18n` to translate the new key in all 14 other locales, replacing the stale old-key entries in place, and updates `i18n.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)