### PR TITLE
fix(security): block literal private/loopback IPs in SSRF-safe dispatcher

### DIFF
--- a/libraries/nestjs-libraries/src/dtos/webhooks/ssrf.safe.dispatcher.ts
+++ b/libraries/nestjs-libraries/src/dtos/webhooks/ssrf.safe.dispatcher.ts
@@ -1,4 +1,4 @@
-import { Agent } from 'undici';
+import { Agent, buildConnector } from 'undici';
 import dns from 'node:dns';
 import net from 'node:net';
 import { isBlockedIp } from './webhook.url.validator';
@@ -6,35 +6,39 @@ import { isBlockedIp } from './webhook.url.validator';
 // Pins DNS resolution: every resolved IP is checked with `isBlockedIp` and
 // the caller (undici) connects to that same set. Closes the TOCTOU window
 // `isSafePublicHttpsUrl` alone leaves open (see GHSA-f7jj-p389-4w45).
-export const ssrfSafeDispatcher = new Agent({
-  connect: {
-    lookup(hostname, options, callback) {
-      if (net.isIP(hostname)) {
-        const family = net.isIP(hostname);
-        if (isBlockedIp(hostname)) {
-          return callback(new Error('Blocked IP'), '', 0);
-        }
-        return options && (options as any).all
-          ? callback(null, [{ address: hostname, family }] as any, family)
-          : callback(null, hostname, family);
-      }
-
-      dns.lookup(hostname, options, (err, address: any, family: any) => {
-        if (err) return callback(err, '', 0);
-        if (Array.isArray(address)) {
-          for (const entry of address) {
-            if (isBlockedIp(entry.address)) {
-              return callback(new Error('Blocked IP'), '', 0);
-            }
+//
+// The `lookup` hook only runs for hostnames that need DNS resolution; Node's
+// net.connect skips it for literal-IP hosts (e.g. http://192.168.1.1/), so a
+// literal private/loopback IP would otherwise bypass the guard entirely. We
+// therefore also check literal IPs in a custom `connect`, which runs for every
+// connection.
+const pinnedConnector = buildConnector({
+  lookup(hostname, options, callback) {
+    dns.lookup(hostname, options, (err, address: any, family: any) => {
+      if (err) return callback(err, '', 0);
+      if (Array.isArray(address)) {
+        for (const entry of address) {
+          if (isBlockedIp(entry.address)) {
+            return callback(new Error('Blocked IP'), '', 0);
           }
-          return callback(null, address as any, 0);
         }
-        if (isBlockedIp(address)) {
-          return callback(new Error('Blocked IP'), '', 0);
-        }
-        callback(null, address, family);
-      });
-    },
+        return callback(null, address as any, 0);
+      }
+      if (isBlockedIp(address)) {
+        return callback(new Error('Blocked IP'), '', 0);
+      }
+      callback(null, address, family);
+    });
+  },
+});
+
+export const ssrfSafeDispatcher = new Agent({
+  connect(options, callback) {
+    const hostname = (options.hostname || '').replace(/^\[|\]$/g, '');
+    if (net.isIP(hostname) && isBlockedIp(hostname)) {
+      return callback(new Error('Blocked IP'), null);
+    }
+    return pinnedConnector(options, callback);
   },
 });
 


### PR DESCRIPTION
## The vulnerability

`ssrfSafeDispatcher` enforced its private-IP allow-list **only** inside the undici `connect.lookup` hook. But Node's `net.connect` calls `lookup` only for hostnames that need DNS resolution — for a **literal-IP host it connects directly and never invokes `lookup`**. So any URL written as a bare private / loopback / link-local IP bypassed the guard completely:

- `http://169.254.169.254/…` — cloud metadata endpoint (can expose temporary cloud credentials → account compromise)
- `http://127.0.0.1:<port>/…`, `http://10.x.x.x/…` — internal-only services that assume "only our own network can reach me"
- `http://192.168.1.1/…`, `http://[::1]/…` — local network / loopback

This is an SSRF hole affecting **every** consumer of the dispatcher: the `uploadFromUrl` agent tool, the public `/upload-from-url` API (n8n & other external clients), and webhook delivery. Any authenticated API/agent user could make the server issue requests into its own private network and read back signal from the response.

## The fix

Move the literal-IP check into a custom `connect` (built via undici's `buildConnector`), which runs for **every** connection regardless of DNS. The hostname DNS-pinning path is preserved as `pinnedConnector.lookup`, so hostnames that *resolve* to private IPs stay blocked too — the TOCTOU protection from GHSA-f7jj-p389-4w45 is unchanged.

## Reproduction & validation

**Pre-fix**, live via the `uploadFromUrl` agent tool over MCP:
```
http://192.168.1.1/a.jpg  ->  {"error":"Failed to fetch URL"}
```
fetch *succeeded* — the server connected to the private host and got a response (the `!response.ok` branch), proving the round-trip happened.

**Post-fix**, same live call:
```
http://192.168.1.1/a.jpg  ->  {"error":"Failed to upload media from URL: fetch failed"}
```
the connection is now rejected at the dispatcher before any socket opens. (With the companion `err.cause` PR applied, this reads `... fetch failed (Blocked IP)`.)

**No regression**, same live tool:
```
https://picsum.photos/200/300.jpg  ->  {"id","path"}      # public image still uploads
https://httpbin.org/status/404     ->  "Failed to fetch URL"  # ordinary non-2xx path intact
```

Also verified with a standalone undici repro: literal `192.168.1.1`, `127.0.0.1`, `169.254.169.254`, `[::1]` and hostname `localhost` are all rejected with `Blocked IP`, while `example.com` still connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)