### PR TITLE
fix(worker): let non-"main" Temporal Workers be activity-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,3 +131,11 @@ POSTIZ_OAUTH_CLIENT_SECRET=""
 # LINK_DRIP_API_KEY="" # Your LinkDrip API key
 # LINK_DRIP_API_ENDPOINT="https://api.linkdrip.com/v1/" # Your self-hosted LinkDrip API endpoint
 # LINK_DRIP_SHORT_LINK_DOMAIN="dripl.ink" # Your self-hosted LinkDrip domain
+
+# Temporal: activity-only Workers (defaults to current behaviour; unset = no-op)
+# The orchestrator registers ~33 Temporal Workers (one per provider queue + "main"),
+# but EVERY workflow runs on the "main" queue -- a provider name only routes a
+# workflow's ACTIVITIES. The other 32 Workers therefore run a webpack bundle build
+# at boot and hold a V8 isolate + sticky cache that never sees a workflow task.
+# Setting this drops workflowsPath from them: 34 isolates -> 2.
+# TEMPORAL_ACTIVITY_ONLY_WORKERS="true"

--- a/libraries/nestjs-libraries/src/temporal/temporal.module.ts
+++ b/libraries/nestjs-libraries/src/temporal/temporal.module.ts
@@ -23,6 +23,40 @@ export const getTemporalModule = (
     Number(process.env.WORKER_CONCURRENCY_DIVIDER) || 1
   );
 
