### PR TITLE
fix(launch): use a clear cancel label in the shortlink confirmation dialog

### DIFF
--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -375,7 +375,9 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
                 'shortlink_urls_question',
                 'Do you want to shortlink the URLs? it will let you get statistics over clicks'
               ),
-              t('yes_shortlink_it', 'Yes, shortlink it!')
+              t('yes_shortlink_it', 'Yes, shortlink it!'),
+              undefined,
+              t('no_original_urls', 'No, original URLs')
             );
           }
         }

--- a/i18n.lock
+++ b/i18n.lock
@@ -653,6 +653,7 @@ checksums:
     please_fix_your_settings: 41c970bc73bb775e8b1882dfdbaad569
     shortlink_urls_question: 5308003901830e666ff9915b4855a9c9
     yes_shortlink_it: b784b6f9ce6d5eec451de7f3c7f1e01d
+    no_original_urls: 06cf15a6bf380da85f537f425dd6d236
     added_successfully: 5a1557f26138d3f80b6449d4570d47a9
     updated_successfully: fb4e4de59015fd30331e0f56c63918c5
     create_post_title: 06549e1cb8bbba2645f5ded68259684d

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "يرجى تصحيح إعداداتك",
   "shortlink_urls_question": "هل تريد تقصير الروابط؟ سيسمح لك ذلك بالحصول على إحصائيات حول النقرات",
   "yes_shortlink_it": "نعم، قصّر الرابط!",
+  "no_original_urls": "لا، أبقِ الروابط الأصلية!",
   "added_successfully": "تمت الإضافة بنجاح",
   "updated_successfully": "تم التحديث بنجاح",
   "create_post_title": "إنشاء منشور",

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "অনুগ্রহ করে আপনার সেটিংস ঠিক করুন",
   "shortlink_urls_question": "আপনি কি URL গুলো শর্টলিংক করতে চান? এতে আপনি ক্লিকের পরিসংখ্যান পেতে পারবেন",
   "yes_shortlink_it": "হ্যাঁ, শর্টলিংক করুন!",
+  "no_original_urls": "না, মূল URL রাখুন",
   "added_successfully": "সফলভাবে যোগ হয়েছে",
   "updated_successfully": "সফলভাবে আপডেট হয়েছে",
   "create_post_title": "পোস্ট তৈরি করুন",

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Bitte korrigieren Sie Ihre Einstellungen",
   "shortlink_urls_question": "Möchten Sie die URLs kürzen? So erhalten Sie Statistiken über Klicks.",
   "yes_shortlink_it": "Ja, bitte kürzen!",
+  "no_original_urls": "Nein, Original-URLs",
   "added_successfully": "Erfolgreich hinzugefügt",
   "updated_successfully": "Erfolgreich aktualisiert",
   "create_post_title": "Beitrag erstellen",

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -651,6 +651,7 @@
   "please_fix_your_settings": "Please fix your settings",
   "shortlink_urls_question": "Do you want to shortlink the URLs? it will let you get statistics over clicks",
   "yes_shortlink_it": "Yes, shortlink it!",
+  "no_original_urls": "No, original URLs",
   "added_successfully": "Added successfully",
   "updated_successfully": "Updated successfully",
   "create_post_title": "Create Post",

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Por favor, corrige tu configuración",
   "shortlink_urls_question": "¿Quieres acortar las URLs? Esto te permitirá obtener estadísticas sobre los clics",
   "yes_shortlink_it": "¡Sí, acórtala!",
+  "no_original_urls": "No, URLs originales",
   "added_successfully": "Agregado exitosamente",
   "updated_successfully": "Actualizado exitosamente",
   "create_post_title": "Crear publicación",

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Veuillez corriger vos paramètres",
   "shortlink_urls_question": "Voulez-vous raccourcir les URL ? Cela vous permettra d'obtenir des statistiques sur les clics.",
   "yes_shortlink_it": "Oui, raccourcissez-les !",
+  "no_original_urls": "Non, URLs originales",
   "added_successfully": "Ajouté avec succès",
   "updated_successfully": "Mis à jour avec succès",
   "create_post_title": "Créer une publication",

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "אנא תקן את ההגדרות שלך",
   "shortlink_urls_question": "האם ברצונך לקצר את הקישורים? זה יאפשר לך לקבל סטטיסטיקות על הקלקות",
   "yes_shortlink_it": "כן, קצר את זה!",
+  "no_original_urls": "לא, כתובות URL מקוריות",
   "added_successfully": "נוסף בהצלחה",
   "updated_successfully": "עודכן בהצלחה",
   "create_post_title": "צור פוסט",

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Per favore, correggi le tue impostazioni",
   "shortlink_urls_question": "Vuoi accorciare gli URL? Ti permetterà di ottenere statistiche sui clic",
   "yes_shortlink_it": "Sì, accorcialo!",
