### PR TITLE
fix: handle missing integrations in launch editor

### DIFF
--- a/apps/backend/src/api/routes/integrations.controller.ts
+++ b/apps/backend/src/api/routes/integrations.controller.ts
@@ -87,39 +87,47 @@ export class IntegrationsController {
 
   @Get('/list')
   async getIntegrationList(@GetOrgFromRequest() org: Organization) {
-    return {
-      integrations: await Promise.all(
-        (
-          await this._integrationService.getIntegrationsList(org.id)
-        ).map(async (p) => {
-          const findIntegration = this._integrationManager.getSocialIntegration(
-            p.providerIdentifier
+    const integrations = await Promise.all(
+      (
+        await this._integrationService.getIntegrationsList(org.id)
+      ).map(async (p) => {
+        const findIntegration = this._integrationManager.getSocialIntegration(
+          p.providerIdentifier
+        );
+        if (!findIntegration) {
+          console.warn(
+            `Skipping integration ${p.id}: provider "${p.providerIdentifier}" is not registered`
           );
-          return {
-            name: p.name,
-            id: p.id,
-            internalId: p.internalId,
-            disabled: p.disabled,
-            editor: findIntegration.editor,
-            stripLinks: !!findIntegration?.stripLinks?.(),
-            picture: p.picture || '/no-picture.jpg',
-            identifier: p.providerIdentifier,
-            inBetweenSteps: p.inBetweenSteps,
-            refreshNeeded: p.refreshNeeded,
-            isCustomFields: !!findIntegration.customFields,
-            ...(findIntegration.customFields
-              ? { customFields: await findIntegration.customFields() }
-              : {}),
-            display: p.profile,
-            type: p.type,
-            time: JSON.parse(p.postingTimes),
-            changeProfilePicture: !!findIntegration?.changeProfilePicture,
-            changeNickName: !!findIntegration?.changeNickname,
-            customer: p.customer,
-            additionalSettings: p.additionalSettings || '[]',
-          };
-        })
-      ),
+          return undefined;
+        }
+        return {
+          name: p.name,
+          id: p.id,
+          internalId: p.internalId,
+          disabled: p.disabled,
+          editor: findIntegration.editor,
+          stripLinks: !!findIntegration?.stripLinks?.(),
+          picture: p.picture || '/no-picture.jpg',
+          identifier: p.providerIdentifier,
+          inBetweenSteps: p.inBetweenSteps,
+          refreshNeeded: p.refreshNeeded,
+          isCustomFields: !!findIntegration.customFields,
+          ...(findIntegration.customFields
+            ? { customFields: await findIntegration.customFields() }
+            : {}),
+          display: p.profile,
+          type: p.type,
+          time: JSON.parse(p.postingTimes),
+          changeProfilePicture: !!findIntegration?.changeProfilePicture,
+          changeNickName: !!findIntegration?.changeNickname,
+          customer: p.customer,
+          additionalSettings: p.additionalSettings || '[]',
+        };
+      })
+    );
+
+    return {
+      integrations: integrations.filter(Boolean),
     };
   }
 

--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -114,6 +114,21 @@ const usePostActions = (onMutate?: () => void) => {
       };
 
       const data = await (await fetch(`/posts/group/${post.group}`)).json();
+      if (
+        !isDuplicate &&
+        data?.integration &&
+        !integrations.some((integration) => integration.id === data.integration)
+      ) {
+        toaster.show(
+          t(
+            'post_channel_no_longer_available',
+            'This post belongs to a channel that is no longer available and cannot be edited.'
+          ),
+          'warning'
+        );
+        return;
+      }
+
       const date = !isDuplicate
         ? null
         : (await (await fetch('/posts/find-slot')).json()).date;
@@ -170,7 +185,7 @@ const usePostActions = (onMutate?: () => void) => {
         title: ``,
       });
     },
-    [integrations, fetch, modal, mutate]
+    [integrations, fetch, modal, mutate, toaster, t]
   );
 
   const copyDebugJson = useCallback(

--- a/apps/frontend/src/components/launches/launches.component.tsx
+++ b/apps/frontend/src/components/launches/launches.component.tsx
@@ -363,16 +363,18 @@ export const LaunchesComponent = () => {
   const [mode] = useCookie('mode', 'dark');
   const { isLoading, data: integrations, mutate } = useIntegrationList();
 
-  const totalNonDisabledChannels = useMemo(() => {
-    return (
-      integrations?.filter((integration: any) => !integration.disabled)
-        ?.length || 0
-    );
+  const validIntegrations = useMemo(() => {
+    return integrations?.filter(Boolean) || [];
   }, [integrations]);
+
+  const totalNonDisabledChannels = useMemo(() => {
+    return validIntegrations.filter((integration: any) => !integration.disabled)
+      .length;
+  }, [validIntegrations]);
   const changeItemGroup = useCallback(
     async (id: string, group: string) => {
       mutate(
-        integrations.map((integration: any) => {
+        validIntegrations.map((integration: any) => {
           if (integration.id === id) {
             return {
               ...integration,
@@ -393,15 +395,15 @@ export const LaunchesComponent = () => {
       });
       mutate();
     },
-    [integrations]
+    [validIntegrations]
   );
   const sortedIntegrations = useMemo(() => {
     return orderBy(
-      integrations,
+      validIntegrations,
       ['type', 'disabled', 'identifier'],
       ['desc', 'asc', 'asc']
     );
-  }, [integrations]);
+  }, [validIntegrations]);
   const menuIntegrations = useMemo(() => {
     return orderBy(
       Object.values(

--- a/apps/frontend/src/components/new-launch/store.ts
+++ b/apps/frontend/src/components/new-launch/store.ts
@@ -102,7 +102,7 @@ interface StoreState {
   setAllIntegrations: (integrations: Integrations[]) => void;
   setCurrent: (current: string) => void;
   addOrRemoveSelectedIntegration: (
-    integration: Integrations,
+    integration: Integrations | undefined,
     settings: any
   ) => void;
   reset: () => void;
@@ -164,9 +164,13 @@ export const useLaunchStore = create<StoreState>()((set) => ({
       current: current,
     })),
   addOrRemoveSelectedIntegration: (
-    integration: Integrations,
+    integration: Integrations | undefined,
     settings: any
   ) => {
+    if (!integration) {
+      return;
+    }
+
     set((state) => {
       const existing = state.selectedIntegrations.find(
         (i) => i.integration.id === integration.id
@@ -224,13 +228,19 @@ export const useLaunchStore = create<StoreState>()((set) => ({
       );
 
       if (integrationIndex === -1) {
+        const selectedIntegration = state.selectedIntegrations.find(
+          (i) => i.integration?.id === integrationId
+        );
+
+        if (!selectedIntegration) {
+          return {};
+        }
+
         return {
           internal: [
             ...state.internal,
             {
-              integration: state.selectedIntegrations.find(
-                (i) => i.integration.id === integrationId
-              )!.integration,
+              integration: selectedIntegration.integration,
               integrationValue: value,
             },
           ],
@@ -301,7 +311,7 @@ export const useLaunchStore = create<StoreState>()((set) => ({
   addRemoveInternal: (integrationId: string) =>
     set((state) => {
       const integration = state.selectedIntegrations.find(
-        (i) => i.integration.id === integrationId
+        (i) => i.integration?.id === integrationId
       );
       const findIntegrationIndex = state.internal.findIndex(
         (i) => i.integration.id === integrationId
@@ -313,6 +323,10 @@ export const useLaunchStore = create<StoreState>()((set) => ({
             (i) => i.integration.id !== integrationId
           ),
         };
+      }
+
+      if (!integration) {
+        return {};
       }
 
       return {
@@ -369,7 +383,10 @@ export const useLaunchStore = create<StoreState>()((set) => ({
           if (item.integration.id === integrationId) {
             const targetIndex = direction === 'up' ? index - 1 : index + 1;
 
-            if (targetIndex < 0 || targetIndex >= item.integrationValue.length) {
+            if (
+              targetIndex < 0 ||
+              targetIndex >= item.integrationValue.length
+            ) {
               return item;
             }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Posts or integrations tied to providers that are no longer registered could crash the launch UI when rendering channels or opening an old post for editing.

This change filters unavailable integrations from the integration list and guards the launch editor path so missing channels show a warning instead of throwing a runtime error.

# Other information:

No build commands were run.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue