### PR TITLE
fix(worker): make non-"main" Temporal Workers activity-only

### DIFF
--- a/libraries/nestjs-libraries/src/temporal/temporal.module.ts
+++ b/libraries/nestjs-libraries/src/temporal/temporal.module.ts
@@ -59,9 +59,12 @@ export const getTemporalModule = (
                   )
                 : undefined;
 
+              // Workflows only ever run on the `main` queue; the other Workers
+              // are activity-only, so skip the workflow bundle (webpack build,
+              // workflow thread + V8 isolate, sticky cache) on them.
               return {
                 taskQueue,
-                workflowsPath: path!,
+                ...(taskQueue === 'main' ? { workflowsPath: path! } : {}),
                 activityClasses: activityClasses!,
                 autoStart: true,
                 ...(concurrency


### PR DESCRIPTION
## TL;DR

The orchestrator registers **33 Temporal Workers**, but **only one of them (`main`) can ever run a workflow**. The other 32 each build a webpack bundle at boot and hold a V8 isolate + sticky cache that will never see a workflow task.

This drops `workflowsPath` from those 32, making them activity-only. Measured in a **local container matching the Railway container's characteristics** — prod build (`nest build` dist), `node:22.20-bookworm-slim`, cgroup memory limit (which gives prod's per-isolate `heap_size_limit` of 2096 MB), against a real Temporal server. Not matched: production load (near-idle Temporal locally) and CPU arch (arm64 vs Railway's amd64).

| | before | after |
|---|---|---|
| webpack bundle builds at boot | **33** | **1** |
| container start → serving | **15.3 s** | **4.9 s** |
| RSS (idle) | 1509 MB | **467 MB** |
| OS threads | 131 | 67 |

**RSS −69%, boot 3× faster.** A host-mode probe additionally measured **V8 isolates 34 → 2** and `jsHeapThreads` **865 MB → 27 MB**. And real posts published end-to-end through it — TikTok twice (host run), X once (container run).

## Why the 32 Workers are useless today

Every workflow in the codebase is started on **`taskQueue: 'main'`**:

| Site | Workflow |
|---|---|
| `apps/orchestrator/src/activities/post.activity.ts:81` | `postWorkflowV105` |
| `apps/orchestrator/src/activities/post.activity.ts:258` | `streakWorkflow` |
| `libraries/.../posts/posts.service.ts:731` | `postWorkflowV105` |
| `libraries/.../autopost/autopost.service.ts:110` | `autoPostWorkflow` |
| `libraries/.../integrations/refresh.integration.service.ts:66` | `refreshTokenWorkflow` |
| `libraries/.../services/email.service.ts:47` | `sendEmailWorkflow` |

The provider name (`tiktok`, `youtube`, …) that gets passed in the workflow's **args** routes its **activities** — `proxyActivities({ taskQueue })` inside the workflow. The **workflow itself** always lives on `main`.

So the provider Workers only ever receive **activity** tasks. Yet because we pass `workflowsPath` to all 33, each one:

1. **runs a full webpack bundle build at boot.** `getOrCreateBundle()` constructs a *new* `WorkflowCodeBundler` and calls `createBundle()` **per Worker** — nothing is shared, despite the name (`@temporalio/worker/lib/worker.js:434-446`). That's ~33 webpack compilations every start. **This is the 15.3 s → 4.9 s boot difference.**
2. **spawns a workflow thread with its own V8 isolate** (`worker.js:226-229`)
3. **allocates a sticky workflow cache**

All three are dead weight for the 32. The SDK skips the workflow thread entirely when no bundle is given, so omitting `workflowsPath` removes all of it.

This is supported configuration, not a trick: per the [`WorkerOptions.workflowsPath` docs](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#workflowspath) the parameter is **optional** — omitting it is how you tell a Worker not to handle workflows, and per the [Worker processes guide](https://docs.temporal.io/develop/typescript/workers/run-worker-process) "a Worker Entity contains a Workflow Worker **and/or** an Activity Worker" — the same definition Temporal gives at the platform level in the [Workers concept docs](https://docs.temporal.io/workers#worker-entity), independent of any SDK.

## Why this cannot harm us

**Workflow tasks and activity tasks are separate task types.** This change removes the *workflow* capability from queues that only ever receive *activity* tasks; activity execution — the only work those queues actually get — is untouched, including per-provider concurrency caps (tiktok 10000, reddit 1). The `main` Worker keeps its bundle and runs workflows exactly as before.

Temporal's own view of the queues after this change (read from a live Temporal server):

```
Task queue: main       Pollers: workflow ✅  activity ✅
Task queue: tiktok     Pollers:              activity ✅   <-- no workflow poller, by design
```

**Verified end to end, not just reasoned about:**

- ✅ **Railway-like container run** (prod build in `node:22.20-bookworm-slim` under a 4 GB cgroup limit, so V8 sizes each isolate's heap to 2096 MB exactly as on Railway): all 33 task queues come up `RUNNING`, exactly 32 log `No workflows registered, not polling for workflow tasks`, the Temporal server shows activity-only pollers on provider queues — and **a real X post scheduled through the normal app flow** (backend → `posts.service.startWorkflow`) **published through it**: timer fired at the exact scheduled second, all activities completed within that second, workflow `Completed`, `state=PUBLISHED`, `releaseURL` set.
- ✅ An isolated harness proved an activity-only worker still executes activities dispatched to it (workflow on `main` → `postSocial` proxied to an activity-only `tiktok` worker → executed).
- ✅ **A real TikTok video published**, twice, through a host-mode orchestrator running this configuration — including one post that had been created by the normal app flow and simply resumed.

It is **not** a workflow code change, so in-flight workflows are unaffected — no data migration, no workflow-determinism concern, no schema change.

## The one invariant to be aware of

This rests on an invariant nothing in the code enforces: if a workflow were ever scheduled on a provider queue, no Worker would poll for it and it would hang silently. That's true today (all six start sites pass `taskQueue: 'main'`). If we ever want a belt-and-suspenders follow-up, it's a guard that fails loudly when a workflow is started on a non-`main` queue.

## Future work (separate change)

Per the [production deployment docs](https://docs.temporal.io/develop/typescript/workers/run-worker-process#run-a-temporal-cloud-worker), best practice is to pre-build the workflow bundle and pass it via `workflowBundle` instead of `workflowsPath`. That's left for a future change — it mostly improves startup time, whereas this change targets memory footprint.

## Notes

- Replaces #1713, which gated this behind a `TEMPORAL_ACTIVITY_ONLY_WORKERS` env var. Since the capability being removed is provably unused, the flag was complexity without benefit; this version is unconditional and touches a single file (4 insertions, 1 deletion).
- `tsc` reports 4 errors on the orchestrator project, all **pre-existing on `main`**; none in files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
