### PR TITLE
feat(nostr): add repost plug with NIP-18 support

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -12,6 +12,7 @@ import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { Integration } from '@prisma/client';
+import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
 
 // @ts-ignore
 global.WebSocket = WebSocket;
@@ -185,16 +186,47 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       password
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
 
     return [
       {
         id: firstPost.id,
-        postId: String(eventId),
-        releaseURL: `https://primal.net/e/${eventId}`,
+        postId: String(textEvent.id),
+        releaseURL: `https://primal.net/e/${textEvent.id}`,
         status: 'completed',
       },
     ];
+  }
+
+  @PostPlug({
+    identifier: 'nostr-repost-post-users',
+    title: 'Add Re-posters',
+    description: 'Add Nostr accounts to repost your post',
+    pickIntegration: ['nostr'],
+    fields: [],
+  })
+  async repostPostUsers(
+    integration: Integration,
+    originalIntegration: Integration,
+    postId: string,
+    _information: any
+  ) {
+    const { password } = AuthService.verifyJWT(integration.token) as any;
+
+    const repostEvent = finalizeEvent(
+      {
+        kind: 6, // NIP-18 Repost
+        content: '',
+        tags: [
+          ['e', postId, list[0]], // event-id + relay hint
+          ['p', originalIntegration.internalId],
+        ],
+        created_at: Math.floor(Date.now() / 1000),
+      },
+      password
+    );
+
+    await this.publish(integration.internalId, repostEvent);
   }
 
   async comment(
@@ -222,13 +254,13 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       password
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
 
     return [
       {
         id: commentPost.id,
-        postId: String(eventId),
-        releaseURL: `https://primal.net/e/${eventId}`,
+        postId: String(textEvent.id),
+        releaseURL: `https://primal.net/e/${textEvent.id}`,
         status: 'completed',
       },
     ];


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) and sign the [CLA](https://contribute.postiz.com/p/postiz/cla) before submitting a PR. -->

# What kind of change does this PR introduce?

Feature. Adds the existing "Add Re-posters" PostPlug for Nostr accounts, matching what X and LinkedIn already support.

# Why was this change needed?

Fixes #1586. Users with multiple Nostr accounts had to repost manually in another Nostr client. Postiz already lets X and LinkedIn users select additional accounts to repost published posts — Nostr was missing this.

The existing publish() helper also returns an unreliable event ID (empty string when relays time out), which would break the repost. Using finalizeEvent()s deterministic .id is more reliable.

# Other information:

Implementation mirrors the exact same @PostPlug pattern used by X.provider and LinkedIn.provider. NIP-18 compliant (kind-6 repost event with e/p tags).

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue