### PR TITLE
fix(integrations): send a single notification when a token refresh fails

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -78,6 +78,10 @@ export class RefreshIntegrationService {
       .catch((err) => false);
 
     if (!refresh || !refresh.accessToken) {
+      // informAboutRefreshError (with the failure cause) already notifies
+      // the user, and refreshNeeded sets the same flag disconnectChannel
+      // would — calling disconnectChannel here sent a second, cause-less
+      // copy of the same email for every failed refresh.
       await this._integrationService.refreshNeeded(
         integration.organizationId,
         integration.id
@@ -87,11 +91,6 @@ export class RefreshIntegrationService {
         integration.organizationId,
         integration,
         cause
-      );
-
-      await this._integrationService.disconnectChannel(
-        integration.organizationId,
-        integration
       );
 
       return false;


### PR DESCRIPTION
## Problem

Every failed token refresh notifies (in-app + email) the user **twice**:

1. `refreshProcess` (`refresh.integration.service.ts`) calls `informAboutRefreshError` with the failure cause — email titled `Could not refresh your <provider> channel <cause>`.
2. It then calls `integrationService.disconnectChannel`, which internally calls `informAboutRefreshError` **again**, without the cause — a second email titled `Could not refresh your <provider> channel`.

The `disconnectChannel` call contributes nothing else in this path: the `refreshNeeded` call two lines earlier already sets the exact same `refreshNeeded: true` flag that `disconnectChannel`'s repository call sets.

## Fix

Remove the `disconnectChannel` call from `refreshProcess`'s failure branch. The user still gets exactly one notification — the informative one that includes the failure cause — and the channel is still flagged as needing reconnection. `disconnectChannel` itself is untouched, so its other callers (analytics token-expiry path, public API, chat tool) keep their existing notify-on-disconnect behavior.

## Repro & validation

- **Repro (before fix):** connected an Instagram (Facebook Business) channel holding an invalid access token, then triggered a post. The publish failed with a token error, the refresh attempt failed (Instagram cannot refresh), and **two** emails arrived for the single failure — one with the cause in the title, one without.
- **Validation (after fix):** repeated the exact same scenario — exactly **one** email arrived (the one including the failure cause), and the channel was still marked as needing reconnection (red badge + blocked posting), as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)