### PR TITLE
fix: scope post mutations to organization

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,25 @@
-import { getJestProjects } from '@nx/jest';
-
 export default {
-  projects: getJestProjects(),
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/**/*.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          isolatedModules: true,
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^@gitroom/backend/(.*)$': '<rootDir>/apps/backend/src/$1',
+    '^@gitroom/frontend/(.*)$': '<rootDir>/apps/frontend/src/$1',
+    '^@gitroom/helpers/(.*)$': '<rootDir>/libraries/helpers/src/$1',
+    '^@gitroom/nestjs-libraries/(.*)$':
+      '<rootDir>/libraries/nestjs-libraries/src/$1',
+    '^@gitroom/react/(.*)$':
+      '<rootDir>/libraries/react-shared-libraries/src/$1',
+    '^@gitroom/orchestrator/(.*)$': '<rootDir>/apps/orchestrator/src/$1',
+    '^@gitroom/extension/(.*)$': '<rootDir>/apps/extension/src/$1',
+  },
 };

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.spec.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.spec.ts
@@ -1,0 +1,140 @@
+import { PostsRepository } from './posts.repository';
+
+describe('PostsRepository', () => {
+  const postModel = {
+    create: jest.fn(),
+    update: jest.fn(),
+    findFirst: jest.fn(),
+    updateMany: jest.fn(),
+  };
+  const commentsModel = {
+    create: jest.fn(),
+  };
+  const tagsModel = {
+    update: jest.fn(),
+    findMany: jest.fn(),
+  };
+  const tagsPostsModel = {
+    deleteMany: jest.fn(),
+  };
+
+  const repository = new PostsRepository(
+    { model: { post: postModel } } as any,
+    { model: { popularPosts: {} } } as any,
+    { model: { comments: commentsModel } } as any,
+    { model: { tags: tagsModel } } as any,
+    { model: { tagsPosts: tagsPostsModel } } as any,
+    { model: { errors: {} } } as any
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes post and group updates to the organization', async () => {
+    postModel.update.mockResolvedValue({ id: 'post-1' });
+    postModel.findFirst.mockResolvedValue({ id: 'previous-post' });
+    postModel.updateMany.mockResolvedValue({ count: 1 });
+    tagsPostsModel.deleteMany.mockResolvedValue({ count: 0 });
+
+    await repository.createOrUpdatePost(
+      'update',
+      'org-1',
+      '2026-07-13T10:00:00.000Z',
+      {
+        integration: { id: 'integration-1' },
+        value: [
+          {
+            id: 'post-1',
+            content: 'Updated post',
+            image: [],
+            delay: 0,
+          },
+        ],
+        settings: {},
+        group: 'group-1',
+      } as any,
+      [],
+      'WEB'
+    );
+
+    expect(postModel.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'post-1',
+          organizationId: 'org-1',
+        },
+      })
+    );
+    expect(postModel.findFirst).toHaveBeenCalledWith({
+      where: {
+        group: 'group-1',
+        organizationId: 'org-1',
+        deletedAt: null,
+        parentPostId: null,
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(postModel.updateMany).toHaveBeenCalledWith({
+      where: {
+        group: 'group-1',
+        organizationId: 'org-1',
+        deletedAt: null,
+      },
+      data: {
+        parentPostId: null,
+        deletedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it('scopes tag edits to the organization', async () => {
+    tagsModel.update.mockResolvedValue({ id: 'tag-1' });
+
+    await repository.editTag('tag-1', 'org-1', {
+      name: 'Product',
+      color: '#ffffff',
+    });
+
+    expect(tagsModel.update).toHaveBeenCalledWith({
+      where: {
+        id: 'tag-1',
+        orgId: 'org-1',
+      },
+      data: {
+        name: 'Product',
+        color: '#ffffff',
+      },
+    });
+  });
+
+  it('connects comments only to posts in the organization', async () => {
+    commentsModel.create.mockResolvedValue({ id: 'comment-1' });
+
+    await repository.createComment('org-1', 'user-1', 'post-1', 'Looks good');
+
+    expect(commentsModel.create).toHaveBeenCalledWith({
+      data: {
+        content: 'Looks good',
+        organization: {
+          connect: {
+            id: 'org-1',
+          },
+        },
+        user: {
+          connect: {
+            id: 'user-1',
+          },
+        },
+        post: {
+          connect: {
+            id: 'post-1',
+            organizationId: 'org-1',
+          },
+        },
+      },
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -568,21 +568,25 @@ export class PostsRepository {
       });
 
       posts.push(
-        await this._post.model.post.upsert({
-          where: {
-            id: value.id || uuidv4(),
-          },
-          create: { ...updateData('create') },
-          update: {
-            ...updateData('update'),
-            lastMessage: {
-              disconnect: true,
-            },
-            submittedForOrder: {
-              disconnect: true,
-            },
-          },
-        })
+        value.id
+          ? await this._post.model.post.update({
+              where: {
+                id: value.id,
+                organizationId: orgId,
+              },
+              data: {
+                ...updateData('update'),
+                lastMessage: {
+                  disconnect: true,
+                },
+                submittedForOrder: {
+                  disconnect: true,
+                },
+              },
+            })
+          : await this._post.model.post.create({
+              data: { ...updateData('create') },
+            })
       );
 
       if (posts.length === 1) {
@@ -590,6 +594,7 @@ export class PostsRepository {
           where: {
             post: {
               id: posts[0].id,
+              organizationId: orgId,
             },
           },
         });
@@ -608,6 +613,7 @@ export class PostsRepository {
             await this._post.model.post.update({
               where: {
                 id: posts[posts.length - 1].id,
+                organizationId: orgId,
               },
               data: {
                 tags: {
@@ -629,6 +635,7 @@ export class PostsRepository {
           await this._post.model.post.findFirst({
             where: {
               group: body.group,
+              organizationId: orgId,
               deletedAt: null,
               parentPostId: null,
             },
@@ -643,6 +650,7 @@ export class PostsRepository {
       await this._post.model.post.updateMany({
         where: {
           group: body.group,
+          organizationId: orgId,
           deletedAt: null,
         },
         data: {
@@ -830,6 +838,7 @@ export class PostsRepository {
     return this._tags.model.tags.update({
       where: {
         id,
+        orgId,
       },
       data: {
         name: body.name,
@@ -858,10 +867,23 @@ export class PostsRepository {
   ) {
     return this._comments.model.comments.create({
       data: {
-        organizationId: orgId,
-        userId,
-        postId,
         content,
+        organization: {
+          connect: {
+            id: orgId,
+          },
+        },
+        user: {
+          connect: {
+            id: userId,
+          },
+        },
+        post: {
+          connect: {
+            id: postId,
+            organizationId: orgId,
+          },
+        },
       },
     });
   }


### PR DESCRIPTION
# What kind of change does this PR introduce?

  Bug fix and tenant-isolation hardening.

  # Why was this change needed?

  Several post-related mutations accepted identifiers from the request but did not
  consistently include the authenticated organization in their database filters.

  The main path was:

  1. `POST /posts` accepted optional post IDs and group IDs.
  2. `PostsService` validated the selected integration but not ownership of those
  identifiers.
  3. `PostsRepository` updated posts by ID and replaced groups by group ID without
  an organization constraint.

  The same underlying issue affected tag edits and comment-to-post connections.

  This meant a caller who knew an identifier belonging to another organization
  could potentially mutate that organization’s data.

  # What changed?

  - Existing posts are now updated using both `id` and `organizationId`.
  - New posts use an explicit create path instead of sharing an unscoped upsert
  path.
  - Previous post-group lookups and soft deletion are scoped by organization.
  - Tag edits and tag relationship cleanup are scoped by organization.
  - Comments connect to a post using both the post ID and organization ID.
  - Added repository regression tests covering post/group updates, tag edits, and
  comment creation.
  - Updated the root Jest configuration to discover and execute the repository’s
  TypeScript specs.

  # Testing

  - `pnpm test --runInBand`
  - `pnpm run build`
  - `pnpm run build:backend`
  - Prettier check on all changed files

  All tests and production builds pass.

  # Review notes / questions

  I’d especially appreciate feedback on two points:

  1. Is relying on Prisma’s existing “record not found” behavior for foreign-
  organization identifiers consistent with the API’s desired response semantics, or
  would maintainers prefer an explicit `BadRequestException`?
  2. Is the standalone `ts-jest` root configuration the preferred direction now
  that the repository has tests, or is there an intended Nx project layout that
  should be restored instead?

  I kept transaction/atomicity improvements out of this PR so it remains focused on
  tenant isolation.