### PR TITLE
fix(instagram): persist publish state at the publish boundary to prevent duplicates and false failures

### DIFF
--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -220,6 +220,27 @@ export class PostActivity {
       integration.providerIdentifier
     );
 
+    // If an earlier attempt of this activity already published the post (the
+    // remote id is persisted at the publish boundary via the progress
+    // callback below), don't publish again — retrying after a post-publish
+    // failure used to create duplicates. A releaseId equal to the one the
+    // workflow loaded before running this activity means the current cycle
+    // hasn't published yet (repeatable posts re-run with the same post id).
+    const [firstPost] = posts;
+    if (firstPost) {
+      const current = await this._postService.getPostReleaseId(firstPost.id);
+      if (current?.releaseId && current.releaseId !== firstPost.releaseId) {
+        return [
+          {
+            id: firstPost.id,
+            postId: current.releaseId,
+            releaseURL: current.releaseURL || '',
+            status: 'success',
+          },
+        ];
+      }
+    }
+
     const newPosts = await this._postService.updateTags(
       integration.organizationId,
       posts
@@ -247,7 +268,17 @@ export class PostActivity {
           ),
         }))
       ),
-      integration
+      integration,
+      async (response) => {
+        // Persist the remote id the moment the platform confirms the
+        // publish, so a crash or retry after this point cannot publish a
+        // duplicate.
+        await this._postService.updatePost(
+          response.id,
+          response.postId,
+          response.releaseURL
+        );
+      }
     );
 
     await this._temporalService.client

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -402,6 +402,18 @@ export class PostsRepository {
     });
   }
 
+  getPostReleaseId(id: string) {
+    return this._post.model.post.findUnique({
+      where: {
+        id,
+      },
+      select: {
+        releaseId: true,
+        releaseURL: true,
+      },
+    });
+  }
+
   updateReleaseId(id: string, orgId: string, releaseId: string) {
     return this._post.model.post.update({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -81,6 +81,10 @@ export class PostsService {
     return this._postRepository.updatePost(id, postId, releaseURL);
   }
 
+  getPostReleaseId(id: string) {
+    return this._postRepository.getPostReleaseId(id);
+  }
+
   async getMissingContent(
     orgId: string,
     postId: string,

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -594,15 +594,44 @@ export class InstagramProvider
     };
   }
 
+  // The post is already live when this is called — a failure fetching the
+  // permalink must not fail the publish (it used to mark a published post
+  // as ERROR, invite duplicate retries and email a false failure).
+  private async getPermalink(
+    type: string,
+    mediaId: string,
+    token: string,
+    fallback: string
+  ) {
+    try {
+      const { permalink } = await (
+        await this.fetch(
+          `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${token}`,
+          undefined,
+          'instagram-permalink'
+        )
+      ).json();
+      return permalink || fallback;
+    } catch (err) {
+      return fallback;
+    }
+  }
+
   async post(
     id: string,
     token: string,
     postDetails: PostDetails<InstagramDto>[],
     integration: Integration,
+    progress?: (response: PostResponse) => Promise<unknown> | unknown,
     type = 'graph.facebook.com'
   ): Promise<PostResponse[]> {
     const [accessToken, userToken] = token.split('___');
     const [firstPost] = postDetails;
+    // Used when the post is live but the permalink can't be fetched — the
+    // publish must still be reported as a success.
+    const fallbackUrl = `https://www.instagram.com/${
+      integration.profile || ''
+    }`;
     console.log('in progress', id);
     const isStory = firstPost.settings.post_type === 'story';
     const isTrialReel = this.assetBoolean(firstPost.settings.is_trial_reel);
@@ -676,7 +705,8 @@ export class InstagramProvider
             `https://${type}/v20.0/${id}/media?${mediaType}${isCarousel}${collaborators}${trialParams}${audioConfiguration}&access_token=${accessToken}${caption}`,
             {
               method: 'POST',
-            }
+            },
+            'instagram-create-media'
           )
         ).json();
         console.log('in progress2', id);
@@ -695,7 +725,7 @@ export class InstagramProvider
                 userToken || accessToken
               }&fields=status_code`,
               undefined,
-              '',
+              'instagram-media-status',
               0,
               true
             )
@@ -719,19 +749,25 @@ export class InstagramProvider
             `https://${type}/v20.0/${id}/media_publish?creation_id=${mediaCreationId}&access_token=${accessToken}&field=id`,
             {
               method: 'POST',
-            }
+            },
+            'instagram-media-publish'
           )
         ).json();
         lastMediaId = mediaId;
 
