### PR TITLE
fix(mcp): serve streamable HTTP statelessly behind MCP_STATELESS

### DIFF
--- a/libraries/nestjs-libraries/src/chat/mcp.metrics.ts
+++ b/libraries/nestjs-libraries/src/chat/mcp.metrics.ts
@@ -1,0 +1,177 @@
+import { INestApplication, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { MCPServer } from '@mastra/mcp';
+import { PerformanceObserver, constants } from 'perf_hooks';
+import v8 from 'v8';
+
+const MB = 1024 * 1024;
+const logger = new Logger('McpMetrics');
+
+// `@mastra/mcp` stores one transport per streamable-HTTP session in
+// `streamableHTTPTransports` and only removes it on `transport.onclose`, which
+// fires only on an explicit client DELETE. That map is the leak.
+//
+// Its sibling `httpServerInstances` is not worth reporting: it stays empty in
+// v1.4.1, written under `if (transport.sessionId)` before the id is assigned.
+// The per-session Server still leaks, retained via the transport's closures.
+//
+// Everything here is read-only. We never touch the map, only observe it.
+type SessionMaps = {
+  streamableHTTPTransports?: Map<string, unknown>;
+};
+
+// heapUsed sampled at an arbitrary moment is dominated by uncollected garbage.
+// Sampling right after a major GC gives the *retained* heap, which is what a
+// leak actually is. The observer costs one callback per GC, no forced pauses.
+let retainedHeap = 0;
+
+const observeMajorGc = () => {
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      const kind = (entry as unknown as { detail?: { kind?: number } }).detail
+        ?.kind;
+      if (kind === constants.NODE_PERFORMANCE_GC_MAJOR) {
+        retainedHeap = process.memoryUsage().heapUsed;
+      }
+    }
+  });
+  observer.observe({ entryTypes: ['gc'] });
+};
+
+export const startMcpMetrics = (app: INestApplication, server: MCPServer) => {
+  const maps = server as unknown as SessionMaps;
+  const transports = () => maps.streamableHTTPTransports;
+
+  logger.log(
+    `V8 heap limit: ${Math.round(
+      v8.getHeapStatistics().heap_size_limit / MB
+    )} MB`
+  );
+
+  if (!transports()) {
+    logger.warn(
+      'Cannot read streamableHTTPTransports from MCPServer — @mastra/mcp internals changed, session metrics disabled'
+    );
+    return;
+  }
+
+  observeMajorGc();
+
+  const intervalMs = Number(process.env.MCP_METRICS_INTERVAL_MS || 900_000);
+  const abandonedAfterMs = Number(
+    process.env.MCP_METRICS_ABANDONED_MS || 3_600_000
+  );
+
+  // Session id -> first time we saw it. Two orders of magnitude smaller than
+  // the ~76 KB transport it tracks, and pruned whenever a session does close.
+  const firstSeen = new Map<string, number>();
+  let previous = new Set<string>();
+  let createdTotal = 0;
+  let closedTotal = 0;
+  let lastRetained = 0;
+
+  const sample = () => {
+    const live = new Set(transports()!.keys());
+    const now = Date.now();
+
+    let created = 0;
+    for (const id of live) {
+      if (!previous.has(id)) {
+        created++;
+        firstSeen.set(id, now);
+      }
+    }
+
+    let closed = 0;
+    for (const id of previous) {
+      if (!live.has(id)) {
+        closed++;
+        firstSeen.delete(id);
+      }
+    }
+
+    let abandoned = 0;
+    for (const seen of firstSeen.values()) {
+      if (now - seen > abandonedAfterMs) {
+        abandoned++;
+      }
+    }
+
+    previous = live;
+    createdTotal += created;
+    closedTotal += closed;
+
+    return { live: live.size, created, closed, abandoned };
+  };
+
+  const snapshot = () => {
+    const mem = process.memoryUsage();
+    return {
+      liveSessions: transports()!.size,
+      createdTotal,
+      closedTotal,
+      retainedHeapMb: Math.round(retainedHeap / MB),
+      heapUsedMb: Math.round(mem.heapUsed / MB),
+      heapTotalMb: Math.round(mem.heapTotal / MB),
+      externalMb: Math.round(mem.external / MB),
+      rssMb: Math.round(mem.rss / MB),
+      heapLimitMb: Math.round(v8.getHeapStatistics().heap_size_limit / MB),
+      uptimeSeconds: Math.round(process.uptime()),
+    };
+  };
+
+  setInterval(() => {
+    const { live, created, closed, abandoned } = sample();
+
+    // Idle service: nothing opened, nothing closed, nothing held. Say nothing.
+    if (!live && !created && !closed) {
+      return;
+    }
+
+    // Retained heap only means anything once a major GC has actually run.
+    const deltaMb = lastRetained
+      ? Math.round((retainedHeap - lastRetained) / MB)
+      : 0;
+    const perSessionKb =
+      created > 0 && lastRetained
+        ? Math.round((retainedHeap - lastRetained) / 1024 / created)
+        : null;
+    const ratePerHour = Math.round(created / (intervalMs / 3_600_000));
+    lastRetained = retainedHeap;
+
+    const heapPart = retainedHeap
+      ? `retainedHeap=${Math.round(retainedHeap / MB)}MB delta=${
+          deltaMb >= 0 ? '+' : ''
+        }${deltaMb}MB`
+      : 'retainedHeap=pending(no major gc yet)';
+
+    // rss/heapTotal/external bridge to the container's memory graph, which
+    // counts the whole process rather than just the V8 heap:
+    //   rss - heapTotal - external ~= native overhead (code, stacks, metadata)
+    const mem = process.memoryUsage();
+
+    logger.log(
+      `mcp-sessions live=${live} new=${created} closed=${closed} ` +
+        `abandoned>${Math.round(abandonedAfterMs / 60_000)}m=${abandoned} ` +
+        `rate=${ratePerHour}/h ${heapPart}` +
+        (perSessionKb === null ? '' : ` perSession~${perSessionKb}KB`) +
+        ` rss=${Math.round(mem.rss / MB)}MB heapTotal=${Math.round(
+          mem.heapTotal / MB
+        )}MB external=${Math.round(mem.external / MB)}MB`
+    );
+  }, intervalMs).unref();
+
+  const token = process.env.MCP_METRICS_TOKEN;
+  app.use('/mcp-metrics', (req: Request, res: Response) => {
+    if (!token || req.headers.authorization !== `Bearer ${token}`) {
+      res.sendStatus(404);
+      return;
+    }
+
+    if (req.query.gc && typeof global.gc === 'function') {
+      global.gc();
+    }
+
+    res.json(snapshot());
+  });
+};

