### PR TITLE
fix(mcp): serve streamable HTTP statelessly

### DIFF
--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -2,7 +2,6 @@ import { INestApplication } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { MastraService } from '@gitroom/nestjs-libraries/chat/mastra.service';
 import { MCPServer } from '@mastra/mcp';
-import { randomUUID } from 'crypto';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { OAuthService } from '@gitroom/nestjs-libraries/database/prisma/oauth/oauth.service';
 import { runWithContext } from './async.storage';
@@ -119,9 +118,7 @@ export const startMcp = async (app: INestApplication) => {
         url: url,
         httpPath: url.pathname,
         options: {
-          sessionIdGenerator: () => {
-            return randomUUID();
-          },
+          serverless: true,
           enableJsonResponse: true,
         },
         req,
@@ -171,9 +168,7 @@ export const startMcp = async (app: INestApplication) => {
         url,
         httpPath: url.pathname,
         options: {
-          sessionIdGenerator: () => {
-            return randomUUID();
-          },
+          serverless: true,
           enableJsonResponse: true,
         },
         req,
@@ -216,9 +211,7 @@ export const startMcp = async (app: INestApplication) => {
           url,
           httpPath: url.pathname,
           options: {
-            sessionIdGenerator: () => {
-              return randomUUID();
-            },
+            serverless: true,
             enableJsonResponse: true,
           },
           req,


### PR DESCRIPTION
Replaces #1697, rebased onto `main` with the `MCP_STATELESS` env gate removed — stateless is now unconditional. Net diff: 3 insertions, 10 deletions.

## Why

`@mastra/mcp` retains a transport per `initialize` request, each holding a per-session `Server` with the whole converted tool schema, released only on an explicit client `DELETE` that connectors never send. The MCP service climbs ~330 MB/h from a ~1 GB baseline and is killed at ~5 GB about twice a day.

Sessions hurt a second way. Any restart empties the map, and connected clients keep presenting a session id the new process has never seen. Mastra answers an unknown id with `400`, where [the spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management) requires `404` for a terminated session — and obliges the client to re-initialize on `404`. Clients get no recovery signal, so they hang until restarted, and each reconnect leaks another session.

The [2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) removes protocol-level sessions outright, so this has to go regardless.

## How

Swap `sessionIdGenerator` for `serverless: true` at the three `startHTTP` call sites (`/mcp-oauth`, `/mcp`, `/mcp/:id`). `serverless: true` routes `startHTTP` to `handleServerlessRequest`, which serves each request with a transient server and stores nothing.

Safe because nothing depends on session state: auth is bound per request through `runWithContext` (AsyncLocalStorage), and no tool uses sampling, elicitation, or server-initiated notifications.

## Reproduced (session mode)

| | |
|---|---|
| 1000 `initialize` vs bare MCPServer | 1000 transports retained, linear heap growth after forced GC |
| 200 `initialize` vs real backend | 200 sessions, **+15 MB** across a forced GC — ~76 KB each |
| One Claude Desktop connection | 4 sessions retained in 49 s |
| Tool calls on an open session | retain nothing — cost tracks **reconnects**, not traffic |
| Restart with Desktop attached | every call `400 Bad Request: No valid session ID`; fresh `initialize` returns 200; client never recovers |

## Validated (stateless)

| | |
|---|---|
| Same 200 `initialize` | **0 transports**, +1 MB heap |
| Real toolset | `tools/list`, `integrationList`, `integrationSchema`, `uploadFromUrlTool`, `integrationSchedulePostTool` identical; drafts same shape |
| Clients exercised | curl, `mcp-remote`, Claude Desktop |
| `initialize` | no longer returns `mcp-session-id` |
| `tools/list` without session id | 200 (session mode: 400) |
| Stale session id from a previous boot | ignored, served normally — the Desktop client stranded above **recovered mid-flight**, no reconnect, no re-adding the connector |

## Not related to the internal Postiz agent

The in-app agent never crosses this code. `copilot.controller.ts` runs `mastra.getAgent('postiz')` in-process via `@ag-ui/mastra`, calling plain `createTool` functions directly. It never sends `initialize`, never enters `startHTTP`, and cannot create or retain a session. No `MCPClient` exists anywhere in the repo.

Posts it creates are tagged `CreationMethod.MCP` only because `integration.schedule.post.ts` hardcodes that literal for any agent tool call — a naming artifact, not a code path. Only external clients (claude.ai, ChatGPT, `mcp-remote`) reach `startHTTP`, so only they leak, and only they are affected here.

## Rollout

Deploy the MCP service, confirm a flat memory graph, then the backend service. Rollback is reverting this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
