### PR TITLE
chore(mcp): instrument streamable-HTTP session retention

### DIFF
--- a/libraries/nestjs-libraries/src/chat/mcp.metrics.ts
+++ b/libraries/nestjs-libraries/src/chat/mcp.metrics.ts
@@ -1,0 +1,177 @@
+import { INestApplication, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { MCPServer } from '@mastra/mcp';
+import { PerformanceObserver, constants } from 'perf_hooks';
+import v8 from 'v8';
+
+const MB = 1024 * 1024;
+const logger = new Logger('McpMetrics');
+
+// `@mastra/mcp` stores one transport per streamable-HTTP session in
+// `streamableHTTPTransports` and only removes it on `transport.onclose`, which
+// fires only on an explicit client DELETE. That map is the leak.
+//
+// Its sibling `httpServerInstances` is not worth reporting: it stays empty in
+// v1.4.1, written under `if (transport.sessionId)` before the id is assigned.
+// The per-session Server still leaks, retained via the transport's closures.
+//
+// Everything here is read-only. We never touch the map, only observe it.
+type SessionMaps = {
+  streamableHTTPTransports?: Map<string, unknown>;
+};
+
+// heapUsed sampled at an arbitrary moment is dominated by uncollected garbage.
+// Sampling right after a major GC gives the *retained* heap, which is what a
+// leak actually is. The observer costs one callback per GC, no forced pauses.
+let retainedHeap = 0;
+
+const observeMajorGc = () => {
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      const kind = (entry as unknown as { detail?: { kind?: number } }).detail
+        ?.kind;
+      if (kind === constants.NODE_PERFORMANCE_GC_MAJOR) {
+        retainedHeap = process.memoryUsage().heapUsed;
+      }
+    }
+  });
+  observer.observe({ entryTypes: ['gc'] });
+};
+
+export const startMcpMetrics = (app: INestApplication, server: MCPServer) => {
+  const maps = server as unknown as SessionMaps;
+  const transports = () => maps.streamableHTTPTransports;
+
+  logger.log(
+    `V8 heap limit: ${Math.round(
+      v8.getHeapStatistics().heap_size_limit / MB
+    )} MB`
+  );
+
+  if (!transports()) {
+    logger.warn(
+      'Cannot read streamableHTTPTransports from MCPServer — @mastra/mcp internals changed, session metrics disabled'
+    );
+    return;
+  }
+
+  observeMajorGc();
+
+  const intervalMs = Number(process.env.MCP_METRICS_INTERVAL_MS || 900_000);
+  const abandonedAfterMs = Number(
+    process.env.MCP_METRICS_ABANDONED_MS || 3_600_000
+  );
+
+  // Session id -> first time we saw it. Two orders of magnitude smaller than
+  // the ~76 KB transport it tracks, and pruned whenever a session does close.
+  const firstSeen = new Map<string, number>();
+  let previous = new Set<string>();
+  let createdTotal = 0;
+  let closedTotal = 0;
+  let lastRetained = 0;
+
+  const sample = () => {
+    const live = new Set(transports()!.keys());
+    const now = Date.now();
+
+    let created = 0;
+    for (const id of live) {
+      if (!previous.has(id)) {
+        created++;
+        firstSeen.set(id, now);
+      }
+    }
+
+    let closed = 0;
+    for (const id of previous) {
+      if (!live.has(id)) {
+        closed++;
+        firstSeen.delete(id);
+      }
+    }
+
+    let abandoned = 0;
+    for (const seen of firstSeen.values()) {
+      if (now - seen > abandonedAfterMs) {
+        abandoned++;
+      }
+    }
+
+    previous = live;
+    createdTotal += created;
+    closedTotal += closed;
+
+    return { live: live.size, created, closed, abandoned };
+  };
+
+  const snapshot = () => {
+    const mem = process.memoryUsage();
+    return {
+      liveSessions: transports()!.size,
+      createdTotal,
+      closedTotal,
+      retainedHeapMb: Math.round(retainedHeap / MB),
+      heapUsedMb: Math.round(mem.heapUsed / MB),
+      heapTotalMb: Math.round(mem.heapTotal / MB),
+      externalMb: Math.round(mem.external / MB),
+      rssMb: Math.round(mem.rss / MB),
+      heapLimitMb: Math.round(v8.getHeapStatistics().heap_size_limit / MB),
+      uptimeSeconds: Math.round(process.uptime()),
+    };
+  };
+
+  setInterval(() => {
+    const { live, created, closed, abandoned } = sample();
+
+    // Idle service: nothing opened, nothing closed, nothing held. Say nothing.
+    if (!live && !created && !closed) {
+      return;
+    }
+
+    // Retained heap only means anything once a major GC has actually run.
+    const deltaMb = lastRetained
+      ? Math.round((retainedHeap - lastRetained) / MB)
+      : 0;
+    const perSessionKb =
+      created > 0 && lastRetained
+        ? Math.round((retainedHeap - lastRetained) / 1024 / created)
+        : null;
+    const ratePerHour = Math.round(created / (intervalMs / 3_600_000));
+    lastRetained = retainedHeap;
+
+    const heapPart = retainedHeap
+      ? `retainedHeap=${Math.round(retainedHeap / MB)}MB delta=${
+          deltaMb >= 0 ? '+' : ''
+        }${deltaMb}MB`
+      : 'retainedHeap=pending(no major gc yet)';
+
+    // rss/heapTotal/external bridge to the container's memory graph, which
+    // counts the whole process rather than just the V8 heap:
+    //   rss - heapTotal - external ~= native overhead (code, stacks, metadata)
+    const mem = process.memoryUsage();
+
+    logger.log(
+      `mcp-sessions live=${live} new=${created} closed=${closed} ` +
+        `abandoned>${Math.round(abandonedAfterMs / 60_000)}m=${abandoned} ` +
+        `rate=${ratePerHour}/h ${heapPart}` +
+        (perSessionKb === null ? '' : ` perSession~${perSessionKb}KB`) +
+        ` rss=${Math.round(mem.rss / MB)}MB heapTotal=${Math.round(
+          mem.heapTotal / MB
+        )}MB external=${Math.round(mem.external / MB)}MB`
+    );
+  }, intervalMs).unref();
+
+  const token = process.env.MCP_METRICS_TOKEN;
+  app.use('/mcp-metrics', (req: Request, res: Response) => {
+    if (!token || req.headers.authorization !== `Bearer ${token}`) {
+      res.sendStatus(404);
+      return;
+    }
+
+    if (req.query.gc && typeof global.gc === 'function') {
+      global.gc();
+    }
+
+    res.json(snapshot());
+  });
+};

