### PR TITLE
chore(worker): read-only memory probe to locate the orchestrator's RSS growth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,3 +131,12 @@ POSTIZ_OAUTH_CLIENT_SECRET=""
 # LINK_DRIP_API_KEY="" # Your LinkDrip API key
 # LINK_DRIP_API_ENDPOINT="https://api.linkdrip.com/v1/" # Your self-hosted LinkDrip API endpoint
 # LINK_DRIP_SHORT_LINK_DOMAIN="dripl.ink" # Your self-hosted LinkDrip domain
+
+# Memory Probe (diagnostics; OFF by default)
+# Logs one `[mem]` line per interval with the process's memory split, to find
+# where the orchestrator's RSS growth actually lives. Read-only: it changes no
+# behaviour. Runs once per PROCESS (one per container), not per Temporal worker.
+# See docs/worker-memory-probe.md for how to read the output.
+# MEMORY_PROBE="true"                # required to enable; anything else = off
+# MEMORY_PROBE_SERVICE="worker-1"    # optional; tags each line. Defaults to RAILWAY_SERVICE_NAME
+# MEMORY_PROBE_INTERVAL_MS="900000"  # optional; default 900000 (15 min). A sample costs ~140ms, so don't go below 60000

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -17,6 +17,7 @@ import { AppModule } from './app.module';
 import { SubscriptionExceptionFilter } from '@gitroom/backend/services/auth/permissions/subscription.exception';
 import { PostValidationExceptionFilter } from '@gitroom/backend/api/routes/posts.validation.exception';
 import { HttpExceptionFilter } from '@gitroom/nestjs-libraries/services/exception.filter';
+import { startMemoryProbe } from '@gitroom/nestjs-libraries/telemetry/memory.probe';
 import { ConfigurationChecker } from '@gitroom/helpers/configuration/configuration.checker';
 import { startMcp } from '@gitroom/nestjs-libraries/chat/start.mcp';
 
