### PR TITLE
fix: keep Temporal workflow when a scheduled post is edited without a time change

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -931,7 +931,10 @@ export class PostsService {
       // post without moving its time keeps the existing workflow - content and
       // settings are re-read from the DB at publish time, so a restart (which
       // would terminate + recreate the workflow) is unnecessary churn.
+      // Only a 'schedule' save may skip: 'draft'/'now' saves must still go
+      // through startWorkflow so the old run is terminated.
       const publishTimeUnchanged =
+        body.type === 'schedule' &&
         !!existingRoot &&
         existingRoot.state === 'QUEUE' &&
         dayjs(existingRoot.publishDate).isSame(dayjs(scheduledDate), 'minute');

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -934,9 +934,7 @@ export class PostsService {
       const publishTimeUnchanged =
         !!existingRoot &&
         existingRoot.state === 'QUEUE' &&
-        dayjs
-          .utc(existingRoot.publishDate)
-          .isSame(dayjs.utc(scheduledDate), 'minute');
+        dayjs(existingRoot.publishDate).isSame(dayjs(scheduledDate), 'minute');
 
       if (body.type !== 'update' && !publishTimeUnchanged) {
         this.startWorkflow(

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -932,10 +932,14 @@ export class PostsService {
       // settings are re-read from the DB at publish time, so a restart (which
       // would terminate + recreate the workflow) is unnecessary churn.
       // Only a 'schedule' save may skip: 'draft'/'now' saves must still go
-      // through startWorkflow so the old run is terminated.
+      // through startWorkflow so the old run is terminated. The existing row
+      // must also BE the root: if the edit promoted a child row (thread head
+      // removed/reordered), the workflow is keyed to the old root, which gets
+      // soft-deleted - the new root needs its own workflow.
       const publishTimeUnchanged =
         body.type === 'schedule' &&
         !!existingRoot &&
+        !existingRoot.parentPostId &&
         existingRoot.state === 'QUEUE' &&
         dayjs(existingRoot.publishDate).isSame(dayjs(scheduledDate), 'minute');
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -900,10 +900,22 @@ export class PostsService {
         content: removeLinks ? stripLinks(updateContent[i]) : updateContent[i],
       }));
 
+      const scheduledDate =
+        body.type === 'now'
+          ? dayjs().format('YYYY-MM-DDTHH:mm:00')
+          : body.date;
+
+      // Grab the current publish time BEFORE the upsert overwrites it, so we
+      // can tell (below) whether an edit actually moved the post's time.
+      const existingRootId = post.value?.[0]?.id;
+      const existingRoot = existingRootId
+        ? await this._postRepository.getPostById(existingRootId, orgId)
+        : null;
+
       const { posts } = await this._postRepository.createOrUpdatePost(
         body.type,
         orgId,
-        body.type === 'now' ? dayjs().format('YYYY-MM-DDTHH:mm:00') : body.date,
+        scheduledDate,
         post,
         body.tags,
         creationMethod,
@@ -914,7 +926,19 @@ export class PostsService {
         return [] as any[];
       }
 
-      if (body.type !== 'update') {
+      // Only (re)start the Temporal workflow when it's actually needed: a new
+      // post, or a scheduled post whose publish time changed. Editing a queued
+      // post without moving its time keeps the existing workflow - content and
+      // settings are re-read from the DB at publish time, so a restart (which
+      // would terminate + recreate the workflow) is unnecessary churn.
+      const publishTimeUnchanged =
+        !!existingRoot &&
+        existingRoot.state === 'QUEUE' &&
+        dayjs
+          .utc(existingRoot.publishDate)
+          .isSame(dayjs.utc(scheduledDate), 'minute');
+
+      if (body.type !== 'update' && !publishTimeUnchanged) {
         this.startWorkflow(
           post.settings.__type.split('-')[0].toLowerCase(),
           posts[0].id,


### PR DESCRIPTION
## Problem

Editing a future scheduled post — via the **dashboard** or the **public API** (`POST /public/v1/posts` with the existing ids) — sent `type: 'schedule'`, which always **terminated and recreated** the post's Temporal workflow, even when only the content or settings changed and the publish time stayed the same. At 100k+ sleeping workflows that is needless churn (terminate + start per edit), and it diverged from the agent's `updatePostTool`, which already leaves the workflow alone for non-time changes.

## Fix

Decide it **server-side** in `PostsService.createPost`: capture the post's current publish time *before* the upsert overwrites it, and only (re)start the workflow when it's a new post or an existing `QUEUE` post whose time actually moved. Content and settings are re-read from the DB at publish time, so an unchanged time needs no restart; a genuine time change still restarts it.

Done in the service (not the edit modal) so it's authoritative and covers every caller — dashboard and public API — and can't be fooled by client-side date state.

## Testing (repro + validate, both surfaces)

Counted Temporal runs for the post before/after an identical time-unchanged edit:

| Surface | Without fix (main) | With fix |
|---|---|---|
| Dashboard edit (settings only, same time) | new workflow created | **no new workflow** |
| `POST /public/v1/posts` (same ids, same time) | 1 → 2 runs | **2 → 2 runs** |

A real date change still recreates the workflow (`TERMINATE_EXISTING`, one new run) in both cases. Decision logic also spot-checked against real stored dates (unchanged → skip, moved → restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)