### PR TITLE
feat(admin): Switch User — swap login between two accounts

### DIFF
--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -16,6 +16,7 @@ import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.reque
 import { StripeService } from '@gitroom/nestjs-libraries/services/stripe.service';
 import { Response, Request } from 'express';
 import { AuthService } from '@gitroom/backend/services/auth/auth.service';
+import { AuthService as AuthChecker } from '@gitroom/helpers/auth/auth.service';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { CheckPolicies } from '@gitroom/backend/services/auth/permissions/permissions.ability';
 import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.management';
@@ -180,6 +181,51 @@ export class UsersController {
 
     if (process.env.NOT_SECURED) {
       response.header('impersonate', id);
+    }
+  }
+
+  @Post('/switch')
+  async switchUser(
+    @GetUserFromRequest() user: User,
+    @Body('id') id: string,
+    @Req() req: Request
+  ) {
+    if (!user.isSuperAdmin) {
+      throw new HttpException('Unauthorized', 400);
+    }
+
+    // `user` is the impersonated account, so the admin id comes from the token.
+    // Require an active impersonation session and never allow the admin's own
+    // account in the swap — either would trade away the admin's login.
+    const adminId = this.getRequestUserId(req);
+    if (
+      !id ||
+      !adminId ||
+      id === user.id ||
+      adminId === user.id ||
+      adminId === id
+    ) {
+      throw new HttpException('Invalid user to switch to', 400);
+    }
+
+    const { kept, switched } = await this._userService.switchUser(
+      user.id,
+      id,
+      adminId
+    );
+
+    await this._stripeService.syncCustomerEmailsAfterSwitch([kept, switched]);
+
+    return { success: true };
+  }
+
+  private getRequestUserId(req: Request): string | null {
+    try {
+      const auth = (req.headers.auth as string) || req.cookies?.auth;
+      const payload = AuthChecker.verifyJWT(auth) as { id?: string } | null;
+      return payload?.id || null;
+    } catch {
+      return null;
     }
   }
 

--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -10,6 +10,7 @@ import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { setCookie } from '@gitroom/frontend/components/layout/layout.context';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+import { useToaster } from '@gitroom/react/toaster/toaster';
 import { Button } from '@gitroom/react/form/button';
 import { ImportDebugPostModal } from '@gitroom/frontend/components/launches/import-debug-post.modal';
 
@@ -463,6 +464,155 @@ const ImportDebugPost = () => {
   );
 };
 
