### PR TITLE
feat(integrations): add provider requirements metadata

### DIFF
--- a/apps/backend/src/api/routes/integrations.controller.ts
+++ b/apps/backend/src/api/routes/integrations.controller.ts
@@ -107,6 +107,9 @@ export class IntegrationsController {
             inBetweenSteps: p.inBetweenSteps,
             refreshNeeded: p.refreshNeeded,
             isCustomFields: !!findIntegration.customFields,
+            capabilities: this._integrationManager.getIntegrationCapabilities(
+              p.providerIdentifier
+            ),
             ...(findIntegration.customFields
               ? { customFields: await findIntegration.customFields() }
               : {}),

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -56,7 +56,6 @@ import {
   socialIntegrationList,
   IntegrationManager,
 } from '@gitroom/nestjs-libraries/integrations/integration.manager';
-import { getValidationSchemas } from '@gitroom/nestjs-libraries/chat/validation.schemas.helper';
 import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integrations/refresh.integration.service';
 import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { PostValidationException } from '@gitroom/backend/api/routes/posts.validation.exception';
@@ -438,30 +437,19 @@ export class PublicIntegrationsController {
         (p: any) => p?.title === 'Verified'
       )?.value || false;
 
-    const integration = socialIntegrationList.find(
-      (p) => p.identifier === loadIntegration.providerIdentifier
-    )!;
+    const requirements = this._integrationManager.getIntegrationRequirements(
+      loadIntegration.providerIdentifier,
+      verified
+    );
 
-    if (!integration) {
+    if (!requirements) {
       return {
         output: { rules: '', maxLength: 0, settings: {}, tools: [] as any[] },
       };
     }
 
-    const maxLength = integration.maxLength(verified);
-    const schemas = !integration.dto
-      ? false
-      : getValidationSchemas()[integration.dto.name];
-    const tools = this._integrationManager.getAllTools();
-    const rules = this._integrationManager.getAllRulesDescription();
-
     return {
-      output: {
-        rules: rules[integration.identifier],
-        maxLength,
-        settings: !schemas ? 'No additional settings required' : schemas,
-        tools: tools[integration.identifier],
-      },
+      output: requirements,
     };
   }
 

--- a/libraries/nestjs-libraries/src/chat/tools/integration.validation.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.validation.tool.ts
@@ -6,7 +6,6 @@ import {
   IntegrationManager,
   socialIntegrationList,
 } from '@gitroom/nestjs-libraries/integrations/integration.manager';
-import { getValidationSchemas } from '@gitroom/nestjs-libraries/chat/validation.schemas.helper';
 import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
 
 @Injectable()
@@ -79,34 +78,51 @@ export class IntegrationValidationTool implements AgentToolInterface {
             .describe(
               "Sometimes settings require some id, tags and stuff, if you don't have, trigger the `triggerTool` function from the tools list [output:callable-tools]"
             ),
+          capabilities: z
+            .object({
+              scheduling: z.boolean(),
+              comments: z.boolean(),
+              mentions: z.boolean(),
+              accountAnalytics: z.boolean(),
+              postAnalytics: z.boolean(),
+              missingContent: z.boolean(),
+              profilePicture: z.boolean(),
+              nickname: z.boolean(),
+              customFields: z.boolean(),
+              externalUrl: z.boolean(),
+              web3: z.boolean(),
+              chromeExtension: z.boolean(),
+              oneTimeToken: z.boolean(),
+              refreshCron: z.boolean(),
+              refreshWait: z.boolean(),
+              stripLinks: z.boolean(),
+              convertToJPEG: z.boolean(),
+              editor: z.enum(['none', 'normal', 'markdown', 'html']),
+              maxConcurrentJob: z.number(),
+              tools: z.array(z.string()),
+            })
+            .optional()
+            .describe(
+              'Derived provider capabilities for generic scheduling and integration flows'
+            ),
         }),
       }),
       execute: async (inputData, context) => {
         checkAuth(inputData, context);
-        const integration = socialIntegrationList.find(
-          (p) => p.identifier === inputData.platform
-        )!;
+        const requirements =
+          this._integrationManager.getIntegrationRequirements(
+            inputData.platform,
+            inputData.isPremium
+          );
 
-        if (!integration) {
+        if (!requirements) {
           return {
             output: { rules: '', maxLength: 0, settings: {}, tools: [] },
           };
         }
 
-        const maxLength = integration.maxLength(inputData.isPremium);
-        const schemas = !integration.dto
-          ? false
-          : getValidationSchemas()[integration.dto.name];
-        const tools = this._integrationManager.getAllTools();
-        const rules = this._integrationManager.getAllRulesDescription();
-
         return {
-          output: {
-            rules: rules[integration.identifier],
-            maxLength,
-            settings: !schemas ? 'No additional settings required' : schemas,
-            tools: tools[integration.identifier],
-          },
+          output: requirements,
         };
       },
     });

