### PR TITLE
fix(tiktok): stop posts silently landing in the TikTok inbox instead of publishing

### DIFF
--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/tiktok.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/tiktok.dto.ts
@@ -1,6 +1,7 @@
 import {
   IsBoolean, ValidateIf, IsIn, IsString, MaxLength, IsOptional
 } from 'class-validator';
+import { JSONSchema } from 'class-validator-jsonschema';
 
 export class TikTokDto {
   @ValidateIf((p) => p.title)
@@ -44,5 +45,12 @@ export class TikTokDto {
 
   @IsIn(['DIRECT_POST', 'UPLOAD'])
   @IsString()
+  @JSONSchema({
+    description:
+      'Required. Use "DIRECT_POST" to actually publish the post to TikTok. ' +
+      '"UPLOAD" does NOT publish: it only sends the media to the user\'s TikTok app inbox, ' +
+      'where they must manually finish and publish it within 24 hours or it is discarded. ' +
+      'Only use "UPLOAD" when the user explicitly asks to review or edit the post inside the TikTok app before publishing.',
+  })
   content_posting_method: 'DIRECT_POST' | 'UPLOAD';
 }

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -19,7 +19,9 @@ import { Integration } from '@prisma/client';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
 @Rules(
-  'TikTok can have one video or one picture or multiple pictures, it cannot be without an attachment'
+  'TikTok can have one video or one picture or multiple pictures, it cannot be without an attachment. ' +
+    'For the "content_posting_method" setting always use "DIRECT_POST" unless the user explicitly asks to review or edit the post inside the TikTok app before publishing. ' +
+    '"UPLOAD" does NOT publish the post: it only sends it to the user\'s TikTok app inbox, where they must manually complete it within 24 hours or it is discarded.'
 )
 export class TiktokProvider extends SocialAbstract implements SocialProvider {
   identifier = 'tiktok';

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -478,6 +478,18 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     );
   }
 