@@ -73,6 +74,16 @@ async function start() {
   try {
     await app.listen(port);
     console.log('Backend started successfully on port ' + port);
+
+    if (process.env.MEMORY_PROBE === 'true') {
+      const interval = Number(process.env.MEMORY_PROBE_INTERVAL_MS);
+      startMemoryProbe(
+        process.env.MEMORY_PROBE_SERVICE ||
+          process.env.RAILWAY_SERVICE_NAME ||
+          'backend',
+        interval > 0 ? interval : undefined
+      );
+    }
 
     checkConfiguration(); // Do this last, so that users will see obvious issues at the end of the startup log without having to scroll up.
 

--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -7,6 +7,7 @@ dayjs.extend(utc);
 
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from '@gitroom/orchestrator/app.module';
+import { startMemoryProbe } from '@gitroom/nestjs-libraries/telemetry/memory.probe';
 import * as dns from 'node:dns';
 dns.setDefaultResultOrder('ipv4first');
 
@@ -16,6 +17,19 @@ async function bootstrap() {
   const port = process.env.ORCHESTRATOR_PORT || 3002;
   await app.listen(port);
   console.log(`Orchestrator health check listening on port ${port}`);
+
+  // One probe per PROCESS (not per Temporal Worker — the ~33 Workers share this
+  // process's heap and RSS). Railway names the service for us, so the tag is
+  // right even if MEMORY_PROBE_SERVICE is never set.
+  if (process.env.MEMORY_PROBE === 'true') {
+    const interval = Number(process.env.MEMORY_PROBE_INTERVAL_MS);
+    startMemoryProbe(
+      process.env.MEMORY_PROBE_SERVICE ||
+        process.env.RAILWAY_SERVICE_NAME ||
+        'orchestrator',
+      interval > 0 ? interval : undefined
+    );
+  }
 }
 
 

--- a/docs/worker-memory-probe.md
+++ b/docs/worker-memory-probe.md
@@ -1,0 +1,260 @@
+# Worker memory probe
+
+Read-only instrumentation to find out **where** the Worker (orchestrator)
+container's memory actually lives. It changes no behaviour: it logs one line a
+minute and nothing else.
+
+## Why
+
+Railway shows the Worker stepping 5 → 15 GB, then 16.6 → 18.3 GB, and Worker 2
+climbing to 22.6 GB before dropping to 7.8 GB (probably a kernel OOM kill). The
+steps are fast, permanent, and happen at **0.2–0.8 vCPU** — something grabs many
+gigabytes while doing almost no work, and never gives them back.
+
+Several mutually exclusive explanations fit the RSS graph equally well, and no
+amount of further log-reading distinguishes them. This probe does, in one
+number.
+
+## The number that matters
+
+```
+native = rss - jsHeap(ALL isolates) - external
+```
+
+`rss` is what the cgroup limit is enforced against and what OOM-kills the
+container, but it is a total — it cannot say *which* allocator holds the pages.
+Splitting it can.
+
+### Why `jsHeap` must count every thread (a bug this probe used to have)
+
+`process.memoryUsage().heapUsed` reports the **current isolate only** — the main
+thread. Temporal runs workflows in `worker_threads`, each with its own V8
+isolate, and the orchestrator registers ~30 Temporal Workers.
+
+Measured: **a worker thread allocating 312 MB moved main-thread `heapUsed` by
+0 MB.** All 312 MB appeared in `native`.
+
+So the naive `rss - heapUsed - external` silently lumps the *workflow threads'
+heaps* in with *Temporal core's Rust buffers* — and those two have completely
+different fixes (bound `maxCachedWorkflows` vs cap activity admission). The
+probe therefore sums every isolate via `process.report.getReport().workers[]`
+(~25–38 ms with 30 threads; negligible once a minute) and reports:
+
+- `jsHeapMain` — the main isolate
+- `jsHeapThreads` — **the workflow threads**, where the sticky workflow cache lives
+- `jsHeap` — the sum, which is what `native` subtracts
+- `threads` — isolate count, so the above can be sanity-checked
+
+## Result → conclusion
+
+Run for at least one full `:00` scheduled-post burst (ideally 24h, to catch a
+step). Then:
+
+| What climbs during a `:00` burst | Conclusion | Next action |
+| --- | --- | --- |
+| **`native` climbs; `jsHeap`, `external`, `arrayBuffers` stay flat** | Memory is in **Temporal core's Rust buffers** — admitted activity-task payloads. The worker is pulling the whole backlog into RAM instead of leaving it in the Temporal server. Confirms the leading hypothesis; rules out every JS-side theory. | Cap the `main` queue: it has `maxConcurrentActivityTaskExecutions: 1000000` (`temporal.module.ts:41,75`) and `WORKER_CONCURRENCY_DIVIDER` is never applied to it. |
+| **`jsHeapThreads` climbs** | Memory is the **Temporal sticky workflow cache** (it lives in the workflow threads' isolates). **The old probe would have mislabelled this as `native` and sent you to cap the wrong thing.** | Set an explicit `maxCachedWorkflows` — the default is ~1082 *per Worker*, each computed as if it owned the machine. |
+| **`external` / `arrayBuffers` climb with RSS** | Memory is **Buffers** — media downloads or `sharp`/`convertToJPEG`. The leading hypothesis is wrong. | Per-queue media caps, a global media-buffer semaphore, and move `convertToJPEG` (`posts.service.ts:378-405`) to ingest time. |
+| **`jsHeapMain` climbs** | Memory is the **main isolate** — retained activity contexts / payloads on the Nest side. | Heap snapshot; hunt retained references. |
+| **Everything falls back after the burst, but `rss` stays high** | **Allocator high-water mark.** glibc is not returning freed pages. This is what turns a transient spike into a permanent floor and eventually into the OOM kill. | Set `MALLOC_ARENA_MAX=2` and `MALLOC_MMAP_THRESHOLD_=131072` as Railway variables (no code change). |
+| **`rss` climbs steadily with no burst and never falls** | A genuine **leak**, not burst-driven. Nothing in `context.md` explains this shape for the Worker. | Heap snapshot with `--heapsnapshot-near-heap-limit=1`; restart the investigation. |
+
+Rows 1 and 5 are **not exclusive** — the likeliest real answer is both at once:
+core admits far too much work, and glibc never gives the memory back afterwards.
+
+## Caveats when reading the output
+
+- **`native` is meaningless on macOS.** macOS under-reports RSS (memory
+  compression), so `heapUsed` can exceed `rss` and `native` goes negative. The
+  probe flags this with `rss=UNRELIABLE(negative-native;macOS?)`. It should
+  never appear on Linux/Railway. Local runs are still useful for the *heap*
+  numbers, just not for `native`.
+- **`threadScan=FAILED`** means the per-isolate scan threw and `jsHeap` is
+  main-thread only — treat `native` as inflated by the workflow threads' heaps.
+- **`heapLimit` is per isolate**, not a process-wide ceiling. See below.
+
+## Enabling
+
+Railway service variables, on the Worker (and optionally the Backend, which has
+its own separate MCP-session leak):
+
+```
+MEMORY_PROBE=true
+MEMORY_PROBE_SERVICE=worker-1     # or worker-2 / backend — tags each line
+MEMORY_PROBE_INTERVAL_MS=1800000  # optional; default is 15 min
+```
+
+Off unless `MEMORY_PROBE=true`. Requires a redeploy to take effect — which
+resets RSS, so allow a full day before drawing conclusions.
+
+### Why 15 minutes (not 60s)
+
+- **Cost.** A sample costs **~140 ms with 34 isolates**, because
+  `process.report.getReport()` walks every worker thread. That is an event-loop
+  block on the orchestrator's main thread. At 15 min it is **0.016%** of
+  wall-clock; at 60 s it would be 0.23%. There is no reason to pay 15× for
+  resolution we do not need.
+- **Resolution.** We are chasing a memory **step** that then plateaus for
+  **hours** (5 → 15 GB, then flat for 14 h). 15 min places a step against a
+  `:00` posting burst comfortably — and it makes a 25,000-line log export span
+  **weeks** instead of a day.
+
+Set `MEMORY_PROBE_INTERVAL_MS=30000` to watch it live locally. Don't go below
+~60 s in production.
+
+## Container test (2026-07-13) — VERIFIED against Railway's base image
+
+**This module** (compiled with the repo's flags), run in `node:22.20-bookworm-slim`
+under a real cgroup v2 memory limit — as close to Railway as we can get locally.
+No database or Temporal server needed: 33 worker threads stand in for the
+Temporal workflow threads.
+
+```bash
+export PATH="/Applications/Docker.app/Contents/Resources/bin:$PATH"
+
+# compile this module with the same flags the orchestrator builds with
+npx tsc libraries/nestjs-libraries/src/telemetry/memory.probe.ts \
+  --outDir /tmp/probe --module commonjs --target ES2022 --esModuleInterop \
+  --skipLibCheck --types node
+
+# harness.js: require('./memory.probe.js'), startMemoryProbe(), spawn 33 Workers
+docker run --rm --memory=8g -v /tmp/probe:/app:ro -w /app \
+  node:22.20-bookworm-slim node harness.js
+```
+
+Results (the real module, not a replica):
+
+```
+[mem] probe started service=orchestrator interval=2000ms cgroupLimit=8192MB heapLimit=2096MB (per isolate) nodeOptions=null
+[mem] service=orchestrator rss=43  jsHeap=4   jsHeapMain=4 jsHeapThreads=0   threads=1  external=2 native=37  heapLimit=2096
+[mem] service=orchestrator rss=464 jsHeap=250 jsHeapMain=5 jsHeapThreads=246 threads=34 external=2 native=212 heapLimit=2096
+```
+
+| Check | Result |
+| --- | --- |
+| cgroup limit read | ✅ `8192MB` — the `/sys/fs/cgroup` path works on cgroup v2 |
+| `native` sign | ✅ positive (the negative-`native` macOS artifact does not occur on Linux) |
+| isolate count | ✅ `threads=34`, and `jsHeapThreads` correctly attributes the 33 threads' heaps |
+| probe cost | ⚠️ **~140 ms** with 34 isolates — ~4× the macOS figure. At a 60 s interval that is 0.23% of wall-clock and far below any Temporal timeout, but it **is** an event-loop block. **Do not lower the interval below 60 s.** |
+
+Separately verified: `process.report.getReport()` does **not** block on busy
+worker threads (20–25 ms even with threads spinning in tight CPU loops), so the
+probe cannot stall the orchestrator.
+
+### The heap limit is ~2 GB regardless of container size
+
+| Container | `heap_size_limit` per isolate | default `maxCachedWorkflows` |
+| --- | --- | --- |
+| 4 GB | 2096 MB | 1110 |
+| 16 GB | 2096 MB | 1110 |
+| 24 GB | 2096 MB | 1110 |
+
+Node caps the V8 heap at ~2 GB for any large container. **Worker threads get the
+same 2096 MB** (Temporal passes no `resourceLimits`). The `4144 MB` seen on a Mac
+is an artifact of running uncontainerized — ignore it.
+
+**This bounds the whole JS heap at ~5 GB** (main thread 2096 + `main`'s workflow
+thread 2096 + 32 idle threads ≈ 960), and exceeding any isolate would print a V8
+`FATAL`, which production never shows. So the 18 GB **cannot** be JS heap — it is
+native. See `context.md` → "READ THIS FIRST".
+
+## Platform compatibility (checked 2026-07-13)
+
+- **`process.memoryUsage()` and `v8.getHeapStatistics()`** are plain Node APIs
+  with no special privileges. They work in any container or microVM and Railway
+  cannot restrict them. The only Node restriction found for Railway is the
+  `--expose-gc` **CLI flag**, which this probe does not use.
+- **The `/sys/fs/cgroup` read is best-effort and never throws.** It handles
+  cgroup v2 namespaced, cgroup v2 *not* namespaced (resolving the nested path
+  from `/proc/self/cgroup` and walking up), and cgroup v1 — and returns
+  `unknown` if none are readable. On macOS it logs `cgroupLimit=unknown`, which
+  is expected, not a failure. **Not yet verified against a real Linux container**
+  (no Docker on the dev machine); if it prints `unknown` on Railway, the probe
+  still works — only the ceiling figure is missing, and that can be read off the
+  Railway dashboard instead.
+
+## Watch `heapLimit` on the first deployed line
+
+`context.md` asserts that with `NODE_OPTIONS` unset, Node 22 caps the V8 heap at
+**~2 GB** in a large container, and that claim has been used to argue "18 GB of
+RSS cannot be heap." **It has never been verified on Railway, and it is already
+shaky**: on the (uncontainerized) dev machine V8 chose a **4144 MB** limit, not
+2048 MB.
+
+Combined with the fact that `heapLimit` is **per isolate** and the orchestrator
+runs ~30 Temporal Workers, the total heap ceiling across the process is far
+higher than the "2 GB" the earlier reasoning relied on. The first `[mem] probe
+started` line on Railway settles the actual number. Read it before trusting any
+argument that depends on it.
+
+## Where it runs, and how much it logs
+
+**One probe per PROCESS**, started from `main.ts` after `app.listen()`.
+
+"Worker" is ambiguous in this system — the probe runs per *container*, not per
+Temporal Worker:
+
+| "Worker" | Count | One probe each? |
+| --- | --- | --- |
+| Railway **Worker service** = a container running the orchestrator | 2 (worker 1, worker 2) | ✅ yes |
+| Temporal **`Worker`** = an in-process task-queue poller | **33 per container** | ❌ no |
+
+A per-Temporal-Worker probe would be meaningless: all 33 share one process, one
+RSS, one set of isolates. The probe measures the **whole process** (`rss` is
+process-wide; `jsHeap` sums all 34 isolates).
+
+**Volume at the 15-minute default: 96 lines/day per process**, plus one
+`probe started` banner at boot.
+
+| Enabled on | Lines/day |
+| --- | --- |
+| both orchestrator containers | 192 |
+| + backend | 288 |
+
+Trivial against a 25,000-line export — which will now span **weeks**.
+
+### Every line identifies its own process
+
+```
+[mem] service=worker pid=1 replica=1a2b3c4d rss=… jsHeap=… …
+```
+
+- `service` — from `MEMORY_PROBE_SERVICE`, falling back to Railway's own
+  `RAILWAY_SERVICE_NAME`, so the tag is right even if you never set it.
+- `replica` — first 8 chars of `RAILWAY_REPLICA_ID`. **This matters:** a Railway
+  service can run several replicas and they all share the same env vars, so
+  `service` alone cannot tell them apart. We still do not know whether the Jul 9
+  memory cliff was the whole service dying or one replica — this is how you find
+  out.
+- `pid` — fallback identity anywhere Railway's vars are absent.
+
+## Reading the output
+
+Every line is prefixed `[mem]`, so it greps cleanly out of a 25,000-line export:
+
+```
+[mem] probe started service=worker-1 interval=60000ms cgroupLimit=32768MB heapLimit=2048MB (per isolate) nodeOptions=null
+[mem] service=worker-1 rss=4821 jsHeap=1204 jsHeapMain=612 jsHeapThreads=592 threads=31 external=143 arrayBuffers=38 native=3474 heapLimit=2048
+```
+
+All values are MB. `cgroupLimit` is read from the cgroup and answers a still-open
+question: what the Worker's real ceiling is (Worker 2 peaked at 22.62 GB — if the
+limit is 24 GB, that was the ceiling).
+
+Watch **`native` vs `jsHeapThreads`** across a `:00` burst. That is the
+experiment, and the distinction between them is the whole point.
+
+## Baseline data point (local dev, idle, 2026-07-13)
+
+```
+[mem] service=orchestrator rss=1797 heapUsed=546 heapTotal=647 external=60 arrayBuffers=43 native=1191
+```
+
+At **idle**, at boot, doing no work: RSS 1797 MB, of which 1191 MB (66%) was
+neither main-thread JS heap nor Buffers. This was taken with the *old* probe, so
+that 1191 MB includes the ~30 workflow threads' isolates — which is precisely the
+ambiguity the current probe resolves. Re-take this baseline with the new build
+before drawing conclusions.
+
+The local echo of production's 3–5 GB idle baseline is real either way: ~30
+Temporal Workers in one process is not free.

--- a/libraries/nestjs-libraries/src/telemetry/memory.probe.ts
+++ b/libraries/nestjs-libraries/src/telemetry/memory.probe.ts
@@ -1,0 +1,247 @@
+// Namespace imports so this module does not depend on `esModuleInterop` being
+// set — it is inherited from tsconfig.base.json today, but a probe should not
+// break the orchestrator's boot if that ever changes.
+import * as v8 from 'v8';
+import { readFileSync } from 'fs';
+
+/**
+ * Read-only memory probe. Logs one line per interval and changes no behaviour.
+ *
+ * It exists to answer a single question about the Worker's 5 -> 15 -> 18 GB
+ * memory steps: WHERE does the resident memory actually live? RSS is what the
+ * cgroup limit is enforced against (and what OOM-kills the container), but RSS
+ * on its own cannot distinguish between the candidate causes. The split can:
+ *
+ *   native = rss - jsHeap(ALL threads) - external
+ *
+ * See docs/worker-memory-probe.md for the result -> conclusion table.
+ *
+ * WHY jsHeap COUNTS ALL THREADS
+ * -----------------------------
+ * `process.memoryUsage().heapUsed` reports the CURRENT isolate only — the main
+ * thread. Temporal runs workflows in worker_threads, each with its own V8
+ * isolate, and the orchestrator registers ~30 Temporal Workers. Those isolates'
+ * heaps are invisible to `heapUsed` (measured: a worker thread allocating
+ * 312 MB moved main-thread `heapUsed` by 0 MB).
+ *
+ * So a naive `rss - heapUsed - external` lumps the workflow threads' heaps in
+ * with Temporal core's Rust buffers, and the two have completely different
+ * fixes (bound `maxCachedWorkflows` vs cap activity admission). We therefore
+ * sum every isolate via process.report.getReport().workers[], which costs
+ * ~25-38 ms with 30 threads — negligible once a minute.
+ */
+
+const MB = 1024 * 1024;
+
+/** Parses one cgroup limit file. Null when absent, unlimited, or unparseable. */
+function readLimitFile(path: string): number | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8').trim();
+  } catch {
+    // Not Linux (macOS dev), or the file is not exposed in this container.
+    return null;
+  }
+
+  // cgroup v2 writes the literal "max" when unlimited.
+  if (raw === 'max') {
+    return null;
+  }
+
+  const bytes = Number(raw);
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return null;
+  }
+
+  // cgroup v1 reports a near-2^63 sentinel when unlimited. Anything above a
+  // terabyte is that sentinel, not a real container limit.
+  if (bytes > 1024 * 1024 * MB) {
+    return null;
+  }
+
+  return Math.round(bytes / MB);
+}
+
+/**
+ * The container's real memory ceiling. Null if it cannot be determined.
+ *
+ * Copes with three layouts, because we do not control (or fully know) how the
+ * platform runs the container:
+ *
+ *   1. cgroup v2, namespaced — the container's limit is at the root of its
+ *      view: /sys/fs/cgroup/memory.max
+ *   2. cgroup v2, NOT namespaced — that path is then the HOST root cgroup and
+ *      reads "max". The real limit lives at the nested path named in
+ *      /proc/self/cgroup. Without this branch we report "unknown" for a
+ *      container that does have a limit.
+ *   3. cgroup v1 — /sys/fs/cgroup/memory/memory.limit_in_bytes
+ *
+ * Never throws: a probe must not be able to take the process down.
+ */
+function cgroupLimitMb(): number | null {
+  const v2 = readLimitFile('/sys/fs/cgroup/memory.max');
+  if (v2 !== null) {
+    return v2;
+  }
+
+  try {
+    const self = readFileSync('/proc/self/cgroup', 'utf8');
+    // cgroup v2 format is a single line: "0::/the/path"
+    const line = self.split('\n').find((l) => l.startsWith('0::'));
+    let rel = line?.slice(3).trim();
+
+    while (rel && rel !== '/') {
+      const nested = readLimitFile(`/sys/fs/cgroup${rel}/memory.max`);
+      if (nested !== null) {
+        return nested;
+      }
+      rel = rel.slice(0, rel.lastIndexOf('/')) || '/';
+    }
+  } catch {
+    // fall through to v1
+  }
+
+  return readLimitFile('/sys/fs/cgroup/memory/memory.limit_in_bytes');
+}
+
+type ThreadHeaps = {
+  /** Live JS heap across EVERY isolate (main + each worker thread), in MB. */
+  jsHeapAll: number;
+  /** The main isolate alone, in MB. */
+  jsHeapMain: number;
+  /** Worker-thread isolates only — Temporal's workflow threads live here. */
+  jsHeapThreads: number;
+  /** Isolate count (1 = main only). */
+  threads: number;
+  /** False when the per-thread scan failed and jsHeapAll is main-only. */
+  complete: boolean;
+};
+
+/** Sums the live JS heap across all isolates. Never throws. */
+function threadHeaps(mainHeapUsedMb: number): ThreadHeaps {
+  try {
+    const report: any = process.report?.getReport();
+    const workers: any[] = Array.isArray(report?.workers) ? report.workers : [];
+
+    const used = (n: any) => Number(n?.javascriptHeap?.usedMemory ?? 0) / MB;
+    const main = used(report) || mainHeapUsedMb;
+    const threads = workers.reduce((sum, w) => sum + used(w), 0);
+
+    return {
+      jsHeapAll: Math.round(main + threads),
+      jsHeapMain: Math.round(main),
+      jsHeapThreads: Math.round(threads),
+      threads: workers.length + 1,
+      complete: true,
+    };
+  } catch {
+    // Degrade to main-thread-only rather than lose the whole sample.
+    return {
+      jsHeapAll: mainHeapUsedMb,
+      jsHeapMain: mainHeapUsedMb,
+      jsHeapThreads: 0,
+      threads: 1,
+      complete: false,
+    };
+  }
+}
+
+export function sampleMemory() {
+  const m = process.memoryUsage();
+  const rss = m.rss / MB;
+  const external = m.external / MB;
+  const heaps = threadHeaps(Math.round(m.heapUsed / MB));
+
+  // Everything resident that is neither a V8 heap nor a Buffer. Temporal
+  // core's Rust allocations and glibc arena slack land here.
+  const native = rss - heaps.jsHeapAll - external;
+
+  return {
+    rss: Math.round(rss),
+    jsHeapAll: heaps.jsHeapAll,
+    jsHeapMain: heaps.jsHeapMain,
+    jsHeapThreads: heaps.jsHeapThreads,
+    threads: heaps.threads,
+    heapTotal: Math.round(m.heapTotal / MB),
+    external: Math.round(external),
+    arrayBuffers: Math.round(m.arrayBuffers / MB),
+    native: Math.round(native),
+    // Per isolate. NOT a process-wide ceiling — see the header comment.
+    heapLimit: Math.round(v8.getHeapStatistics().heap_size_limit / MB),
+    complete: heaps.complete,
+    // macOS under-reports RSS (memory compression), so heapUsed can exceed it
+    // and `native` can go negative. Harmless locally, but the number is
+    // meaningless when this is set. Should never be true on Linux/Railway.
+    rssUnreliable: native < 0,
+  };
+}
+
+/**
+ * Starts the probe. Returns a stop function.
+ *
+ * `service` tags the line so Worker 1 / Worker 2 / backend are separable when
+ * the logs are exported and grepped.
+ *
+ * Default interval is 15 MINUTES. Two reasons, both measured:
+ *
+ *   COST — a sample costs ~140 ms with 34 isolates (measured in-container),
+ *   because process.report.getReport() walks every worker thread. That is an
+ *   event-loop block on the orchestrator's main thread. At 15 min it is 0.016%
+ *   of wall-clock; at 60 s it would be 0.23%. No reason to pay 15x for
+ *   resolution we do not need.
+ *
+ *   RESOLUTION — we are chasing a memory STEP that then plateaus for HOURS
+ *   (5 -> 15 GB, then flat for 14 h). 15 min is ample to place a step against a
+ *   `:00` posting burst, and it makes a 25,000-line log export span weeks
+ *   instead of a day.
+ *
+ * Override with MEMORY_PROBE_INTERVAL_MS (e.g. 30000) to watch it live locally.
+ * Do not go below ~60s in production.
+ */
+export function startMemoryProbe(service: string, intervalMs = 15 * 60_000) {
+  const limit = cgroupLimitMb();
+  const first = sampleMemory();
+
+  // Identify WHICH process emitted the line. A Railway service can run several
+  // replicas, and they all share the same env vars — so `service` alone cannot
+  // tell them apart. That matters: we still do not know whether the Jul 9 memory
+  // cliff was the whole service dying or a single replica. Railway injects
+  // RAILWAY_REPLICA_ID per replica; `pid` is the fallback for anywhere else.
+  const replica = (
+    process.env.RAILWAY_REPLICA_ID ||
+    process.env.RAILWAY_DEPLOYMENT_ID ||
+    ''
+  ).slice(0, 8);
+  const who =
+    `service=${service} pid=${process.pid}` +
+    (replica ? ` replica=${replica}` : '');
+
+  console.log(
+    `[mem] probe started ${who} interval=${intervalMs}ms ` +
+      `cgroupLimit=${limit === null ? 'unknown' : `${limit}MB`} ` +
+      `heapLimit=${first.heapLimit}MB (per isolate) ` +
+      `nodeOptions=${JSON.stringify(process.env.NODE_OPTIONS ?? null)}`
+  );
+
+  const tick = () => {
+    const s = sampleMemory();
+    // Single line, prefixed so it greps cleanly out of a 25k-line export:
+    //   grep '^\[mem\]' logs.json
+    console.log(
+      `[mem] ${who} rss=${s.rss} ` +
+        `jsHeap=${s.jsHeapAll} jsHeapMain=${s.jsHeapMain} ` +
+        `jsHeapThreads=${s.jsHeapThreads} threads=${s.threads} ` +
+        `external=${s.external} arrayBuffers=${s.arrayBuffers} ` +
+        `native=${s.native} heapLimit=${s.heapLimit}` +
+        (s.complete ? '' : ' threadScan=FAILED') +
+        (s.rssUnreliable ? ' rss=UNRELIABLE(negative-native;macOS?)' : '')
+    );
+  };
+
+  tick();
+  const timer = setInterval(tick, intervalMs);
+  // Never hold the process open on the probe's account.
+  timer.unref?.();
+
+  return () => clearInterval(timer);
+}