--- a/libraries/nestjs-libraries/src/integrations/integration.manager.ts
+++ b/libraries/nestjs-libraries/src/integrations/integration.manager.ts
@@ -2,7 +2,13 @@ import 'reflect-metadata';
 
 import { Injectable } from '@nestjs/common';
 import { XProvider } from '@gitroom/nestjs-libraries/integrations/social/x.provider';
-import { SocialProvider } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import {
+  ProviderToolMetadata,
+  SocialProvider,
+  SocialProviderCapabilities,
+  SocialProviderRequirements,
+} from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import { buildProviderCapabilities } from '@gitroom/nestjs-libraries/integrations/provider.capabilities';
 import { LinkedinProvider } from '@gitroom/nestjs-libraries/integrations/social/linkedin.provider';
 import { RedditProvider } from '@gitroom/nestjs-libraries/integrations/social/reddit.provider';
 import { DevToProvider } from '@gitroom/nestjs-libraries/integrations/social/dev.to.provider';
@@ -36,6 +42,7 @@ import { MoltbookProvider } from '@gitroom/nestjs-libraries/integrations/social/
 import { SkoolProvider } from '@gitroom/nestjs-libraries/integrations/social/skool.provider';
 import { WhopProvider } from '@gitroom/nestjs-libraries/integrations/social/whop.provider';
 import { MeweProvider } from '@gitroom/nestjs-libraries/integrations/social/mewe.provider';