+  // EVERY workflow in this codebase is started on `taskQueue: 'main'`
+  // (post.activity.ts:81 and :258, posts.service.ts:731, autopost.service.ts:110,
+  // refresh.integration.service.ts:66, email.service.ts:47). The provider name in
+  // a workflow's args routes its ACTIVITIES; the workflow itself always lives on
+  // `main`. So only ONE of the ~33 Workers below ever runs a workflow.
+  //
+  // Yet we hand `workflowsPath` to all of them, and each one therefore:
+  //   1. runs a FULL WEBPACK BUNDLE BUILD at boot -- getOrCreateBundle()
+  //      constructs a new WorkflowCodeBundler per Worker, nothing is shared
+  //      (@temporalio/worker worker.js:434-446). That is ~33 webpack compiles.
+  //   2. spawns a workflow thread with its own V8 isolate (worker.js:226-229)
+  //   3. allocates a sticky workflow cache
+  // For the 32 non-`main` Workers all three are dead weight: no workflow task
+  // ever arrives on their queue. Measured: 34 isolates, ~868 MB of idle JS heap.
+  //
+  // The SDK skips the workflow thread entirely when no bundle is given, so
+  // omitting `workflowsPath` removes all three costs. Verified: 34 isolates -> 2.
+  //
+  // Opt-in rather than the default ONLY because its safety rests on an invariant
+  // nothing enforces: if a workflow were ever scheduled on a provider queue, no
+  // Worker would poll for it and it would hang silently. True today; it would
+  // fail quietly if that ever changed.
+  const activityOnlyWorkers =
+    process.env.TEMPORAL_ACTIVITY_ONLY_WORKERS === 'true';
+
+  if (isWorkers) {
+    // One line at boot so the effective config is verifiable in production
+    // rather than assumed. Greppable as `[temporal]`.
+    console.log(
+      `[temporal] activityOnlyWorkers=${activityOnlyWorkers} ` +
+        `divider=${divider} excludeQueues=[${excludeQueues.join(',')}]`
+    );
+  }
+
   return TemporalModule.register({
     isGlobal: true,
     connection: {
@@ -59,9 +93,14 @@ export const getTemporalModule = (
                   )
                 : undefined;
 
+              // Workflows only ever run on `main`, so every other Worker can be
+              // activity-only: no bundle => no webpack build, no workflow
+              // thread, no V8 isolate, no sticky cache.
+              const runsWorkflows = taskQueue === 'main' || !activityOnlyWorkers;
+
               return {
                 taskQueue,
-                workflowsPath: path!,
+                ...(runsWorkflows ? { workflowsPath: path! } : {}),
                 activityClasses: activityClasses!,
                 autoStart: true,
                 ...(concurrency


### PR DESCRIPTION
## TL;DR

The orchestrator registers **33 Temporal Workers**, but **only one of them (`main`) can ever run a workflow**. The other 32 each build a webpack bundle at boot and hold a V8 isolate + sticky cache that will never see a workflow task.

Setting `TEMPORAL_ACTIVITY_ONLY_WORKERS=true` drops `workflowsPath` from those 32. Measured on the real orchestrator against a real Temporal server:

| | before | after |
|---|---|---|
| V8 isolates | **34** | **2** |
| `jsHeapThreads` | **865 MB** | **27 MB** |
| RSS (idle) | 1630 MB | **649 MB** |
| Nest boot | **10,276 ms** | **807 ms** |

**RSS −60%, boot 12× faster.** And a real TikTok post published end-to-end through it (twice).

## Why the 32 Workers are useless today

Every workflow in the codebase is started on **`taskQueue: 'main'`**:

| Site | Workflow |
|---|---|
| `apps/orchestrator/src/activities/post.activity.ts:81` | `postWorkflowV105` |
| `apps/orchestrator/src/activities/post.activity.ts:258` | `streakWorkflow` |
| `libraries/.../posts/posts.service.ts:731` | `postWorkflowV105` |
| `libraries/.../autopost/autopost.service.ts:110` | `autoPostWorkflow` |
| `libraries/.../integrations/refresh.integration.service.ts:66` | `refreshTokenWorkflow` |
| `libraries/.../services/email.service.ts:47` | `sendEmailWorkflow` |

The provider name (`tiktok`, `youtube`, …) that gets passed in the workflow's **args** routes its **activities** — `proxyActivities({ taskQueue })` inside the workflow. The **workflow itself** always lives on `main`.

So the provider Workers only ever receive **activity** tasks. Yet because we pass `workflowsPath` to all 33, each one:

1. **runs a full webpack bundle build at boot.** `getOrCreateBundle()` constructs a *new* `WorkflowCodeBundler` and calls `createBundle()` **per Worker** — nothing is shared, despite the name (`@temporalio/worker/lib/worker.js:434-446`). That's ~33 webpack compilations every start. **This is the 10.3s → 0.8s boot difference.**
2. **spawns a workflow thread with its own V8 isolate** (`worker.js:226-229`)
3. **allocates a sticky workflow cache**

All three are dead weight for the 32. The SDK skips the workflow thread entirely when no bundle is given, so omitting `workflowsPath` removes all of it.

## Why this cannot harm us

**Workflow tasks and activity tasks are separate task types.** This change removes the *workflow* capability from queues that only ever receive *activity* tasks.

Temporal's own view of the queues, with the flag on:

```
Task queue: main       Pollers: workflow ✅  activity ✅
Task queue: tiktok     Pollers:              activity ✅   <-- no workflow poller, by design
```

**Verified end to end, not just reasoned about:**

- ✅ All 33 task queues still come up `RUNNING` (`Worker state changed ... state: 'RUNNING'` for `tumblr`, `mewe`, every provider).
- ✅ An isolated harness proved an activity-only worker still executes activities dispatched to it (workflow on `main` → `postSocial` proxied to an activity-only `tiktok` worker → executed).
- ✅ **A real TikTok video published**, twice, through an orchestrator running with `threads=2` and this flag on — including one post that had been created by the normal app flow (backend → `posts.service.startWorkflow`) and simply resumed. `state=PUBLISHED`, `releaseURL` set, no error.

**Blast radius if something is wrong:** it's a single env var. Unset it and you're back to today's behaviour on the next deploy — no data migration, no workflow-determinism concern, no schema change. It is **not** a workflow code change, so in-flight workflows are unaffected.

## Why it's opt-in rather than the default

Its safety rests on an invariant that **nothing in the code enforces**: if a workflow were ever scheduled on a provider queue, no Worker would poll for it and it would **hang silently**. That's true today (all six start sites pass `taskQueue: 'main'`), but it would fail quietly if someone changed it. Making it opt-in keeps the current behaviour as the default until we're happy.

If we later want it on by default, the right follow-up is a guard that fails loudly when a workflow is started on a non-`main` queue.

## Benefits

- **~60% lower idle RSS** and **32 fewer V8 isolates** — directly relevant to the orchestrator's OOM kills (worker 2 hit 22.62 GB before being killed).
- **12× faster boot** (10.3s → 0.8s), which also shortens every deploy and every crash-restart.
- **Correctness/hygiene:** we stop paying for a capability we never use.

This is worth doing **regardless of how the memory investigation concludes** — it doesn't trade anything away.

## Relationship to the other branches

- `chore/worker-memory-probe` (#1712) — the read-only probe used to take the measurements above. Independent.
- `fix/temporal-max-cached-workflows` — **deliberately kept separate.** That one genuinely *changes* caching behaviour (a smaller cache means more history replays), so it's a tuning experiment, not a fix, and must be revertable independently of this.

## New env var

| Variable | Default | Effect |
|---|---|---|
| `TEMPORAL_ACTIVITY_ONLY_WORKERS` | *(unset — today's behaviour)* | `"true"` ⇒ the 32 non-`main` Workers get no `workflowsPath` |

Added to `.env.example`. Also logs a `[temporal] ...` line at boot so the effective config is verifiable in production rather than assumed:

```
[temporal] activityOnlyWorkers=true divider=1 excludeQueues=[]
```

## Notes

- With the var unset, the resulting worker configs are byte-for-byte today's (checked against the real provider list: 33 workers, 34 isolates, per-provider caps untouched — tiktok 10000, reddit 1).
- `tsc` reports 4 errors on the orchestrator project, all **pre-existing on `main`**; none in files touched here.
- Root `eslint` currently fails to load its own config on `main` (reproduced on an untouched file), so it could not be run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)