### PR DESCRIPTION
## ⚠️ Requires new env vars — this PR is a **no-op until you set them**

| Variable | Required? | Default | Notes |
|---|---|---|---|
| `MEMORY_PROBE` | **Yes, to enable** | *(unset = off)* | Must be exactly `"true"`. Anything else and the probe never starts. |
| `MEMORY_PROBE_SERVICE` | No | `RAILWAY_SERVICE_NAME` | Tags each log line. Usually correct without being set. |
| `MEMORY_PROBE_INTERVAL_MS` | No | `900000` (15 min) | A sample costs ~140 ms — **don't go below `60000`** in production. |

Set on the two orchestrator (**Worker**) services, and optionally the backend. **Requires a redeploy** to take effect — which resets RSS, so allow a full day before drawing conclusions. Added to `.env.example` (commented out).

Also *read* but not set by us: `RAILWAY_SERVICE_NAME` and `RAILWAY_REPLICA_ID` — [Railway-provided variables](https://docs.railway.com/reference/variables), injected into all deployments, used to identify which container/replica emitted each line. If absent, falls back to `pid`.

## Why

The orchestrator (`Worker`) containers step from ~5 GB → ~15 GB, then to 18.31 GB, and worker 2 climbed to **22.62 GB before dropping to 7.8 GB** — a kernel OOM kill. The steps are fast, permanent, and happen at **0.2–0.8 vCPU**: something grabs many GB while doing almost no work and never gives it back.

Several mutually exclusive explanations fit the RSS graph equally well, and no amount of further log-reading separates them. I've proposed and killed three already. This PR stops guessing and measures, via one number:

```
native = rss - jsHeap(ALL isolates) - external
```

## What it adds

One log line per interval. **Nothing else changes** — it's read-only.

```
[mem] service=worker pid=1 replica=1a2b3c4d rss=4821 jsHeap=1204 jsHeapMain=612 \
      jsHeapThreads=592 threads=34 external=143 arrayBuffers=38 native=3474 heapLimit=2096
```

| Field | Meaning |
|---|---|
| `rss` | what the cgroup limit is enforced against, and what OOM-kills the container |
| `jsHeap` | live JS heap summed across **every** V8 isolate |
| `jsHeapMain` | the Nest main thread |
| `jsHeapThreads` | the Temporal **workflow threads** — where the sticky workflow cache lives |
| `threads` | isolate count (expect 34: 33 Temporal Workers + main) |
| `external` / `arrayBuffers` | Buffers — media downloads, `sharp` |
| `native` | the residue: neither V8 heap nor Buffers. Temporal core's **Rust** allocations land here |
| `heapLimit` | **per isolate**, not process-wide |

**Why it sums every isolate.** `process.memoryUsage().heapUsed` reports only the *current* isolate. Temporal runs workflows in `worker_threads`, and the orchestrator registers **33** Temporal Workers ⇒ 34 isolates. Measured: a worker thread allocating **312 MB moved main-thread `heapUsed` by 0 MB** and showed up entirely as `native`. Without summing isolates, the sticky workflow cache gets misread as Rust-core memory and we'd cap the wrong thing. So the probe sums all isolates via `process.report.getReport().workers[]`.

## Load it adds

**~140 ms per sample** with 34 isolates (measured in-container) — `getReport()` walks every worker thread, so it's an event-loop block on the main thread.

**Default interval: 15 minutes ⇒ 0.016% of wall-clock.** At 60 s it would be 0.23%; there's no reason to pay 15× for resolution we don't need, since we're chasing a step that then plateaus for *hours*.

Separately verified: **`getReport()` does not block on busy worker threads** — 20–25 ms even with threads spinning in tight CPU loops. The probe cannot stall the orchestrator.

## Where it runs

**Once per process**, from `main.ts` after `app.listen()` — **not** per Temporal Worker. "Worker" is ambiguous here:

| "Worker" | Count | One probe each? |
|---|---|---|
| Railway **Worker service** (a container) | 2 | ✅ yes |
| Temporal **`Worker`** (task-queue poller) | **33 per container** | ❌ no |

All 33 share one process, one RSS, one set of isolates — a per-Temporal-Worker probe would be meaningless.

**Volume: 96 lines/day per process** (192/day across both worker containers), plus a boot banner. Trivial against a 25,000-line log export, which will now span *weeks*.

## What we learn from the result

Run it across one `:00` scheduled-post burst (ideally 24 h, to catch a step):

| What climbs | Conclusion | Action it implies |
|---|---|---|
| **`native`**; `jsHeap`/`external` flat | **Temporal core's Rust buffers** — admitted activity-task payloads and/or payloads retained by cached workflows (SDK docs: *"the size of all Payloads sent or received by the Workflow"*, Core SDK #363) | Bound `maxCachedWorkflows`; cap `main`'s activity admission (currently `maxConcurrentActivityTaskExecutions: 1000000`) |
| **`jsHeapThreads`** | The **sticky workflow cache** (it lives in the workflow threads' isolates) | Set an explicit `maxCachedWorkflows` — the default is ~1110, computed as if the Worker owned the whole process |
| **`external`/`arrayBuffers`** | **Media Buffers** — `convertToJPEG`, provider downloads | Per-queue media caps + a global media semaphore |
| **`jsHeapMain`** | Retained payloads/contexts on the Nest side | Heap snapshot; hunt retained references |
| everything falls back, but `rss` stays high | **glibc allocator high-water mark** | `MALLOC_ARENA_MAX=2`, `MALLOC_MMAP_THRESHOLD_=131072` (no code change) |
| `rss` climbs with no burst, never falls | A genuine **leak** | Heap snapshot; restart the investigation |

Full table and rationale in `docs/worker-memory-probe.md`.

## Container-verified against Railway's base image

Compiled this module with the orchestrator's build flags and ran **it** (not a replica) in `node:22.20-bookworm-slim` under a real cgroup v2 memory limit, with 33 worker threads standing in for Temporal's:

- ✅ cgroup read works — `cgroupLimit=8192MB`
- ✅ `native` is positive (the negative-`native` artifact is macOS-only — macOS under-reports RSS, and the probe *flags* it rather than printing a nonsense number)
- ✅ `threads=34`, and `jsHeapThreads` correctly attributes the 33 thread heaps
- ✅ `heapLimit = 2096 MB` per isolate at container sizes **4g / 16g / 24g alike**

That last point is a finding in itself. Node caps the V8 heap at ~2 GB for any large container, and worker threads get the same (Temporal sets no `resourceLimits`). That bounds the **whole** JS heap at ~5 GB (main 2096 + `main`'s workflow thread 2096 + 32 idle threads ≈ 960) — and exceeding any isolate would print a V8 `FATAL`, which production never shows. **So the 18 GB is not JS heap; it's native.** This probe is what confirms that in production rather than by inference.

## Risk

- **Off by default.** Without `MEMORY_PROBE=true`, deploying this is a complete no-op.
- Read-only: no behaviour change, no data touched.
- Every failure path degrades rather than throwing — a failed thread scan logs `threadScan=FAILED`, a missing cgroup logs `cgroupLimit=unknown`, absent Railway vars fall back to `pid`.

## Notes

- `tsc` on the orchestrator reports 4 errors, all **pre-existing on `main`** (`autopost.service.ts`, `media.repository.ts`, `empty.provider.ts`, `short-linking/providers/empty.ts`) — none in files touched here.
- Root `eslint` currently fails to load its own config on `main` (reproduced on an untouched file), so it could not be run.
- Follow-up branch `fix/temporal-worker-memory-config` adds the env-gated knobs (`TEMPORAL_MAX_CACHED_WORKFLOWS`, `TEMPORAL_ACTIVITY_ONLY_WORKERS`, `TEMPORAL_MAIN_MAX_CONCURRENT_ACTIVITIES`) that this probe's result tells us how to set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)