+const SwitchUser = () => {
+  const fetch = useFetch();
+  const t = useT();
+  const toaster = useToaster();
+  const currentUser = useUser();
+  const [name, setName] = useState('');
+  const [selected, setSelected] = useState<{
+    id: string;
+    name: string;
+    email: string;
+  } | null>(null);
+  const [switching, setSwitching] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!name) {
+      return [];
+    }
+    return await (await fetch(`/user/impersonate?name=${name}`)).json();
+  }, [name]);
+
+  const { data } = useSWR(`/switch-search-${name}`, load, {
+    refreshWhenHidden: false,
+    revalidateOnMount: true,
+    revalidateOnReconnect: false,
+    revalidateOnFocus: false,
+    refreshWhenOffline: false,
+    revalidateIfStale: false,
+    refreshInterval: 0,
+  });
+
+  const mapData = useMemo(() => {
+    // one row per user-organization: dedupe by user id, drop the impersonated user
+    const seen = new Set<string>();
+    return (data || [])
+      .filter((curr: any) => curr.user.id !== currentUser?.id)
+      .filter((curr: any) => {
+        if (seen.has(curr.user.id)) {
+          return false;
+        }
+        seen.add(curr.user.id);
+        return true;
+      })
+      .map((curr: any) => ({
+        id: curr.user.id,
+        name: curr.user.name,
+        email: curr.user.email,
+      }));
+  }, [data, currentUser?.id]);
+
+  const pick = useCallback(
+    (item: { id: string; name: string; email: string }) => () => {
+      setSelected(item);
+      setName('');
+    },
+    []
+  );
+
+  const doSwitch = useCallback(async () => {
+    if (!selected) {
+      return;
+    }
+    if (
+      !(await deleteDialog(
+        t(
+          'switch_user_confirm',
+          `This will replace the current account's login with ${selected.email}. All data and the subscription stay with the account — only the login changes, and the new login gains its full access. Switch back to revert.`
+        ),
+        t('yes_switch', 'Yes, switch'),
+        t('switch_user_title', 'Switch User?'),
+        t('no_cancel', 'No, cancel')
+      ))
+    ) {
+      return;
+    }
+    setSwitching(true);
+    try {
+      const res = await fetch('/user/switch', {
+        method: 'POST',
+        body: JSON.stringify({ id: selected.id }),
+      });
+      // customFetch does not throw on HTTP errors
+      if (!res.ok) {
+        throw new Error(await res.text().catch(() => ''));
+      }
+      window.location.reload();
+    } catch {
+      setSwitching(false);
+      toaster.show(
+        t('switch_user_failed', 'The user switch failed and nothing was changed'),
+        'warning'
+      );
+    }
+  }, [selected]);
+
+  return (
+    <div className="relative flex items-center gap-[10px]">
+      <div className="flex-1 min-w-[220px]">
+        <Input
+          autoComplete="off"
+          placeholder={t('select_user_to_switch_to', 'Select user to switch to')}
+          name="switchUser"
+          disableForm={true}
+          label=""
+          removeError={true}
+          value={
+            selected
+              ? `${selected.name ? `${selected.name} - ` : ''}${selected.email}`
+              : name
+          }
+          onChange={(e) => {
+            setSelected(null);
+            setName(e.target.value);
+          }}
+        />
+      </div>
+      <Button
+        onClick={doSwitch}
+        loading={switching}
+        disabled={!selected}
+        className="rounded-[4px] whitespace-nowrap"
+      >
+        {t('switch_user', 'Switch User')}
+      </Button>
+      {!!mapData?.length && !selected && (
+        <>
+          <div
+            className="bg-primary/80 fixed start-0 top-0 w-full h-full z-[998]"
+            onClick={() => setName('')}
+          />
+          <div className="absolute top-[100%] start-0 w-full bg-sixth border border-customColor6 text-textColor z-[999]">
+            {mapData.map((item: any) => (
+              <div
+                onClick={pick(item)}
+                key={item.id}
+                className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer"
+              >
+                {t('user_1', 'user:')}
+                {item.id.split('-').at(-1)} -{' '}
+                {item.name ? `${item.name} - ` : ''}
+                {item.email}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
 export const Impersonate = () => {
   const fetch = useFetch();
   const [name, setName] = useState('');
@@ -524,11 +674,15 @@ export const Impersonate = () => {
   return (
     <div>
       <div className="bg-forth h-[52px] flex justify-center items-center border-input border rounded-[8px] text-white">
-        <div className="relative flex flex-col w-[600px]">
+        <div
+          className={`relative flex flex-col ${
+            user?.impersonate ? 'w-full px-[20px]' : 'w-[600px]'
+          }`}
+        >
           <div className="relative z-[1]">
             {user?.impersonate ? (
-              <div className="text-center flex justify-center items-center gap-[20px]">
-                <div>
+              <div className="text-center flex justify-center items-center gap-[10px]">
+                <div className="whitespace-nowrap">
                   {t('currently_impersonating', 'Currently Impersonating')}
                 </div>
                 <div>
@@ -541,6 +695,7 @@ export const Impersonate = () => {
                 </div>
                 {user?.tier?.current === 'FREE' && <Subscription />}
                 {billingEnabled && <ManageBilling />}
+                <SwitchUser />
               </div>
             ) : (
               <div className="flex items-center gap-[10px]">

--- a/apps/frontend/src/components/layout/new-modal.tsx
+++ b/apps/frontend/src/components/layout/new-modal.tsx
@@ -341,7 +341,7 @@ export const DecisionModal: FC<{
   const { closeCurrent } = useModals();
   return (
     <div className="flex flex-col">
-      <div>{description}</div>
+      <div className="max-w-[600px]">{description}</div>
       <div className="flex gap-[12px] mt-[16px]">
         <Button
           onClick={() => {

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
@@ -1,13 +1,78 @@
-import { PrismaRepository } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
+import {
+  PrismaRepository,
+  PrismaTransaction,
+} from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
-import { Provider } from '@prisma/client';
+import { Provider, User } from '@prisma/client';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { UserDetailDto } from '@gitroom/nestjs-libraries/dtos/users/user.details.dto';
 import { EmailNotificationsDto } from '@gitroom/nestjs-libraries/dtos/users/email-notifications.dto';
+import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
+
+const pickCredentials = ({
+  email,
+  password,
+  providerName,
+  providerId,
+  account,
+  connectedAccount,
+  activated,
+}: User) => ({
+  email,
+  password,
+  providerName,
+  providerId,
+  account,
+  connectedAccount,
+  activated,
+});
 
 @Injectable()
 export class UsersRepository {
-  constructor(private _user: PrismaRepository<'user'>) {}
+  constructor(
+    private _user: PrismaRepository<'user'>,
+    private _transaction: PrismaTransaction
+  ) {}
+
+  switchUserCredentials(currentUserId: string, targetUserId: string) {
+    return this._transaction.model.$transaction(async (tx) => {
+      // deterministic lock order so concurrent switches sharing a user
+      // serialize instead of deadlocking
+      await tx.$queryRaw`SELECT id FROM "User" WHERE id IN (${currentUserId}, ${targetUserId}) ORDER BY id FOR UPDATE`;
+
+      const current = await tx.user.findUnique({
+        where: { id: currentUserId },
+      });
+      const target = await tx.user.findUnique({ where: { id: targetUserId } });
+
+      if (!current || !target) {
+        throw new Error('User not found');
+      }
+
+      const currentCredentials = pickCredentials(current);
+      const targetCredentials = pickCredentials(target);
+
+      // (email, providerName) is unique and checked per-statement, so park the
+      // current user on a throwaway email first, then fill each freed slot
+      await tx.user.update({
+        where: { id: current.id },
+        data: { email: `switch-${makeId(10)}-${current.email}` },
+      });
+      await tx.user.update({
+        where: { id: target.id },
+        data: currentCredentials,
+      });
+      await tx.user.update({
+        where: { id: current.id },
+        data: targetCredentials,
+      });
+
+      return {
+        kept: { id: current.id, email: targetCredentials.email },
+        switched: { id: target.id, email: currentCredentials.email },
+      };
+    });
+  }
 
   getImpersonateUser(name: string) {
     return this._user.model.user.findMany({

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
@@ -1,16 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '@gitroom/nestjs-libraries/database/prisma/users/users.repository';
 import { Provider } from '@prisma/client';
 import { UserDetailDto } from '@gitroom/nestjs-libraries/dtos/users/user.details.dto';
 import { EmailNotificationsDto } from '@gitroom/nestjs-libraries/dtos/users/email-notifications.dto';
 import { OrganizationRepository } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.repository';
+import { NotificationService } from '@gitroom/nestjs-libraries/database/prisma/notifications/notification.service';
 
 @Injectable()
 export class UsersService {
   constructor(
     private _usersRepository: UsersRepository,
-    private _organizationRepository: OrganizationRepository
+    private _organizationRepository: OrganizationRepository,
+    private _notificationService: NotificationService
   ) {}
+
+  private readonly _logger = new Logger(UsersService.name);
 
   getUserByEmail(email: string) {
     return this._usersRepository.getUserByEmail(email);
@@ -26,6 +30,49 @@ export class UsersService {
 
   getUserByProvider(providerId: string, provider: Provider) {
     return this._usersRepository.getUserByProvider(providerId, provider);
+  }
+
+  async switchUser(
+    currentUserId: string,
+    targetUserId: string,
+    adminId: string
+  ) {
+    const { kept, switched } =
+      await this._usersRepository.switchUserCredentials(
+        currentUserId,
+        targetUserId
+      );
+
+    this._logger.log(
+      `User login switch performed by admin ${adminId}: account ${
+        kept.id
+      } login ${switched.email} -> ${kept.email}; account ${
+        switched.id
+      } login ${kept.email} -> ${switched.email}`
+    );
+
+    // the swap is already committed; a notification failure must not fail it
+    if (this._notificationService.hasEmailProvider()) {
+      await Promise.all(
+        [kept, switched].map((account) =>
+          this._notificationService
+            .sendEmail(
+              account.email,
+              'Your Postiz login was changed',
+              `An administrator changed the login for your Postiz account. ` +
+                `You can now sign in using ${account.email}. ` +
+                `Your subscription and plan were not changed by this switch — ` +
+                `if you intended to cancel a subscription, please do that ` +
+                `separately from your billing settings.`
+            )
+            .catch((err) =>
+              this._logger.error(`Failed to notify ${account.email}`, err)
+            )
+        )
+      );
+    }
+
+    return { kept, switched };
   }
 
   activateUser(id: string) {

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -159,6 +159,42 @@ export class StripeService {
     );
   }
 
+  // After a login swap, move each Stripe customer's email to the login that
+  // now owns it. Owner-only so a member's switch can't rewrite a shared org's
+  // billing email, deduped per customer, and skipping admin-granted
+  // subscriptions (their paymentId is a user id, not a `cus_...` customer).
+  async syncCustomerEmailsAfterSwitch(
+    accounts: { id: string; email: string }[]
+  ) {
+    if (!process.env.STRIPE_PUBLISHABLE_KEY) {
+      return;
+    }
+    const emailByCustomer = new Map<string, string>();
+    for (const account of accounts) {
+      const organizations = await this._organizationService.getOrgsByUserId(
+        account.id
+      );
+      for (const org of organizations) {
+        if (
+          org.users?.[0]?.role === 'SUPERADMIN' &&
+          org.paymentId?.startsWith('cus_') &&
+          !emailByCustomer.has(org.paymentId)
+        ) {
+          emailByCustomer.set(org.paymentId, account.email);
+        }
+      }
+    }
+    await Promise.all(
+      [...emailByCustomer].map(([customerId, email]) =>
+        stripe.customers
+          .update(customerId, {
+            email: email.indexOf('@') > -1 ? email : `${email}@postiz.com`,
+          })
+          .catch(() => {})
+      )
+    );
+  }
+
   async createOrGetCustomer(organization: Organization) {
     if (organization.paymentId) {
       return organization.paymentId;


### PR DESCRIPTION
Adds a super-admin **Switch User** action to the impersonation bar: it swaps the login credentials (email, password, OAuth identity, activation state) between two accounts, while each account keeps its id, organization, subscription, channels and media — so each login now reaches the other's data.

- Atomic swap in a single Postgres transaction: a throwaway parking email works around the per-statement `(email, providerName)` unique index, with a deterministic `FOR UPDATE` lock ordering.
- Guarded: requires an active impersonation session and rejects the admin's own account as the swap target — fixes both Sentry review findings from #1668 (a direct call or self-pick would have swapped the admin's own login away).
- Stripe customer emails follow the login — real `cus_` customers only (admin-granted subscriptions are skipped), owner-only for shared orgs, deduped per customer.
- Both accounts get an email that their login changed and that the subscription was not touched.
- Frontend: search picker + confirmation dialog in the impersonation bar; a failed switch shows a toaster instead of silently reloading.

Supersedes #1668 — same feature, split from the unrelated admin-subscription fixes, with review trims, proper Controller >> Service >> Repository layering, and the Sentry findings fixed.

Tested end-to-end (swap + switch back between an admin-granted and a real Stripe subscription); the Stripe customer-email sync was verified in the Stripe test dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)