### PR TITLE
fix(tiktok): default content_posting_method to DIRECT_POST

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
@@ -16,6 +16,38 @@ import {
 const validUrlExtension = new ValidUrlExtension();
 const validUrlPath = new ValidUrlPath();
 
+// Settings the agent tends to guess when the schema gives it no guidance —
+// fill them explicitly so an omitted key never lands on a surprising value
+// (e.g. TikTok UPLOAD sends the post to the user's app inbox instead of
+// publishing it).
+export const PROVIDER_SETTINGS_DEFAULTS: Record<string, Record<string, any>> =
+  {
+    tiktok: { content_posting_method: 'DIRECT_POST' },
+  };
+
+export const buildSettings = (
+  providerIdentifier: string,
+  settings: { key: string; value: any }[],
+  base: AllProvidersSettings
+): AllProvidersSettings => {
+  const merged = settings.reduce(
+    (acc: AllProvidersSettings, s: { key: string; value: any }) => ({
+      ...acc,
+      [s.key]: s.value,
+    }),
+    base
+  );
+
+  const defaults = PROVIDER_SETTINGS_DEFAULTS[providerIdentifier] || {};
+  for (const [key, value] of Object.entries(defaults)) {
+    if ((merged as any)[key] === undefined || (merged as any)[key] === '') {
+      (merged as any)[key] = value;
+    }
+  }
+
+  return merged;
+};
+
 // Same URL validation as MediaDto (valid.url.path) - each attachment must
 // point to an allowed upload domain and a supported file extension.
 const attachmentUrl = z
@@ -147,11 +179,9 @@ If the tools return errors, you would need to rerun it with the right parameters
 
           // Same server-side validation as the dashboard / public API
           // (settings DTO + media checkValidity + empty / too-long content).
-          const settings = platform.settings.reduce(
-            (acc: AllProvidersSettings, s: { key: string; value: any }) => ({
-              ...acc,
-              [s.key]: s.value,
-            }),
+          const settings = buildSettings(
+            integrations[platform.integrationId]?.providerIdentifier || '',
+            platform.settings,
             {} as AllProvidersSettings
           );
 
@@ -216,11 +246,9 @@ If the tools return errors, you would need to rerun it with the right parameters
               {
                 integration,
                 group: makeId(10),
-                settings: post.settings.reduce(
-                  (acc: AllProvidersSettings, s: { key: string; value: any }) => ({
-                    ...acc,
-                    [s.key]: s.value,
-                  }),
+                settings: buildSettings(
+                  integration.providerIdentifier,
+                  post.settings,
                   {
                     __type: integration.providerIdentifier,
                   } as AllProvidersSettings

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/tiktok.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/tiktok.dto.ts
@@ -1,6 +1,7 @@
 import {
   IsBoolean, ValidateIf, IsIn, IsString, MaxLength, IsOptional
 } from 'class-validator';
+import { JSONSchema } from 'class-validator-jsonschema';
 
 export class TikTokDto {
   @ValidateIf((p) => p.title)
@@ -44,5 +45,12 @@ export class TikTokDto {
 
   @IsIn(['DIRECT_POST', 'UPLOAD'])
   @IsString()
+  @JSONSchema({
+    description:
+      'Required. Use "DIRECT_POST" to actually publish the post to TikTok. ' +
+      '"UPLOAD" does NOT publish: it only sends the media to the user\'s TikTok app inbox, ' +
+      'where they must manually finish and publish it within 24 hours or it is discarded. ' +
+      'Only use "UPLOAD" when the user explicitly asks to review or edit the post inside the TikTok app before publishing.',
+  })
   content_posting_method: 'DIRECT_POST' | 'UPLOAD';
 }

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -19,7 +19,9 @@ import { Integration } from '@prisma/client';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
 @Rules(
-  'TikTok can have one video or one picture or multiple pictures, it cannot be without an attachment'
+  'TikTok can have one video or one picture or multiple pictures, it cannot be without an attachment. ' +
+    'For the "content_posting_method" setting always use "DIRECT_POST" unless the user explicitly asks to review or edit the post inside the TikTok app before publishing. ' +
+    '"UPLOAD" does NOT publish the post: it only sends it to the user\'s TikTok app inbox, where they must manually complete it within 24 hours or it is discarded.'
 )
 export class TiktokProvider extends SocialAbstract implements SocialProvider {
   identifier = 'tiktok';


### PR DESCRIPTION
## Problem

Scheduled TikTok posts were being marked **successful** in Postiz and Temporal but never published. The `postSocial` activity returned `postId: "missing"` with a `tiktok.com/messages` release URL.

Root cause: the post had `content_posting_method: "UPLOAD"` instead of `DIRECT_POST`. `UPLOAD` does **not** publish — TikTok's API delivers the video to the account's **app inbox**, where the user must manually complete it within ~24h or it's discarded. This is TikTok's `SEND_TO_USER_INBOX` terminal status, which we (correctly) treat as a successful upload.

Why the agent chose `UPLOAD`: the chat/MCP agent had to supply `content_posting_method` with **no guidance** — it's a bare required enum (`'DIRECT_POST' | 'UPLOAD'`) with no description or default, and TikTok's agent `@Rules` said nothing about it. For a video post, "UPLOAD" reads like the obvious choice. The user never asked for it; the model guessed.

## Fix (three layers)

- **`@Rules` guidance** (`tiktok.provider.ts`): the agent is now told to use `DIRECT_POST` unless the user explicitly asks to review/edit inside the TikTok app first, and that `UPLOAD` does not publish.
- **Hard default** (`integration.schedule.post.ts`): a `PROVIDER_SETTINGS_DEFAULTS` map + `buildSettings()` helper fills `content_posting_method` with `DIRECT_POST` when the key is omitted — applied in **both** the validation and creation paths — so an omitted value can never land on `UPLOAD` by accident. The default map is TikTok-only; all other providers reduce to the exact prior behavior.
- **Schema description** (`tiktok.dto.ts`): `@JSONSchema({ description })` explains, on the field itself, that `UPLOAD` never publishes.

### Why all three

They cover different populations, and the layers are not redundant:

| Consumer | Reached by |
|---|---|
| Internal web agent + external MCP agents | `@Rules` (via `integrationSchema`), plus the default as a backstop |
| Public API caller that reads `rules` from `GET /public/v1/integration-settings/:id` | `@Rules` |
| Public API caller that reads only the settings schema | `@JSONSchema` description |

Note the default only fills a key that is `undefined`/`''`. Because the field is **required**, an agent nearly always sends *something* — so the prose rule and the field description are what actually steer it away from `UPLOAD`; the default is insurance against omission.

The `@JSONSchema` decorator is metadata only — it registers no validator, so `@IsIn([...])` still rejects a missing or invalid value and **the field remains required**. The dashboard is unaffected: its React form hardcodes `DIRECT_POST`.

## Testing

- Validated live over MCP: scheduling a TikTok draft **omitting** `content_posting_method` now yields `DIRECT_POST`.
- Generated-schema check on `TikTokDto`: `description` present, `enum` unchanged, `content_posting_method` still listed in `required`.
- Behavior-preserving for non-TikTok providers (defaults map has only a `tiktok` entry).
- Typechecks (backend).

## Not covered here

Two other copies of this enum are documented outside this repo and are unreachable from a backend change. Both are being fixed separately:

- `gitroomhq/postiz-docs` — `public-api/providers/tiktok.mdx` describes `UPLOAD` as "Upload for manual posting"; `public-api/openapi.json` has a bare enum with no description. (Hand-maintained, not generated.)
- `gitroomhq/postiz-agent` — the skill bundles its own `PROVIDER_SETTINGS.md`, which lists the enum with no explanation. Skill runs read that file rather than calling `integrations:settings`, so no backend fix reaches them.

## Notes

First of two related changes. A follow-up feature branch (agent list/update of scheduled posts) stacks on this one and will be opened as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)