+  // UPLOAD does not publish - it only drops the media into the user's TikTok
+  // inbox - so only an explicit UPLOAD selects it. A missing value (drafts, or
+  // any caller that skipped the setting) publishes instead of silently landing
+  // in the inbox.
+  private contentPostingMethod(
+    firstPost: PostDetails<TikTokDto>
+  ): TikTokDto['content_posting_method'] {
+    return firstPost?.settings?.content_posting_method === 'UPLOAD'
+      ? 'UPLOAD'
+      : 'DIRECT_POST';
+  }
+
   private postingMethod(
     method: TikTokDto['content_posting_method'],
     isPhoto: boolean
@@ -493,7 +505,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
   private buildTikokPostInfoBody(firstPost: PostDetails<TikTokDto>) {
     const isPhoto = !hasExtension(firstPost?.media?.[0]?.path, 'mp4');
-    const method = firstPost?.settings?.content_posting_method;
+    const method = this.contentPostingMethod(firstPost);
 
     if (method === 'DIRECT_POST') {
       return {
@@ -750,7 +762,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     if (isPhoto) {
       return {
         post_mode:
-          firstPost?.settings?.content_posting_method === 'DIRECT_POST'
+          this.contentPostingMethod(firstPost) === 'DIRECT_POST'
             ? 'DIRECT_POST'
             : 'MEDIA_UPLOAD',
         media_type: 'PHOTO',
@@ -796,7 +808,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     } = await (
       await this.fetch(
         `https://open.tiktokapis.com/v2/post/publish${this.postingMethod(
-          firstPost.settings.content_posting_method,
+          this.contentPostingMethod(firstPost),
           isPhoto
         )}`,
         {


### PR DESCRIPTION
## Problem

Scheduled TikTok posts were being marked **successful** in Postiz and Temporal but never published. The `postSocial` activity returned `postId: "missing"` with a `tiktok.com/messages` release URL.

Root cause: the post had `content_posting_method: "UPLOAD"` instead of `DIRECT_POST`. `UPLOAD` does **not** publish — TikTok's API delivers the video to the account's **app inbox**, where the user must manually complete it within ~24h or it's discarded. This is TikTok's `SEND_TO_USER_INBOX` terminal status, which we (correctly) treat as a successful upload.

Why the agent chose `UPLOAD`: the chat/MCP agent had to supply `content_posting_method` with **no guidance** — it's a bare required enum (`'DIRECT_POST' | 'UPLOAD'`) with no description, and TikTok's agent `@Rules` said nothing about it. For a video post, "UPLOAD" reads like the obvious choice. The user never asked for it; the model guessed.

## Fix

**1. `@Rules` guidance** (`tiktok.provider.ts`) — the agent is now told to use `DIRECT_POST` unless the user explicitly asks to review/edit inside the TikTok app first, and that `UPLOAD` does not publish.

**2. Schema description** (`tiktok.dto.ts`) — `@JSONSchema({ description })` explains, on the field itself, that `UPLOAD` never publishes. It's metadata only: it registers no validator, so `@IsIn([...])` still rejects a missing or invalid value and **the field remains required**.

Both are prose the model reads *before* it picks a value, which is the only thing that helps here — the field is required, so the model always sends *something*, and no server-side default can rescue an explicit `UPLOAD`. They reach different populations:

| Consumer | Reached by |
|---|---|
| Internal web agent + external MCP agents | `@Rules` (via `integrationSchema`) and the field description |
| Public API caller that reads `rules` from `GET /public/v1/integration-settings/:id` | `@Rules` |
| Public API caller that reads only the settings schema | `@JSONSchema` description |

The dashboard is unaffected — its React form hardcodes `DIRECT_POST`.

**3. Consistent handling of a missing value** (`tiktok.provider.ts`) — while fixing the above it turned out the three places that read `content_posting_method` disagreed about what an *absent* value means:

| Site | Absent value meant |
|---|---|
| `postingMethod()` | `DIRECT_POST` — its `switch` already has `case 'DIRECT_POST': default:` |
| `buildTikokPostInfoBody()` | inbox-shaped body, **no `privacy_level`** |
| `buildTikokSourceInfoBody()` | photo `post_mode: 'MEDIA_UPLOAD'` — the app inbox |

Net effect: a **photo** with no method silently went to the inbox, and a **video** with no method hit the *publish* endpoint with a body missing `privacy_level`, which TikTok rejects. Normalized in one `contentPostingMethod()` helper — only an explicit `UPLOAD` selects the inbox flow, everything else publishes — used at all three sites, so the video endpoint's existing default is now the behavior of the whole publish path.

Settings validation already keeps a missing value out of the publish path for normal posts (the field is required in `TikTokDto`, validated with `skipMissingProperties: false`), so this is the belt-and-braces layer for anything that bypasses it: drafts, older rows, direct repository writes.

## Testing

- Reproduced and verified live over MCP on a test channel.
- Drove the three body/endpoint builders with photo and video posts, method present and absent: **absent now matches `DIRECT_POST` exactly** (endpoint, `post_info.privacy_level`, `post_mode`), and explicit `UPLOAD` is unchanged. Before the change, absent gave `MEDIA_UPLOAD` for photos and a `privacy_level`-less direct body for videos.
- Generated-schema check on `TikTokDto`: `description` present, `enum` unchanged, `content_posting_method` still listed in `required`.
- Typechecks (backend) — the 6 remaining errors in `nestjs-libraries` are pre-existing and unrelated (mastodon, media repository, track service).

## Not covered here

Two other copies of this enum are documented outside this repo and are unreachable from a backend change. Both are being fixed separately:

- `gitroomhq/postiz-docs` — `public-api/providers/tiktok.mdx` describes `UPLOAD` as "Upload for manual posting"; `public-api/openapi.json` has a bare enum with no description. (Hand-maintained, not generated.)
- `gitroomhq/postiz-agent` — the skill bundles its own `PROVIDER_SETTINGS.md`, which lists the enum with no explanation. Skill runs read that file rather than calling `integrations:settings`, so no backend fix reaches them.

## Notes

Supersedes #1687, which could not take the rewritten history (force-push is blocked on that branch). The earlier version of this fix also added a `PROVIDER_SETTINGS_DEFAULTS` map to `integration.schedule.post.ts` that filled an omitted `content_posting_method`; it has been dropped. It put a TikTok-specific value in a generic tools file, it only applied on the MCP path (so the same payload behaved differently through MCP than through the public API), and it was redundant — the field is required, so an omitted key is rejected by validation rather than falling through to `UPLOAD`. The provider-level normalization above covers the same ground where it actually matters, at publish time.

First of two related changes. A follow-up feature branch (agent list/update of scheduled posts) stacks on this one and will be opened as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
