### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@
 
 To have the project up and running, please follow the [Quick Start Guide](https://docs.postiz.com/quickstart)
 
+Prefer a managed instance with no server to run? One-click deploy Postiz on Zenith:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/postiz)
+
 ## Sponsor Postiz
 
 We now give a few options to Sponsor Postiz:


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
Postiz to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Quick Start
(links to https://zenith.hosting/host/postiz).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

---

# What kind of change does this PR introduce?

Docs update: adds a one-click "Deploy with Zenith" managed-hosting badge to the Quick Start section of the README.

# Why was this change needed?

Postiz is now in the Zenith Hosting marketplace, so self-hosters who would rather use a managed instance (no server to run) have a one-click deploy path.

# Other information:

Docs-only, additions-only, one file (README.md). Full disclosure: this PR was AI-assisted. I have left the CLA and AI checklist boxes unchecked for the maintainers/author to handle honestly rather than tick them myself.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue
