### PR TITLE
fix(admin): don't hit Stripe for admin-granted subscriptions

### DIFF
--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -96,6 +96,12 @@ export class BillingController {
 
   @Get('/portal')
   async modifyPayment(@GetOrgFromRequest() org: Organization) {
+    // Admin-granted/never-subscribed orgs have no real `cus_...` customer, so
+    // there is no Stripe billing portal to open (the UI hides the button; this
+    // guards the endpoint against a "No such customer" Stripe error).
+    if (!org.paymentId?.startsWith('cus_')) {
+      throw new HttpException('No Stripe customer for this organization', 400);
+    }
     const customer = await this._stripeService.getCustomerByOrganizationId(
       org.id
     );
@@ -116,6 +122,13 @@ export class BillingController {
     @GetUserFromRequest() user: User,
     @Body() body: { feedback: string }
   ) {
+    // An admin-granted subscription has no Stripe subscription to cancel (its
+    // paymentId is the user id, not a `cus_...` customer). The UI hides the
+    // self-service cancel button for these; removal is an admin-only action.
+    if (!org.paymentId?.startsWith('cus_')) {
+      throw new HttpException('No Stripe subscription to cancel', 400);
+    }
+
     await this._notificationService.sendEmail(
       process.env.EMAIL_FROM_ADDRESS,
       'Subscription Cancelled',
@@ -166,6 +179,15 @@ export class BillingController {
   ) {
     if (!user.isSuperAdmin) {
       throw new HttpException('Unauthorized', 400);
+    }
+
+    // Admin-granted subscriptions have no Stripe subscription to cancel; the
+    // admin panel hides this and offers "Remove Subscription" instead.
+    if (!org.paymentId?.startsWith('cus_')) {
+      throw new HttpException(
+        'Admin-granted subscription; use remove-subscription instead',
+        400
+      );
     }
 
     return this._stripeService.cancelSubscription(org.id);

--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -128,6 +128,11 @@ export class UsersController {
         ? false
         : organization?.isTrailing,
       allowTrial: organization?.allowTrial,
+      // A real Stripe customer has a `cus_...` paymentId. Admin-granted
+      // subscriptions store the user id there instead, and never-subscribed
+      // orgs have none, so gate billing-portal UI on this to avoid calling
+      // Stripe with a non-existent customer ("No such customer").
+      hasStripeCustomer: !!organization?.paymentId?.startsWith('cus_'),
       streakSince: organization?.streakSince || null,
       publicApi:
         // @ts-ignore

--- a/apps/frontend/src/components/billing/main.billing.component.tsx
+++ b/apps/frontend/src/components/billing/main.billing.component.tsx
@@ -539,12 +539,14 @@ export const MainBillingComponent: FC<{
       </div>
       {!!subscription?.id && (
         <div className="flex justify-center mt-[20px] gap-[10px]">
-          <Button onClick={updatePayment}>
-            {t(
-              'update_payment_method_invoices_history',
-              'Update Payment Method / Invoices History'
-            )}
-          </Button>
+          {!!(user as any)?.hasStripeCustomer && (
+            <Button onClick={updatePayment}>
+              {t(
+                'update_payment_method_invoices_history',
+                'Update Payment Method / Invoices History'
+              )}
+            </Button>
+          )}
           {isGeneral && !subscription?.cancelAt && (
             <Button
               className="bg-red-500"

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -202,6 +202,12 @@ export class StripeService {
 
   async prorate(organizationId: string, body: BillingSubscribeDto) {
     const org = await this._organizationService.getOrgById(organizationId);
+    // Admin-granted subscriptions store the user id in paymentId (not a real
+    // `cus_...` customer); there is nothing to prorate against and Stripe would
+    // throw "No such customer", so return a zero price without calling it.
+    if (org?.paymentId && !org.paymentId.startsWith('cus_')) {
+      return { price: 0 };
+    }
     const customer = await this.createOrGetCustomer(org!);
     const priceData = pricing[body.billing];
     const allProducts = await stripe.products.list({
@@ -541,6 +547,11 @@ export class StripeService {
   }
 
   async finishTrial(paymentId: string) {
+    // No real Stripe customer (admin-granted or never-subscribed) → nothing to
+    // finish; skip the call that would throw "No such customer".
+    if (!paymentId?.startsWith('cus_')) {
+      return;
+    }
     const list = (
       await stripe.subscriptions.list({
         customer: paymentId,
@@ -554,6 +565,12 @@ export class StripeService {
 
   async checkDiscount(customer: string) {
     if (!process.env.STRIPE_DISCOUNT_ID) {
+      return false;
+    }
+
+    // No real Stripe customer (admin-granted or never-subscribed) → no discount
+    // to offer; skip the call that would throw "No such customer".
+    if (!customer?.startsWith('cus_')) {
       return false;
     }
 
@@ -592,6 +609,11 @@ export class StripeService {
   }
 
   async applyDiscount(customer: string) {
+    // No real Stripe customer (admin-granted or never-subscribed) → nothing to
+    // apply a discount to; skip the call that would throw "No such customer".
+    if (!customer?.startsWith('cus_')) {
+      return false;
+    }
     const check = this.checkDiscount(customer);
     if (!check) {
       return false;
@@ -844,7 +866,10 @@ export class StripeService {
 
   async getCharges(organizationId: string) {
     const org = await this._organizationService.getOrgById(organizationId);
-    if (!org?.paymentId) {
+    // Only real Stripe customers have charges. Admin-granted subscriptions
+    // store the user id in `paymentId` (not a `cus_...` customer), so calling
+    // Stripe for them just throws "No such customer".
+    if (!org?.paymentId || !org.paymentId.startsWith('cus_')) {
       return [];
     }
 

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -614,7 +614,7 @@ export class StripeService {
     if (!customer?.startsWith('cus_')) {
       return false;
     }
-    const check = this.checkDiscount(customer);
+    const check = await this.checkDiscount(customer);
     if (!check) {
       return false;
     }


### PR DESCRIPTION
Admin-granted subscriptions store the user id in `Organization.paymentId` (not a real `cus_...` customer), so every billing path that fed `paymentId` to Stripe threw "No such customer" — the per-plan `prorate` call on billing-page load was flooding the error logs.

- `getCharges` / `prorate` / `checkDiscount` / `applyDiscount` / `finishTrial` now skip Stripe for any non-`cus_` paymentId (empty charges / zero price / no coupon / no-op).
- `/billing/portal`, `/billing/cancel` and `/billing/cancel-subscription` reject with a clean 400 instead of a Stripe error.
- `/self` exposes `hasStripeCustomer`, and the billing page only renders the "Update Payment Method / Invoices History" button when there is a real customer.

Validated by impersonating an admin-granted account (billing page loads with no Stripe error logs, portal button hidden) and a real `cus_` subscriber (button shows, portal works).

Split from #1668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)