--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -7,6 +7,7 @@ import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/o
 import { OAuthService } from '@gitroom/nestjs-libraries/database/prisma/oauth/oauth.service';
 import { runWithContext } from './async.storage';
 import { createOAuthMiddleware } from './oauth-middleware';
+import { startMcpMetrics } from './mcp.metrics';
 const fixAcceptHeader = (req: Request) => {
   const value = 'application/json, text/event-stream';
   req.headers.accept = value;
@@ -44,6 +45,8 @@ export const startMcp = async (app: INestApplication) => {
   };
 
   const server = new MCPServer(serverConfig);
+
+  startMcpMetrics(app, server);
 
   const oauthMiddleware = createOAuthMiddleware({
     oauth: {


### PR DESCRIPTION
## Context

The MCP service climbs **~330 MB/h** from a ~1 GB baseline until it is OOM-killed at ~5 GB, roughly **twice a day**, then restarts and repeats. The climb is load-independent, which points at client reconnects rather than traffic volume.

The mechanism is a session leak in `@mastra/mcp`: one transport (and, transitively, one per-session `Server` holding the whole converted tool schema) is retained per `initialize` request, and released only on an explicit client `DELETE` that connectors never send. There is no idle timeout, so the map grows for the life of the process.

The same session design also means **every restart — an OOM kill or an ordinary deploy — strands connected customer agents**, which must be restarted, and each reconnect leaves another permanently retained session behind. And it is a dead end upstream: the [2026-07-28 MCP specification](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) removes `Mcp-Session-Id` and protocol-level sessions entirely.

## What this PR does

**Measures, does not fix.** No transport behaviour changes; the session map is only read, via `.size` and `.keys()`. The fix ships separately in #1697.

It records retained heap (sampled right after each major GC via a `PerformanceObserver`, so uncollected garbage can't masquerade as a leak), plus `live` / `new` / `closed` / `abandoned>60m` session counts from a single 15-minute key-set diff — no per-session timers.

The two numbers that matter are `perSession~KB` and `rate=/h`. Their product predicts the MB/h the container should show. **If it explains the full 330 MB/h, this leak is the whole story; if it explains a third of it, there is a second leak that the stateless fix would otherwise have masked.** That is the reason to land instrumentation first and read production before fixing.

## Output

One line per 15 minutes, suppressed entirely while idle:

```
mcp-sessions live=1832 new=87 closed=0 abandoned>60m=1604 rate=348/h \
  retainedHeap=2101MB delta=+7MB perSession~82KB rss=2680MB heapTotal=2210MB external=94MB
```

`closed=0` beside a growing `abandoned` count is the direct proof that sessions are never released.

## Deploying

No environment variables required. `/mcp-metrics` returns `404` unless `MCP_METRICS_TOKEN` is set. Overhead is one `setInterval`, one `PerformanceObserver` doing work only on major GCs, and an O(n) key scan every 15 minutes.

The commit message documents how to line these log lines up against the Railway memory graph (compare slopes, not absolute values — Railway charts the whole container, we report one process's V8 heap).
