### PR TITLE
fix(agent-chat): guard integration lookup in manualPosting modal

### DIFF
--- a/apps/frontend/src/components/agents/agent.chat.tsx
+++ b/apps/frontend/src/components/agents/agent.chat.tsx
@@ -303,7 +303,7 @@ const OpenModal: FC<{
                 integration: integration.integrationId,
                 integrationPicture:
                   properties.find((p) => p.id === integration.integrationId)
-                    .picture || '',
+                    ?.picture || '',
                 settings: integration.settings || {},
                 posts: integration.posts.map((p) => ({
                   approvedSubmitForOrder: 'NO',


### PR DESCRIPTION
## Problem

Opening the agent-chat "populated modal" (the `manualPosting` CopilotKit action) can white-screen the whole chat with:

```
TypeError: Cannot read properties of undefined (reading 'picture')
  at OpenModal.useCallback[startModal] (agent.chat.tsx:305)
```

`manualPosting` builds the modal from `properties` — the channels the user has **selected in the agent-chat sidebar** (`PropertiesContext`, fed by `AgentList`). It looked up the integration with `properties.find(...).picture` and **no null guard**. Whenever the action references an integration that isn't in the selected list, `find` returns `undefined` and `.picture` throws.

This is reachable any time the agent opens the modal for a channel the user hasn't selected in the sidebar — e.g. asking the agent to open a modal for an existing post's channel.

## Fix

One-character defensive guard — `properties.find(...)?.picture || ''` — so the modal degrades to an empty picture instead of crashing. No behavior change when the integration *is* present.

## Notes

Pre-existing latent crash, independent of any specific feature. Small and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)