### PR TITLE
fix(agent): surface err.cause in uploadFromUrl tool error messages

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -121,10 +121,22 @@ so the attachment passes the upload-domain validation. Returns the hosted media 
             getFile.path
           );
         } catch (err) {
+          // undici's fetch rejects with a generic TypeError('fetch failed')
+          // and hides the real reason (DNS, TLS, SSRF block, ...) in
+          // err.cause, so surface it for the agent. Error.cause isn't in the
+          // es2020 lib typings this repo compiles against, hence the cast.
+          const cause =
+            err instanceof Error
+              ? (err as Error & { cause?: unknown }).cause
+              : undefined;
+          const causeText =
+            cause instanceof Error && cause.message
+              ? ` (${cause.message})`
+              : '';
           return {
             error: `Failed to upload media from URL: ${
               err instanceof Error ? err.message : 'Unexpected error'
-            }`,
+            }${causeText}`,
           };
         }
       },


### PR DESCRIPTION
## Why

undici's `fetch()` rejects network-level failures (DNS, TLS, connection refused, SSRF-dispatcher block) with a **generic** `TypeError('fetch failed')` and puts the actual reason in `err.cause` — see [`lib/web/fetch/index.js#L271`](https://github.com/nodejs/undici/blob/2dc7e189dc6bc32097f7c926b2818d6e69b3f2a8/lib/web/fetch/index.js#L271):

```js
p.reject(new TypeError('fetch failed', { cause: response.error }))
```

The `uploadFromUrl` tool's catch block (added in #1649) only surfaced `err.message`, so the agent — and the user — saw a bare `fetch failed` with no indication of *why* the URL couldn't be fetched.

## What

Append `err.cause.message` to the `{ error }` result when present, e.g. `fetch failed (getaddrinfo ENOTFOUND example.com)` instead of just `fetch failed`. `Error.cause` isn't in the `es2020` lib typings this repo compiles against, hence the cast; the access is guarded so a missing or empty cause changes nothing.

## Reproduction & validation

**Pre-fix:** a fetch rejection surfaced only as the bare `Failed to upload media from URL: fetch failed`.

**Post-fix**, live via the `uploadFromUrl` agent tool over MCP:
```
http://no-such-host-cause-test.invalid/a.jpg
  ->  {"error":"Failed to upload media from URL: fetch failed (getaddrinfo ENOTFOUND no-such-host-cause-test.invalid)"}
```

**Together with the companion SSRF literal-IP fix (#1671)** — the two compose to give an actionable reason for blocked internal addresses:
```
http://192.168.1.1/a.jpg
  ->  {"error":"Failed to upload media from URL: fetch failed (Blocked IP)"}
```

## Relation to #1671

Independent files, independently mergeable. This PR makes #1671's SSRF block (and every other fetch rejection on this path) legible in the agent's message; #1671 stands on its own without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)