### PR TITLE
fix(pinterest): keep analytics within the 90-day window

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -391,7 +391,10 @@ export class PinterestProvider
     date: number
   ): Promise<AnalyticsData[]> {
     const until = dayjs().format('YYYY-MM-DD');
-    const since = dayjs().subtract(date, 'day').format('YYYY-MM-DD');
+    // Pinterest analytics only cover the last 90 days (89 for a UTC safety margin)
+    const since = dayjs()
+      .subtract(Math.min(date, 89), 'day')
+      .format('YYYY-MM-DD');
 
     const {
       all: { daily_metrics },
@@ -456,8 +459,8 @@ export class PinterestProvider
     date: number
   ): Promise<AnalyticsData[]> {
     const today = dayjs().format('YYYY-MM-DD');
-    // Use a very long date range (2 years) to capture lifetime metrics for older posts
-    const since = dayjs().subtract(2, 'year').format('YYYY-MM-DD');
+    // Pinterest only serves pin analytics for the last 90 days (89 for a UTC safety margin)
+    const since = dayjs().subtract(89, 'day').format('YYYY-MM-DD');
 
     try {
       // Fetch pin analytics from Pinterest API


### PR DESCRIPTION
## Problem

Production logs show, for every Pinterest post:

```
Error fetching Pinterest post analytics: ApplicationFailure: Unknown Error
```

with Pinterest's underlying message: **"You can only get data from the last 90 days."**

Pinterest's analytics endpoints (`/v5/pins/{pin_id}/analytics`, `/v5/user_account/analytics`) only serve the **last 90 days** (evaluated in UTC). But `postAnalytics()` requested `start_date` **2 years** ago, so the call failed every time and pin analytics were always empty. Introduced in `5cca81e0` ("feat: post analytics").

## Changes

- **`postAnalytics`** — `start_date` is now **89 days** back instead of 2 years (89 rather than 90 avoids an off-by-one when the server's local date leads UTC).
- **`analytics`** (account level) — clamps the requested period to `Math.min(date, 89)` so a longer UI selection can't trip the same error.

Replaces #1665: per review there, analytics shouldn't be coupled to `this.fetch`/`handleErrors`, so the `handleErrors` mapping is dropped — #1725 decouples analytics from `this.fetch` across all providers.

Pin metrics older than ~90 days simply aren't available from Pinterest's API; older posts return only the recent-window data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)