+import { getValidationSchemas } from '@gitroom/nestjs-libraries/chat/validation.schemas.helper';
 
 export const socialIntegrationList: Array<SocialAbstract & SocialProvider> = [
   new XProvider(),
@@ -77,6 +84,8 @@ export const socialIntegrationList: Array<SocialAbstract & SocialProvider> = [
 @Injectable()
 export class IntegrationManager {
   async getAllIntegrations() {
+    const tools = this.getAllTools();
+
     return {
       social: await Promise.all(
         socialIntegrationList.map(async (p) => ({
@@ -87,7 +96,10 @@ export class IntegrationManager {
           isExternal: !!p.externalUrl,
           isWeb3: !!p.isWeb3,
           isChromeExtension: !!p.isChromeExtension,
-          ...(p.extensionCookies ? { extensionCookies: p.extensionCookies } : {}),
+          capabilities: buildProviderCapabilities(p, tools[p.identifier] || []),
+          ...(p.extensionCookies
+            ? { extensionCookies: p.extensionCookies }
+            : {}),
           ...(p.customFields ? { customFields: await p.customFields() } : {}),
         }))
       ),
@@ -96,11 +108,7 @@ export class IntegrationManager {
   }
 
   getAllTools(): {
-    [key: string]: {
-      description: string;
-      dataSchema: any;
-      methodName: string;
-    }[];
+    [key: string]: ProviderToolMetadata[];
   } {
     return socialIntegrationList.reduce(
       (all, current) => ({
@@ -110,6 +118,50 @@ export class IntegrationManager {
           [],
       }),
       {}
+    );
+  }
+
+  getIntegrationRequirements(
+    providerIdentifier: string,
+    additionalSettings?: any
+  ): SocialProviderRequirements | undefined {
+    const integration = socialIntegrationList.find(
+      (p) => p.identifier === providerIdentifier
+    );
+
+    if (!integration) {
+      return undefined;
+    }
+
+    const tools = this.getAllTools()[integration.identifier] || [];
+    const rules = this.getAllRulesDescription()[integration.identifier] || '';
+    const schemas = !integration.dto
+      ? false
+      : getValidationSchemas()[integration.dto.name];
+
+    return {
+      rules,
+      maxLength: integration.maxLength(additionalSettings),
+      settings: !schemas ? 'No additional settings required' : schemas,
+      tools,
+      capabilities: buildProviderCapabilities(integration, tools),
+    };
+  }
+
+  getIntegrationCapabilities(
+    providerIdentifier: string
+  ): SocialProviderCapabilities | undefined {
+    const integration = socialIntegrationList.find(
+      (p) => p.identifier === providerIdentifier
+    );
+
+    if (!integration) {
+      return undefined;
+    }
+
+    return buildProviderCapabilities(
+      integration,
+      this.getAllTools()[integration.identifier] || []
     );
   }
 

--- a/libraries/nestjs-libraries/src/integrations/provider.capabilities.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/provider.capabilities.spec.ts
@@ -1,0 +1,43 @@
+import { buildProviderCapabilities } from './provider.capabilities';
+
+describe('buildProviderCapabilities', () => {
+  it('derives capabilities from provider methods, flags, and tools', () => {
+    const capabilities = buildProviderCapabilities(
+      {
+        post: jest.fn(),
+        comment: jest.fn(),
+        mention: jest.fn(),
+        postAnalytics: jest.fn(),
+        customFields: jest.fn(),
+        stripLinks: () => true,
+        refreshWait: true,
+        convertToJPEG: true,
+        editor: 'markdown',
+        maxConcurrentJob: 3,
+      },
+      [
+        {
+          description: 'Find channels',
+          dataSchema: [],
+          methodName: 'channels',
+        },
+      ]
+    );
+
+    expect(capabilities).toMatchObject({
+      scheduling: true,
+      comments: true,
+      mentions: true,
+      postAnalytics: true,
+      customFields: true,
+      stripLinks: true,
+      refreshWait: true,
+      convertToJPEG: true,
+      editor: 'markdown',
+      maxConcurrentJob: 3,
+      tools: ['channels'],
+    });
+    expect(capabilities.accountAnalytics).toBe(false);
+    expect(capabilities.missingContent).toBe(false);
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/provider.capabilities.ts
+++ b/libraries/nestjs-libraries/src/integrations/provider.capabilities.ts
@@ -1,0 +1,55 @@
+import {
+  ProviderToolMetadata,
+  SocialEditor,
+  SocialProviderCapabilities,
+} from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+
+type ProviderCapabilitySource = {
+  post?: (...args: any[]) => any;
+  comment?: (...args: any[]) => any;
+  mention?: (...args: any[]) => any;
+  analytics?: (...args: any[]) => any;
+  postAnalytics?: (...args: any[]) => any;
+  missing?: (...args: any[]) => any;
+  changeProfilePicture?: (...args: any[]) => any;
+  changeNickname?: (...args: any[]) => any;
+  customFields?: (...args: any[]) => any;
+  externalUrl?: (...args: any[]) => any;
+  stripLinks?: () => boolean;
+  isWeb3?: boolean;
+  isChromeExtension?: boolean;
+  oneTimeToken?: boolean;
+  refreshCron?: boolean;
+  refreshWait?: boolean;
+  convertToJPEG?: boolean;
+  editor: SocialEditor;
+  maxConcurrentJob: number;
+};
+
+export function buildProviderCapabilities(
+  provider: ProviderCapabilitySource,
+  tools: ProviderToolMetadata[] = []
+): SocialProviderCapabilities {
+  return {
+    scheduling: typeof provider.post === 'function',
+    comments: typeof provider.comment === 'function',
+    mentions: typeof provider.mention === 'function',
+    accountAnalytics: typeof provider.analytics === 'function',
+    postAnalytics: typeof provider.postAnalytics === 'function',
+    missingContent: typeof provider.missing === 'function',
+    profilePicture: typeof provider.changeProfilePicture === 'function',
+    nickname: typeof provider.changeNickname === 'function',
+    customFields: typeof provider.customFields === 'function',
+    externalUrl: typeof provider.externalUrl === 'function',
+    web3: !!provider.isWeb3,
+    chromeExtension: !!provider.isChromeExtension,
+    oneTimeToken: !!provider.oneTimeToken,
+    refreshCron: !!provider.refreshCron,
+    refreshWait: !!provider.refreshWait,
+    stripLinks: !!provider.stripLinks?.(),
+    convertToJPEG: !!provider.convertToJPEG,
+    editor: provider.editor,
+    maxConcurrentJob: provider.maxConcurrentJob,
+    tools: tools.map((tool) => tool.methodName),
+  };
+}

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -32,7 +32,7 @@ export interface IAuthenticator {
     integrationId: string,
     accessToken: string,
     postId: string,
-    fromDate: number,
+    fromDate: number
   ): Promise<AnalyticsData[]>;
   changeNickname?(
     id: string,
@@ -55,7 +55,6 @@ export interface AnalyticsData {
   data: Array<{ total: string; date: string }>;
   percentageChange: number;
 }
-
 
 export type GenerateAuthUrlResponse = {
   url: string;
@@ -127,6 +126,45 @@ export type MediaContent = {
   thumbnailTimestamp?: number;
 };
 
+export type SocialEditor = 'none' | 'normal' | 'markdown' | 'html';
+
+export type ProviderToolMetadata = {
+  description: string;
+  dataSchema: any;
+  methodName: string;
+};
+
+export type SocialProviderCapabilities = {
+  scheduling: boolean;
+  comments: boolean;
+  mentions: boolean;
+  accountAnalytics: boolean;
+  postAnalytics: boolean;
+  missingContent: boolean;
+  profilePicture: boolean;
+  nickname: boolean;
+  customFields: boolean;
+  externalUrl: boolean;
+  web3: boolean;
+  chromeExtension: boolean;
+  oneTimeToken: boolean;
+  refreshCron: boolean;
+  refreshWait: boolean;
+  stripLinks: boolean;
+  convertToJPEG: boolean;
+  editor: SocialEditor;
+  maxConcurrentJob: number;
+  tools: string[];
+};
+
+export type SocialProviderRequirements = {
+  rules: string;
+  maxLength: number;
+  settings: any;
+  tools: ProviderToolMetadata[];
+  capabilities: SocialProviderCapabilities;
+};
+
 export type FetchPageInformationResult = {
   id: string;
   name: string;
@@ -153,7 +191,7 @@ export interface SocialProvider
   isWeb3?: boolean;
   isChromeExtension?: boolean;
   extensionCookies?: { name: string; domain: string }[];
-  editor: 'none' | 'normal' | 'markdown' | 'html';
+  editor: SocialEditor;
   customFields?: () => Promise<
     {
       key: string;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature / architecture improvement. This adds reusable provider requirements and capabilities metadata for Postiz social integrations.

# Why was this change needed?

Postiz supports many social providers, but consumers had to infer provider behavior from scattered optional methods and duplicate the rules/settings/max-length assembly in multiple places. This change centralizes provider requirements in `IntegrationManager`, derives capabilities from the existing provider interface, and exposes the same metadata to dashboard integration lists, public integration settings, and the AI integration schema tool.

The goal is to make provider-aware workflows scale better as Postiz adds more platforms, tools, and provider-specific abilities.

# Other information:

No similar open issues or PRs were found for "provider requirements metadata" or "provider capabilities".

Validation performed locally:
- `npx -y pnpm@10.6.1 exec prettier --check <changed files>`
- `npx -y pnpm@10.6.1 exec jest libraries/nestjs-libraries/src/integrations/provider.capabilities.spec.ts --runInBand --config <inline ts-jest config>`
- `TS_NODE_COMPILER_OPTIONS={"module":"commonjs"} node -r ts-node/register -r tsconfig-paths/register -e <IntegrationManager requirements smoke check>`
- `npx -y pnpm@10.6.1 --filter ./apps/backend run build`

Local note: this machine has Node v26.0.0, while `package.json` declares `>=22.12.0 <23.0.0`; install/build emitted that engine warning, but the backend build passed.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue