### PR TITLE
fix(admin): exclude the current admin from the impersonation search

### DIFF
--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -153,7 +153,7 @@ export class UsersController {
       throw new HttpException('Unauthorized', 400);
     }
 
-    return this._userService.getImpersonateUser(name);
+    return this._userService.getImpersonateUser(name, user.id);
   }
 
   @Post('/impersonate')

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -103,9 +103,11 @@ export class OrganizationRepository {
     });
   }
 
-  getImpersonateUser(name: string) {
+  getImpersonateUser(name: string, excludeUserId?: string) {
     return this._userOrg.model.userOrganization.findMany({
       where: {
+        // Never let an admin impersonate (or switch to) themselves.
+        ...(excludeUserId ? { userId: { not: excludeUserId } } : {}),
         OR: [
           {
             organizationId: {

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
@@ -20,8 +20,8 @@ export class UsersService {
     return this._usersRepository.getUserById(id);
   }
 
-  getImpersonateUser(name: string) {
-    return this._organizationRepository.getImpersonateUser(name);
+  getImpersonateUser(name: string, excludeUserId?: string) {
+    return this._organizationRepository.getImpersonateUser(name, excludeUserId);
   }
 
   getUserByProvider(providerId: string, provider: Provider) {


### PR DESCRIPTION
An admin could see and pick their own account in the impersonation list and "impersonate" themselves. `getImpersonateUser` now takes the requesting user id and excludes it from the results.

Split from #1668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)