### PR TITLE
fix: use plain fetch instead of this.fetch in analytics methods

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -820,7 +820,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       // by post_total_media_view_unique (unique media views = reach), available on
       // Graph API v23.0+. Engagement metrics below are unaffected.
       const { data } = await (
-        await this.fetch(
+        await fetch(
           `https://graph.facebook.com/v23.0/${postId}/insights?metric=post_total_media_view_unique,post_reactions_by_type_total,post_clicks,post_clicks_by_type&access_token=${accessToken}`
         )
       ).json();

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -1037,7 +1037,7 @@ export class InstagramProvider
     try {
       // Fetch media insights from Instagram Graph API
       const { data } = await (
-        await this.fetch(
+        await fetch(
           `https://${type}/v21.0/${postId}/insights?metric=views,reach,saved,likes,comments,shares&access_token=${accessToken}`
         )
       ).json();

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -433,7 +433,7 @@ export class LinkedinPageProvider
 
     const { elements: shareElements }: { elements: PostShareStatElement[] } =
       await (
-        await this.fetch(shareStatsUrl, {
+        await fetch(shareStatsUrl, {
           headers: {
             Authorization: `Bearer ${accessToken}`,
             'LinkedIn-Version': '202601',
@@ -449,7 +449,7 @@ export class LinkedinPageProvider
         postId
       )}`;
       socialActions = await (
-        await this.fetch(socialActionsUrl, {
+        await fetch(socialActionsUrl, {
           headers: {
             Authorization: `Bearer ${accessToken}`,
             'LinkedIn-Version': '202601',

--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -461,7 +461,7 @@ export class PinterestProvider
 
     try {
       // Fetch pin analytics from Pinterest API
-      const response = await this.fetch(
+      const response = await fetch(
         `https://api.pinterest.com/v5/pins/${postId}/analytics?start_date=${since}&end_date=${today}&metric_types=IMPRESSION,PIN_CLICK,OUTBOUND_CLICK,SAVE`,
         {
           method: 'GET',

--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -566,7 +566,7 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
     try {
       // Fetch thread insights from Threads API
       const { data } = await (
-        await this.fetch(
+        await fetch(
           `https://graph.threads.net/v1.0/${postId}/insights?metric=views,likes,replies,reposts,quotes&access_token=${accessToken}`
         )
       ).json();

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -860,7 +860,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
     try {
       // Get user stats (follower_count, following_count, likes_count, video_count)
-      const userStatsResponse = await this.fetch(
+      const userStatsResponse = await fetch(
         'https://open.tiktokapis.com/v2/user/info/?fields=follower_count,following_count,likes_count,video_count',
         {
           method: 'GET',
@@ -910,7 +910,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       }
 
       // Get recent videos and aggregate their stats
-      const videoListResponse = await this.fetch(
+      const videoListResponse = await fetch(
         'https://open.tiktokapis.com/v2/video/list/?fields=id',
         {
           method: 'POST',
@@ -929,7 +929,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
         const videoIds = videos.map((v: { id: string }) => v.id);
 
         // Query video details to get engagement metrics
-        const videoQueryResponse = await this.fetch(
+        const videoQueryResponse = await fetch(
           'https://open.tiktokapis.com/v2/video/query/?fields=id,like_count,comment_count,share_count,view_count',
           {
             method: 'POST',
@@ -1036,7 +1036,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
     if (postId.indexOf('v_pub_url') > -1) {
       const post = await (
-        await this.fetch(
+        await fetch(
           'https://open.tiktokapis.com/v2/post/publish/status/fetch/',
           {
             method: 'POST',
@@ -1047,10 +1047,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
             body: JSON.stringify({
               publish_id: postId,
             }),
-          },
-          '',
-          0,
-          true
+          }
         )
       ).json();
 
@@ -1063,7 +1060,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
     try {
       // Query video details using the video ID
-      const response = await this.fetch(
+      const response = await fetch(
         'https://open.tiktokapis.com/v2/video/query/?fields=id,like_count,comment_count,share_count,view_count',
         {
           method: 'POST',


### PR DESCRIPTION
## Problem

`this.fetch` (from `SocialAbstract`) is the **posting** wrapper: it routes response bodies through `handleErrors()`, sleeps 5s and retries on 429/500, and throws Temporal `ApplicationFailure`s (`BadBody`/`RefreshToken`). None of that belongs in analytics calls served from the backend API — and it forces analytics concerns into `handleErrors`, as seen in #1665 (review: "this.fetch should not be connected with pinterest analytics").

## Changes

Swapped `this.fetch` → plain `fetch` (the pattern every existing `analytics()` implementation already uses) in every analytics method that used it:

- **Pinterest** — `postAnalytics`
- **Facebook** — `postAnalytics`
- **Instagram** — `postAnalytics`
- **LinkedIn Page** — `postAnalytics` (2 calls)
- **Threads** — `postAnalytics`
- **TikTok** — `analytics` (3 calls) and `postAnalytics` (2 calls)

On failure these methods now fall into their existing catch/fallback paths and return empty data, same as the plain-fetch analytics methods behave today. Non-analytics uses of `this.fetch` (posting, TikTok `missing()`, LinkedIn repost plug) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)