-        const { permalink } = await (
-          await this.fetch(
-            `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${
-              userToken || accessToken
-            }`
-          )
-        ).json();
-        lastPermalink = permalink;
+        await progress?.({
+          id: firstPost.id,
+          postId: mediaId,
+          releaseURL: fallbackUrl,
+          status: 'success',
+        });
+
+        lastPermalink = await this.getPermalink(
+          type,
+          mediaId,
+          userToken || accessToken,
+          fallbackUrl
+        );
       }
 
       return [
@@ -748,17 +784,24 @@ export class InstagramProvider
           `https://${type}/v20.0/${id}/media_publish?creation_id=${medias[0]}&access_token=${accessToken}&field=id`,
           {
             method: 'POST',
-          }
+          },
+          'instagram-media-publish'
         )
       ).json();
 
-      const { permalink } = await (
-        await this.fetch(
-          `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${
-            userToken || accessToken
-          }`
-        )
-      ).json();
+      await progress?.({
+        id: firstPost.id,
+        postId: mediaId,
+        releaseURL: fallbackUrl,
+        status: 'success',
+      });
+
+      const permalink = await this.getPermalink(
+        type,
+        mediaId,
+        userToken || accessToken,
+        fallbackUrl
+      );
 
       return [
         {
@@ -778,7 +821,8 @@ export class InstagramProvider
           )}&access_token=${accessToken}`,
           {
             method: 'POST',
-          }
+          },
+          'instagram-create-carousel'
         )
       ).json();
 
@@ -796,7 +840,7 @@ export class InstagramProvider
               userToken || accessToken
             }`,
             undefined,
-            '',
+            'instagram-media-status',
             0,
             true
           )
@@ -810,17 +854,24 @@ export class InstagramProvider
           `https://${type}/v20.0/${id}/media_publish?creation_id=${containerId}&access_token=${accessToken}&field=id`,
           {
             method: 'POST',
-          }
+          },
+          'instagram-media-publish'
         )
       ).json();
 