--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -7,6 +7,7 @@ import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/o
 import { OAuthService } from '@gitroom/nestjs-libraries/database/prisma/oauth/oauth.service';
 import { runWithContext } from './async.storage';
 import { createOAuthMiddleware } from './oauth-middleware';
+import { startMcpMetrics } from './mcp.metrics';
 const fixAcceptHeader = (req: Request) => {
   const value = 'application/json, text/event-stream';
   req.headers.accept = value;
@@ -44,6 +45,8 @@ export const startMcp = async (app: INestApplication) => {
   };
 
   const server = new MCPServer(serverConfig);
+
+  startMcpMetrics(app, server);
 
   const oauthMiddleware = createOAuthMiddleware({
     oauth: {

--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -19,6 +19,20 @@ const fixAcceptHeader = (req: Request) => {
   }
 };
 
+// Session mode makes `@mastra/mcp` retain a transport, and a per-session server
+// holding the whole tool schema, for every `initialize` request -- released only
+// on an explicit client DELETE, which connectors never send. Stateless mode
+// serves each request with a transient server that is discarded afterwards.
+//
+// Nothing here depends on session state: auth is bound per request through
+// `runWithContext`, and no tool uses sampling, elicitation or notifications.
+const statelessMcp = process.env.MCP_STATELESS === 'true';
+
+const mcpHttpOptions: Parameters<MCPServer['startHTTP']>[0]['options'] =
+  statelessMcp
+    ? { serverless: true, enableJsonResponse: true }
+    : { sessionIdGenerator: () => randomUUID(), enableJsonResponse: true };
+
 export const startMcp = async (app: INestApplication) => {
   const mastraService = app.get(MastraService, { strict: false });
   const organizationService = app.get(OrganizationService, { strict: false });
@@ -121,12 +135,7 @@ export const startMcp = async (app: INestApplication) => {
       await server.startHTTP({
         url: url,
         httpPath: url.pathname,
-        options: {
-          sessionIdGenerator: () => {
-            return randomUUID();
-          },
-          enableJsonResponse: true,
-        },
+        options: mcpHttpOptions,
         req,
         res,
       });
@@ -173,12 +182,7 @@ export const startMcp = async (app: INestApplication) => {
       await server.startHTTP({
         url,
         httpPath: url.pathname,
-        options: {
-          sessionIdGenerator: () => {
-            return randomUUID();
-          },
-          enableJsonResponse: true,
-        },
+        options: mcpHttpOptions,
         req,
         res,
       });
@@ -218,12 +222,7 @@ export const startMcp = async (app: INestApplication) => {
         await server.startHTTP({
           url,
           httpPath: url.pathname,
-          options: {
-            sessionIdGenerator: () => {
-              return randomUUID();
-            },
-            enableJsonResponse: true,
-          },
+          options: mcpHttpOptions,
           req,
           res,
         });


### PR DESCRIPTION
> **Stacked on #1696.** Base is `chore/mcp-session-instrumentation`, so this cannot merge before the instrumentation PR does. GitHub retargets it to `main` automatically once #1696 lands.
>
> This commit is **self-contained** and does not depend on #1696. To ship it alone, `git rebase --onto main chore/mcp-session-instrumentation feat/mcp-stateless-transport` and open a fresh PR against `main` — verified to apply with zero conflicts and typecheck clean, with the commit content and message unchanged.

## Why

`@mastra/mcp` retains a transport per `initialize` request, each holding a per-session `Server` with the whole converted tool schema, released only on an explicit client `DELETE` that connectors never send. The MCP service climbs ~330 MB/h from a ~1 GB baseline and is killed at ~5 GB about twice a day.

Sessions hurt a second way. Any restart empties the map, and connected clients keep presenting a session id the new process has never seen. Mastra answers an unknown id with `400`, where [the spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management) requires `404` for a terminated session — and obliges the client to re-initialize on `404`. Clients get no recovery signal, so they hang until restarted, and each reconnect leaks another session.

The [2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) removes protocol-level sessions outright, so this has to go regardless.

## How

`serverless: true` routes `startHTTP` to `handleServerlessRequest`, which serves each request with a transient server and stores nothing. Applied to all three endpoints via one `mcpHttpOptions`, gated on `MCP_STATELESS=true` and **defaulting to today's session mode** — merging changes nothing until the variable is set.

Safe because nothing depends on session state: auth is bound per request through `runWithContext` (AsyncLocalStorage), and no tool uses sampling, elicitation, or server-initiated notifications.

## Reproduced (session mode)

| | |
|---|---|
| 1000 `initialize` vs bare MCPServer | 1000 transports retained, linear heap growth after forced GC |
| 200 `initialize` vs real backend | 200 sessions, **+15 MB** across a forced GC — ~76 KB each |
| One Claude Desktop connection | 4 sessions retained in 49 s |
| Tool calls on an open session | retain nothing — cost tracks **reconnects**, not traffic |
| Restart with Desktop attached | every call `400 Bad Request: No valid session ID`; fresh `initialize` returns 200; client never recovers |

## Validated (stateless)

| | |
|---|---|
| Same 200 `initialize` | **0 transports**, +1 MB heap |
| Real toolset | `tools/list`, `integrationList`, `integrationSchema`, `uploadFromUrlTool`, `integrationSchedulePostTool` identical; drafts same shape |
| Clients exercised | curl, `mcp-remote`, Claude Desktop |
| `initialize` | no longer returns `mcp-session-id` |
| `tools/list` without session id | 200 (session mode: 400) |
| Stale session id from a previous boot | ignored, served normally — the Desktop client stranded above **recovered mid-flight**, no reconnect, no re-adding the connector |

## Not related to the internal Postiz agent

The in-app agent never crosses this code. `copilot.controller.ts` runs `mastra.getAgent('postiz')` in-process via `@ag-ui/mastra`, calling plain `createTool` functions directly. It never sends `initialize`, never enters `startHTTP`, and cannot create or retain a session. No `MCPClient` exists anywhere in the repo.

Posts it creates are tagged `CreationMethod.MCP` only because `integration.schedule.post.ts` hardcodes that literal for any agent tool call — a naming artifact, not a code path. Only external clients (claude.ai, ChatGPT, `mcp-remote`) reach `startHTTP`, so only they leak, and only they are affected here.

## Rollout

Set `MCP_STATELESS=true` on the MCP service, confirm `live=0` in the `mcp-sessions` log line and a flat memory graph, then the backend service. Rollback is unsetting the variable.