### PR TITLE
feat(youtube): explain Shorts thumbnail caveat with a reusable info tooltip

### DIFF
--- a/apps/frontend/src/components/layout/top.tip.tsx
+++ b/apps/frontend/src/components/layout/top.tip.tsx
@@ -2,5 +2,10 @@
 
 import { Tooltip } from 'react-tooltip';
 export const ToolTip = () => {
-  return <Tooltip className="z-[200]" id="tooltip" />;
+  return (
+    <Tooltip
+      className="z-[200] !max-w-[320px] whitespace-normal break-words !text-[13px] !leading-snug"
+      id="tooltip"
+    />
+  );
 };

--- a/apps/frontend/src/components/media/media.component.tsx
+++ b/apps/frontend/src/components/media/media.component.tsx
@@ -885,7 +885,7 @@ export const MultiMediaComponent: FC<{
   );
 };
 export const MediaComponent: FC<{
-  label: string;
+  label: React.ReactNode;
   description: string;
   value?: {
     path: string;

--- a/apps/frontend/src/components/new-launch/providers/youtube/youtube.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/youtube/youtube.provider.tsx
@@ -12,6 +12,7 @@ import { MediumTags } from '@gitroom/frontend/components/new-launch/providers/me
 import { MediaComponent } from '@gitroom/frontend/components/media/media.component';
 import { Select } from '@gitroom/react/form/select';
 import { YoutubePreview } from '@gitroom/frontend/components/new-launch/providers/youtube/youtube.preview';
+import { InfoTooltip } from '@gitroom/frontend/components/ui/info.tooltip';
 const type = [
   {
     label: 'Public',
@@ -72,7 +73,12 @@ const YoutubeSettings: FC = () => {
           type="image"
           width={1280}
           height={720}
-          label="Thumbnail"
+          label={
+            <span className="flex items-center gap-[6px]">
+              Thumbnail
+              <InfoTooltip content="YouTube — not Postiz — decides if a video is a Short (vertical, up to 3 min). For Shorts, YouTube often ignores custom thumbnails and uses a video frame instead, without reporting an error — so a thumbnail here is best-effort. Custom thumbnails also need a verified channel and a JPEG or PNG under 2MB." />
+            </span>
+          }
           description="Thumbnail picture (optional)"
           {...register('thumbnail')}
         />

--- a/apps/frontend/src/components/ui/info.tooltip.tsx
+++ b/apps/frontend/src/components/ui/info.tooltip.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { FC } from 'react';
+import clsx from 'clsx';
+
+// Small circled "i" icon. Uses currentColor so it inherits the surrounding
+// text color and adapts to light/dark automatically.
+export const InfoIcon: FC<{ size?: number; className?: string }> = ({
+  size = 16,
+  className,
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    className={className}
+  >
+    <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.6" />
+    <path
+      d="M12 11v5"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+    />
+    <circle cx="12" cy="8" r="1" fill="currentColor" />
+  </svg>
+);
+
+// Reusable info "(i)" affordance that shows `content` in a tooltip on hover.
+// Wires into the global react-tooltip instance (<Tooltip id="tooltip" />,
+// mounted in layout/top.tip.tsx), so no extra provider is needed at call sites.
+// Use it next to any label, e.g.:
+//   <span className="flex items-center gap-[6px]">
+//     Thumbnail <InfoTooltip content="..." />
+//   </span>
+export const InfoTooltip: FC<{
+  content: string;
+  size?: number;
+  className?: string;
+}> = ({ content, size = 16, className }) => (
+  <span
+    data-tooltip-id="tooltip"
+    data-tooltip-content={content}
+    className={clsx(
+      'inline-flex items-center justify-center cursor-help opacity-60 hover:opacity-100 transition-opacity',
+      className
+    )}
+  >
+    <InfoIcon size={size} />
+  </span>
+);


### PR DESCRIPTION
## Problem

A user reported that thumbnails set on **YouTube Shorts don't propagate**. Importantly, **their posts don't fail** — the video publishes fine and no error is surfaced. The thumbnail just never appears.

Root cause is a YouTube platform limitation, not a Postiz bug: the Data API's `thumbnails.set` call **returns HTTP 200 success but is silently ignored** for videos YouTube classifies as Shorts — YouTube generates a thumbnail from a video frame instead. Postiz can't control whether a video becomes a Short: that's YouTube's decision based on **vertical aspect ratio + duration (≤ 3 min)**, and there is no API flag to opt in or out. So a custom thumbnail on a Short is inherently best-effort.

It also requires a **verified channel** and a **JPEG/PNG under 2 MB**, which isn't communicated anywhere in the UI.

## What this PR does

Adds an **"(i)" info tooltip** next to the YouTube **Thumbnail** setting explaining the Shorts caveat and the format/verification requirements, so users understand why a thumbnail may not show up.

- **New reusable `InfoTooltip` component** (`apps/frontend/src/components/ui/info.tooltip.tsx`) — a circled-"i" icon wired to the app's existing global `react-tooltip` instance (`<Tooltip id="tooltip" />`). Reusable from any file: `<InfoTooltip content="…" />`.
- **`MediaComponent.label`** widened from `string` → `ReactNode` (backward compatible — all existing string callers stay valid) so a label can carry the icon inline.
- **Global tooltip** (`top.tip.tsx`) given a `max-width` + wrapping so long content renders as a compact box instead of a screen-spanning bar. This is a *max*, so existing short tooltips are unaffected.

## Screenshot

Hovering the "(i)" next to **Thumbnail** shows a compact, wrapped tooltip:

> YouTube — not Postiz — decides if a video is a Short (vertical, up to 3 min). For Shorts, YouTube often ignores custom thumbnails and uses a video frame instead, without reporting an error — so a thumbnail here is best-effort. Custom thumbnails also need a verified channel and a JPEG or PNG under 2MB.

## References

- YouTube Data API — [Thumbnails: set](https://developers.google.com/youtube/v3/docs/thumbnails/set)
- Google Issue Tracker [#381127084](https://issuetracker.google.com/issues/381127084) — custom thumbnails ignored on Shorts (see the **July 2026** comment confirming the API accepts the request but the thumbnail isn't applied to Shorts)
- Community tool documenting the workaround/constraints (1280×720, < 2 MB, center-crop on small devices): [jbreed/yt-thumbnail-upload](https://github.com/jbreed/yt-thumbnail-upload)

## Notes / follow-up

This PR is UI-only (sets expectations). A separate follow-up should make the **server-side thumbnail step best-effort** in `youtube.provider.ts` — today, when the API *does* actively reject a thumbnail (bad format/size, unverified account), it throws `BadBody` *after* the video is already published, marking the whole post failed (and risking a duplicate re-upload). That path should return `success` with the video's `postId` + a warning instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)