-      const { permalink } = await (
-        await this.fetch(
-          `https://${type}/v20.0/${mediaId}?fields=permalink&access_token=${
-            userToken || accessToken
-          }`
-        )
-      ).json();
+      await progress?.({
+        id: firstPost.id,
+        postId: mediaId,
+        releaseURL: fallbackUrl,
+        status: 'success',
+      });
+
+      const permalink = await this.getPermalink(
+        type,
+        mediaId,
+        userToken || accessToken,
+        fallbackUrl
+      );
 
       return [
         {

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
@@ -180,13 +180,15 @@ export class InstagramStandaloneProvider
     id: string,
     accessToken: string,
     postDetails: PostDetails<InstagramDto>[],
-    integration: Integration
+    integration: Integration,
+    progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]> {
     return instagramProvider.post(
       id,
       accessToken,
       postDetails,
       integration,
+      progress,
       'graph.instagram.com'
     );
   }

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -268,9 +268,17 @@ export class LinkedinPageProvider
     id: string,
     accessToken: string,
     postDetails: PostDetails[],
-    integration: Integration
+    integration: Integration,
+    progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]> {
-    return super.post(id, accessToken, postDetails, integration, 'company');
+    return super.post(
+      id,
+      accessToken,
+      postDetails,
+      integration,
+      progress,
+      'company'
+    );
   }
 
   override async comment(

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -803,6 +803,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     postDetails: PostDetails<LinkedinDto>[],
     integration: Integration,
+    progress?: (response: PostResponse) => Promise<unknown> | unknown,
     type = 'personal' as 'company' | 'personal'
   ): Promise<PostResponse[]> {
     let processedPostDetails = postDetails;

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -86,7 +86,11 @@ export interface ISocialMediaIntegration {
     id: string,
     accessToken: string,
     postDetails: PostDetails[],
-    integration: Integration
+    integration: Integration,
+    // Called the moment the platform confirms a publish, so the caller can
+    // persist the remote id before any later step can fail — a retry after
+    // a post-publish failure must not publish a duplicate.
+    progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]>; // Schedules a new post
 
   comment?(


### PR DESCRIPTION
## User incident

A user reported that a scheduled Instagram post triggered the error email *"An error occurred while posting on instagram: Instagram blocked your request"* — yet the post **was published** on Instagram, and retrying created **duplicate posts**.

The Jul 5 occurrence is **fully characterized from Temporal history**:
- `postSocial` failed with Graph **code 4 "Application request limit reached" / subcode 2207051 ("action is blocked")** — Instagram's app-level rate limit. Our error mapping surfaces subcode 2207051 as "Instagram blocked your request" (deterministically — every 2207051 response produces that exact email).
- The activity ran **2m09s** before failing — long enough for container creation and status polling — so the failure happened at or after the publish step, consistent with the post being live despite the error.
- Single execution, `attempt: 1`, no retries (2207051 is classified `bad-body` → non-retryable at every layer), so that occurrence's duplicate risk came from the user reasonably retrying a post that was falsely marked failed.
- The user also reported duplicates for posts on **June 24–27**. ⚠️ Temporal history for those runs is no longer retained, so whether those duplicates came from user retries or from automatic activity retries (e.g. the 10-minute activity timeout on long video processing — which the repro below shows produces silent duplicates) is undetermined.

## Root cause

`postSocial` persists nothing until the entire activity completes. The Instagram flow is multi-step (create container → poll status → `media_publish` → fetch permalink), so any failure **after** `media_publish`:
1. marks a live post as ERROR and emails a false failure (inviting a manual duplicate), and
2. leaves Temporal retries free to publish again from scratch (automatic duplicates, with a green workflow and a success email — invisible in Postiz).

## Reproduction (unpatched code, real Instagram account)

⚠️ The production trigger (the code 4 rate limit seen in the Jul 5 Temporal history) cannot be triggered on demand, so both repros use **synthetic failures at the same boundaries**:
- **False failure**: force the permalink fetch to fail right after a successful publish → post live on Instagram, but Postiz marks it ERROR and sends the error email.
- **Silent duplicates**: crash the activity right after a successful publish → the Temporal retry re-publishes → two identical Instagram posts, green workflow, success email, no trace in Postiz.

## Fix

- **Publish-boundary persistence**: the provider reports each publish through a new optional `progress` callback the moment Instagram confirms it; `postSocial` persists the remote id (`updatePost`) right there.
- **Retry idempotency guard**: on an activity retry, if the persisted `releaseId` differs from the snapshot the workflow loaded before the activity ran, an earlier attempt already published — return the persisted result instead of publishing again. Comparing against the snapshot (not mere existence) keeps **repeatable posts** working: they re-run with the same post id and an old `releaseId` already set.
- **Non-fatal permalink fetch**: the post is live when it runs; on any failure — rate limits included — it falls back to the account URL instead of failing the publish. A rate-limited permalink fetch therefore no longer produces any error at all.
- **Step-labeled Graph calls** (`instagram-create-media`, `instagram-media-status`, `instagram-media-publish`, `instagram-create-carousel`, `instagram-permalink`): every future failure names the exact call, so publish-step vs post-publish failures are distinguishable at a glance.
- LinkedIn providers: thread the new optional `progress` parameter through `post()` (they had a trailing parameter in the same position).

## Post-fix validation (same scenarios, patched code)

- **Permalink failure**: post published, shown as published in Postiz with the account URL as release URL, one success email, **no error email**, green workflow.
- **Crash after publish**: **exactly one Instagram post** — the retried attempt hit the guard (`attempt: 2` visible in Temporal with the simulated failure as `lastFailure`), skipped publishing, and completed successfully.

## Remaining gap (out of scope for this PR)

If Instagram returns an error on the **`media_publish` call itself** but processes the publish anyway (which Meta occasionally does under rate limiting), the post is still marked failed — this is undetectable from the publish response. After this fix, that is the *only* case where a failure email can coexist with a live post; users seeing "Instagram blocked your request" during heavy posting should double-check Instagram before retrying.

**Possible follow-up to also remove the error in this edge case — verify-then-decide:** when `media_publish` fails with a rate-limit/block-type error, query the account's recent media (`GET /{ig-user-id}/media?fields=id,caption,timestamp,permalink&limit=10`) before failing the post:
- media found within the publish window (timestamp ≥ publish start, caption match where present) → Instagram processed it: report success with the real media id through the same progress callback — no error shown, no duplicate risk;
- no match → the block was real: fail as today;
- verification call itself fails (same rate-limited window) → fail as today, never regress.

Blanket-treating publish-call rate limits as success is NOT an option: in the common case the post really wasn't published, and a false "published" (silent publish loss) is worse than a false "failed". The timestamp window must be tight so a repeatable post's previous cycle (identical caption) can't false-match, and stories are excluded initially (different edge, murkier matching).

## Known limitation

Multi-media stories publish in a loop with a per-story checkpoint: a retry after a mid-loop crash returns the already-published stories without duplicating them, but does not publish the remainder — biased toward never duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)