### PR TITLE
fix(tiktok): resume the in-flight publish on re-run to prevent duplicate posts

### DIFF
--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -227,8 +227,11 @@ export class PostActivity {
     // workflow loaded before running this activity means the current cycle
     // hasn't published yet (repeatable posts re-run with the same post id).
     const [firstPost] = posts;
+    let inFlight: string | undefined;
     if (firstPost) {
-      const current = await this._postService.getPostReleaseId(firstPost.id);
+      const current = await this._postService.getPostPublishState(
+        firstPost.id
+      );
       if (current?.releaseId && current.releaseId !== firstPost.releaseId) {
         return [
           {
@@ -238,6 +241,20 @@ export class PostActivity {
             status: 'success',
           },
         ];
+      }
+
+      // A previous attempt initiated a publish but died before observing its
+      // outcome — pass the provider publish id along so the provider can
+      // resume polling it instead of publishing again. The freshness window
+      // guards repeatable posts: a marker left over from an earlier cycle
+      // (polling never exceeds ~9 minutes) must not suppress a real publish.
+      if (
+        current?.inFlightId &&
+        current.inFlightAt &&
+        new Date(current.inFlightAt).getTime() >
+          Date.now() - 2 * 60 * 60 * 1000
+      ) {
+        inFlight = current.inFlightId;
       }
     }
 
@@ -250,7 +267,7 @@ export class PostActivity {
       integration.internalId,
       integration.token,
       await Promise.all(
-        (newPosts || []).map(async (p) => ({
+        (newPosts || []).map(async (p, index) => ({
           id: p.id,
           message: stripHtmlValidation(
             getIntegration.editor,
@@ -266,10 +283,22 @@ export class PostActivity {
             JSON.parse(p.image || '[]'),
             getIntegration?.convertToJPEG || false
           ),
+          ...(index === 0 && inFlight ? { inFlight } : {}),
         }))
       ),
       integration,
       async (response) => {
+        if (response.status === 'in-progress') {
+          // The publish is initiated but not confirmed — record it only as
+          // a resume hint for a possible retry; the post is not published
+          // yet, so it must not be marked PUBLISHED.
+          await this._postService.setPostInFlight(
+            response.id,
+            response.postId
+          );
+          return;
+        }
+
         // Persist the remote id the moment the platform confirms the
         // publish, so a crash or retry after this point cannot publish a
         // duplicate.

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -398,11 +398,13 @@ export class PostsRepository {
         state: 'PUBLISHED',
         releaseURL,
         releaseId: postId,
+        inFlightId: null,
+        inFlightAt: null,
       },
     });
   }
 
-  getPostReleaseId(id: string) {
+  getPostPublishState(id: string) {
     return this._post.model.post.findUnique({
       where: {
         id,
@@ -410,6 +412,20 @@ export class PostsRepository {
       select: {
         releaseId: true,
         releaseURL: true,
+        inFlightId: true,
+        inFlightAt: true,
+      },
+    });
+  }
+
+  setPostInFlight(id: string, inFlightId: string) {
+    return this._post.model.post.update({
+      where: {
+        id,
+      },
+      data: {
+        inFlightId,
+        inFlightAt: new Date(),
       },
     });
   }
@@ -437,6 +453,9 @@ export class PostsRepository {
         ...(err
           ? { error: typeof err === 'string' ? err : JSON.stringify(err) }
           : {}),
+        // A terminal error ends the current publish attempt — drop the
+        // in-flight marker so it can't leak into a later repeat cycle.
+        ...(state === 'ERROR' ? { inFlightId: null, inFlightAt: null } : {}),
       },
       include: {
         integration: {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -81,8 +81,12 @@ export class PostsService {
     return this._postRepository.updatePost(id, postId, releaseURL);
   }
 
-  getPostReleaseId(id: string) {
-    return this._postRepository.getPostReleaseId(id);
+  getPostPublishState(id: string) {
+    return this._postRepository.getPostPublishState(id);
+  }
+
+  setPostInFlight(id: string, inFlightId: string) {
+    return this._postRepository.setPostInFlight(id, inFlightId);
   }
 
   async getMissingContent(

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -404,6 +404,8 @@ model Post {
   parentPostId               String?
   releaseId                  String?
   releaseURL                 String?
+  inFlightId                 String?
+  inFlightAt                 DateTime?
   settings                   String?
   image                      String?
   submittedForOrderId        String?

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -90,6 +90,10 @@ export interface ISocialMediaIntegration {
     // Called the moment the platform confirms a publish, so the caller can
     // persist the remote id before any later step can fail — a retry after
     // a post-publish failure must not publish a duplicate.
+    // A provider may also report an *unconfirmed* publish with
+    // status 'in-progress' (postId = the provider's in-flight publish id):
+    // the publish has been initiated but may still fail, so the caller must
+    // only record it as a resume hint, never as a completed publish.
     progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]>; // Schedules a new post
 
@@ -116,6 +120,11 @@ export type PostDetails<T = any> = {
   settings: T;
   media?: MediaContent[];
   poll?: PollDetails;
+  // The provider publish id of a publish that is already in flight for this
+  // post (from a previous attempt that died mid-poll). When set, a provider
+  // that supports it should resume observing that publish instead of
+  // initiating a new one.
+  inFlight?: string;
 };
 
 export type PollDetails = {

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -407,11 +407,18 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
-  private async uploadedVideoSuccess(
+  // Observes an in-flight publish to its terminal state. FAILED comes back as
+  // a discriminated result (nothing was published — the caller decides whether
+  // to re-init or surface the error); poll-exhaustion throws, and token /
+  // network errors from this.fetch propagate untouched.
+  private async pollPublishStatus(
     id: string,
     publishId: string,
     accessToken: string
-  ): Promise<{ url: string; id: string }> {
+  ): Promise<
+    | { status: 'complete'; url: string; id: string }
+    | { status: 'failed'; response: any }
+  > {
     // eslint-disable-next-line no-constant-condition
     for (const i of Array(27).keys()) {
       // ~9 minutes at 20s interval
@@ -438,6 +445,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
       if (status === 'SEND_TO_USER_INBOX') {
         return {
+          status: 'complete',
           url: 'https://www.tiktok.com/messages?lang=en',
           id: 'missing',
         };
@@ -445,6 +453,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
       if (status === 'PUBLISH_COMPLETE') {
         return {
+          status: 'complete',
           url: !publicaly_available_post_id
             ? `https://www.tiktok.com/@${id}`
             : `https://www.tiktok.com/@${id}/video/` +
@@ -456,13 +465,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       }
 
       if (status === 'FAILED') {
-        const handleError = this.handleErrors(JSON.stringify(post));
-        throw new BadBody(
-          'titok-error-upload',
-          JSON.stringify(post),
-          Buffer.from(JSON.stringify(post)),
-          handleError?.value || ''
-        );
+        return { status: 'failed', response: post };
       }
 
       await timer(20000);
@@ -474,6 +477,26 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       Buffer.from(JSON.stringify({})),
       'TikTok refused to publish your post'
     );
+  }
+
+  private async uploadedVideoSuccess(
+    id: string,
+    publishId: string,
+    accessToken: string
+  ): Promise<{ url: string; id: string }> {
+    const result = await this.pollPublishStatus(id, publishId, accessToken);
+
+    if (result.status === 'failed') {
+      const handleError = this.handleErrors(JSON.stringify(result.response));
+      throw new BadBody(
+        'titok-error-upload',
+        JSON.stringify(result.response),
+        Buffer.from(JSON.stringify(result.response)),
+        handleError?.value || ''
+      );
+    }
+
+    return { url: result.url, id: result.id };
   }
 
   private postingMethod(
@@ -776,9 +799,43 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     id: string,
     accessToken: string,
     postDetails: PostDetails<TikTokDto>[],
-    integration: Integration
+    integration: Integration,
+    progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]> {
     const [firstPost] = postDetails;
+
+    // A previous attempt already initiated this publish (init + bytes) but
+    // died before observing the outcome. TikTok completes the publish
+    // server-side, so a fresh init would create a duplicate — resume
+    // observing the in-flight publish instead. FAILED means nothing was
+    // published, so we fall through to a fresh init below; token / network
+    // errors propagate so the next attempt resumes again.
+    if (firstPost?.inFlight) {
+      const resumed = await this.pollPublishStatus(
+        integration.profile!,
+        firstPost.inFlight,
+        accessToken
+      );
+
+      if (resumed.status === 'complete') {
+        await progress?.({
+          id: firstPost.id,
+          postId: String(resumed.id),
+          releaseURL: resumed.url,
+          status: 'success',
+        });
+
+        return [
+          {
+            id: firstPost.id,
+            releaseURL: resumed.url,
+            postId: String(resumed.id),
+            status: 'success',
+          },
+        ];
+      }
+    }
+
     const isPhoto = !hasExtension(firstPost?.media?.[0]?.path, 'mp4');
     const videoPath = firstPost?.media?.[0]?.path!;
 
@@ -811,6 +868,17 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       )
     ).json();
 
+    // The publish boundary: from here on TikTok owns the publish and a retry
+    // must resume observing it, not init again. Reported before the byte
+    // upload on purpose — a crash mid-upload leaves TikTok waiting for bytes,
+    // and the resume path's poll ends in FAILED → clean re-init.
+    await progress?.({
+      id: firstPost.id,
+      postId: publish_id,
+      releaseURL: '',
+      status: 'in-progress',
+    });
+
     // Videos: stream the bytes to the upload_url returned by the init call.
     if (!isPhoto && upload_url && videoSize) {
       await this.uploadTikTokVideoBytes(
@@ -826,6 +894,13 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       publish_id,
       accessToken
     );
+
+    await progress?.({
+      id: firstPost.id,
+      postId: String(videoId),
+      releaseURL: url,
+      status: 'success',
+    });
 
     return [
       {


### PR DESCRIPTION
> [!IMPORTANT]
> **Deployment requires a DB schema push before rolling the workers.** This PR adds two columns (`Post.inFlightId`, `Post.inFlightAt`) and the new code writes them on every TikTok init — deploying it against a DB without the columns fails the publish. Run `prisma db push` (or apply the equivalent `ALTER TABLE`) first. The columns are additive and nullable: metadata-only ALTER, no row rewrite, and old running code ignores them, so pushing the schema early is safe in any order relative to old workers.

## Motivation

A user posting to TikTok once a day hit a confirmed double-publish: TikTok access tokens live ~24h, so with 24-hour gaps between posts the token expires right around publish time — specifically *after* the publish init + video upload succeeded, but *during* `postSocial`'s status polling. The poll failed with `access_token_invalid`, the workflow's token-refresh loop refreshed the token and re-ran `postSocial` from scratch → a second init → **two identical TikTok posts**, green workflow, success email, no error anywhere. (The failing attempt's Temporal failure details contained `{"publish_id":"v_pub_file~..."}` — proof the failure was the status fetch for an already-in-flight publish.)

Once TikTok's init + byte upload are done, TikTok completes the publish server-side; our polling is pure observation. So a re-run must **resume observing** the in-flight publish, never initiate a new one.

## What changed

- **Schema** (additive, nullable only): `Post.inFlightId` / `Post.inFlightAt`.
- **TikTok provider**: reports `'in-progress'` via the `progress` callback (from #1681) immediately after init returns `publish_id` — before the byte upload, so a crash mid-upload also resumes safely. On a re-run with an in-flight marker it skips init and polls that `publish_id` to completion; `FAILED` falls through to a clean re-init (nothing was published), while token/network errors propagate so the next re-run resumes again. The status poll was restructured into `pollPublishStatus` returning a discriminated result for `FAILED`; the normal path's throwing behavior is unchanged.
- **`postSocial`**: computes the resume hint from the same fresh read as the #1681 `releaseId` guard (which is untouched and stays first) and injects it as `PostDetails.inFlight`; the progress callback branches — `'in-progress'` persists the marker only (post is *not* marked published), confirmed statuses persist `releaseId` as before.
- **Marker lifecycle**: cleared on publish success (`updatePost`) and on terminal error (`changeState(ERROR)`); a 2-hour freshness window makes stale markers from a previous repeat-post cycle inert (polling never exceeds ~9 minutes).

Skip-on-retry (what #1681 does for Instagram via `releaseId`) is deliberately **not** used here: a TikTok `publish_id` at init is in-flight, not confirmed — processing can still fail, and reporting success for a failed publish would be a silent publish loss. Resume-and-observe is the correct semantic.

## Verification (real TikTok test channel)

1. **Repro on pre-fix code**: simulated crash after init+upload → Temporal retry re-inited → **two identical posts**, green workflow — reproduced the incident exactly.
2. **With the fix, same crash**: the retry resumed the same `publish_id` (no second init) → **exactly one post**, workflow green; `inFlightId` matched the crashed attempt's `publish_id` during the retry gap, `NULL` after, `releaseId` populated, state `PUBLISHED`.
3. **Normal-publish regression**: one Post Now → one post, marker set during the run and cleared on completion.

## Deploy notes

- **Schema push first** — see the callout at the top.
- Stacked on #1681 (`fix/instagram-publish-boundary`) — it reuses the `progress` callback infrastructure added there. Rebase onto main after #1681 merges.
- Existing rows and already-scheduled posts are unaffected: the columns default to `NULL`, which every code path treats as "no marker". Since the fix lives in activity/provider code, running workflows started before the deploy get the protection on their next publish.
- Other providers never send `'in-progress'` and never read `inFlight` — behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)