### PR TITLE
feat(nostr): add repost plug with NIP-18 support

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -12,6 +12,7 @@ import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { Integration } from '@prisma/client';
+import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
 
 // @ts-ignore
 global.WebSocket = WebSocket;
@@ -185,16 +186,47 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       password
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
 
     return [
       {
         id: firstPost.id,
-        postId: String(eventId),
-        releaseURL: `https://primal.net/e/${eventId}`,
+        postId: String(textEvent.id),
+        releaseURL: `https://primal.net/e/${textEvent.id}`,
         status: 'completed',
       },
     ];
+  }
+
+  @PostPlug({
+    identifier: 'nostr-repost-post-users',
+    title: 'Add Re-posters',
+    description: 'Add Nostr accounts to repost your post',
+    pickIntegration: ['nostr'],
+    fields: [],
+  })
+  async repostPostUsers(
+    integration: Integration,
+    originalIntegration: Integration,
+    postId: string,
+    _information: any
+  ) {
+    const { password } = AuthService.verifyJWT(integration.token) as any;
+
+    const repostEvent = finalizeEvent(
+      {
+        kind: 6, // NIP-18 Repost
+        content: '',
+        tags: [
+          ['e', postId, list[0]], // event-id + relay hint
+          ['p', originalIntegration.internalId],
+        ],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      password
+    );
+
+    await this.publish(integration.internalId, repostEvent);
   }
 
   async comment(
@@ -222,13 +254,13 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       password
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
 
     return [
       {
         id: commentPost.id,
-        postId: String(eventId),
-        releaseURL: `https://primal.net/e/${eventId}`,
+        postId: String(textEvent.id),
+        releaseURL: `https://primal.net/e/${textEvent.id}`,
         status: 'completed',
       },
     ];


### PR DESCRIPTION
## What

Adds the existing "Add Re-posters" PostPlug for Nostr accounts, matching the X and LinkedIn patterns. Users with multiple Nostr accounts can now repost published posts from other Nostr accounts directly in Postiz.

## Changes

### 1. Add `repostPostUsers` PostPlug
- `@PostPlug` with `identifier: 'nostr-repost-post-users'`, `pickIntegration: ['nostr']`
- Signs and publishes a NIP-18 repost event (kind: 6) from the selected Nostr integration
- Includes `e` tag (original event ID + relay hint) and `p` tag (original author pubkey)

### 2. Fix `post()` and `comment()` — use `textEvent.id` for `postId`
- The existing `publish()` helper resolves with `{}` via `oneose` when no matching events arrive within 6 seconds, returning an empty postId
- This meant `repostPostUsers()` would receive an empty string and fail to emit a valid repost
- Using `finalizeEvent()`'s deterministic `textEvent.id` is more reliable and avoids a network round-trip

## Testing
- The plug appears in the Postiz Plugs UI for Nostr integrations alongside the existing X and LinkedIn repost plugs
- Works with multiple Nostr accounts — each integration can repost another's content
- NIP-18 compliant: kind-6 event with proper `e` + `p` tags

close #1586