+  "no_original_urls": "No, URL originali",
   "added_successfully": "Aggiunto con successo",
   "updated_successfully": "Aggiornato con successo",
   "create_post_title": "Crea post",

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "設定を修正してください",
   "shortlink_urls_question": "URLを短縮リンクにしますか？クリック数の統計を取得できます。",
   "yes_shortlink_it": "はい、短縮リンクにします！",
+  "no_original_urls": "いいえ、元のURLのままにします",
   "added_successfully": "追加に成功しました",
   "updated_successfully": "更新に成功しました",
   "create_post_title": "投稿を作成",

--- a/libraries/react-shared-libraries/src/translation/locales/ka_ge/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ka_ge/translation.json
@@ -466,6 +466,7 @@
     "are_you_sure": "დარწმუნებული ხართ?",
     "yes_delete_it": "კი, წაშალე!",
     "no_cancel": "არა, გაუქმება!",
+    "no_original_urls": "არა, ორიგინალი URL-ები",
     "are_you_sure_you_want_to_delete": "ნამდვილად გსურთ წაშალოთ {{name}}?",
     "are_you_sure_you_want_to_delete_the_image": "ნამდვილად გსურთ სურათის წაშლა?",
     "are_you_sure_you_want_to_logout": "ნამდვილად გსურთ გასვლა?",

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "설정을 수정해 주세요",
   "shortlink_urls_question": "URL을 단축하시겠습니까? 클릭 통계를 확인할 수 있습니다.",
   "yes_shortlink_it": "네, 단축하세요!",
+  "no_original_urls": "아니요, 원래 URL을 유지하세요!",
   "added_successfully": "성공적으로 추가되었습니다",
   "updated_successfully": "성공적으로 업데이트되었습니다",
   "create_post_title": "게시물 작성",

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Por favor, corrija suas configurações",
   "shortlink_urls_question": "Você quer encurtar as URLs? Isso permitirá obter estatísticas sobre os cliques",
   "yes_shortlink_it": "Sim, encurte!",
+  "no_original_urls": "Não, URLs originais",
   "added_successfully": "Adicionado com sucesso",
   "updated_successfully": "Atualizado com sucesso",
   "create_post_title": "Criar publicação",

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Пожалуйста, исправьте ваши настройки",
   "shortlink_urls_question": "Хотите сократить ссылки? Это позволит получать статистику по кликам.",
   "yes_shortlink_it": "Да, сократить!",
+  "no_original_urls": "Нет, оставить оригинальные URL",
   "added_successfully": "Успешно добавлено",
   "updated_successfully": "Успешно обновлено",
   "create_post_title": "Создать пост",

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Lütfen ayarlarınızı düzeltin",
   "shortlink_urls_question": "URL'leri kısaltmak ister misiniz? Bu, tıklamalar üzerinde istatistik almanızı sağlar.",
   "yes_shortlink_it": "Evet, kısalt!",
+  "no_original_urls": "Hayır, orijinal URL'leri koru!",
   "added_successfully": "Başarıyla eklendi",
   "updated_successfully": "Başarıyla güncellendi",
   "create_post_title": "Gönderi Oluştur",

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "Vui lòng sửa cài đặt của bạn",
   "shortlink_urls_question": "Bạn có muốn rút gọn các URL không? Điều này sẽ giúp bạn thống kê số lần nhấp chuột",
   "yes_shortlink_it": "Vâng, hãy rút gọn!",
+  "no_original_urls": "Không, giữ URL gốc!",
   "added_successfully": "Thêm thành công",
   "updated_successfully": "Cập nhật thành công",
   "create_post_title": "Tạo bài đăng",

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -649,6 +649,7 @@
   "please_fix_your_settings": "请修正您的设置",
   "shortlink_urls_question": "您想要对网址进行短链处理吗？这样可以统计点击次数。",
   "yes_shortlink_it": "是的，短链处理！",
+  "no_original_urls": "不，保留原始网址！",
   "added_successfully": "添加成功",
   "updated_successfully": "更新成功",
   "create_post_title": "创建帖子",


### PR DESCRIPTION
## Problem

When scheduling a post with links, the "Do you want to shortlink the URLs?" confirmation dialog answered with **"Yes, shortlink it!"** / **"No, cancel!"**. The cancel label is misleading — it reads like it aborts posting altogether, when it actually just posts with the original URLs.

## Changes

- Pass a custom cancel label — **"No, original URLs"** — at the shortlink call site in `manage.modal.tsx`, using the existing (previously unused there) `cancelButton` parameter of `deleteDialog`. All other `deleteDialog` usages keep the default "No, cancel!".
- Add the `no_original_urls` key to the English source translations and run lingo.dev to translate it across all 14 target locales (`i18n.lock` updated).
- Hand-fix 8 machine translations (ja, ko, ar, tr, zh, bn, ru, vi) that rendered the label as a statement of absence ("there are no original URLs") instead of a choice ("No, keep the original URLs"), matching each locale's existing button-label style.

## Testing

Manually tested locally: the dialog now shows "Yes, shortlink it!" / "No, original URLs", and both choices schedule the post with/without shortlinked URLs respectively. All 16 locale JSON files verified to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)