### PR TITLE
fix: correct Short.io API integration

### DIFF
--- a/libraries/nestjs-libraries/src/short-linking/providers/short.io.ts
+++ b/libraries/nestjs-libraries/src/short-linking/providers/short.io.ts
@@ -2,13 +2,13 @@ import { ShortLinking } from '@gitroom/nestjs-libraries/short-linking/short-link
 
 const options = {
   headers: {
-    Authorization: `Bearer ${process.env.SHORT_IO_SECRET_KEY}`,
+    Authorization: `${process.env.SHORT_IO_SECRET_KEY}`,
     'Content-Type': 'application/json',
   },
 };
 
 export class ShortIo implements ShortLinking {
-  shortLinkDomain = 'short.io';
+  shortLinkDomain = process.env.SHORT_IO_DOMAIN || 'short.io';
 
   async linksStatistics(links: string[]) {
     return Promise.all(
@@ -38,10 +38,8 @@ export class ShortIo implements ShortLinking {
       ...options,
       method: 'POST',
       body: JSON.stringify({
-        url: link,
-        tenantId: id,
-        domain: this.shortLinkDomain,
         originalURL: link,
+        domain: this.shortLinkDomain,
       }),
     }).then((res) => res.json());
 


### PR DESCRIPTION
- Remove 'Bearer' prefix from Authorization header (Short.io API doesn't use it)
- Use SHORT_IO_DOMAIN env var for configurable domain
- Fix convertLinkToShortLink request body to match Short.io API spec

# What kind of change does this PR introduce?

 Bug fix

# Why was this change needed?

 The Short.io API integration had three bugs preventing short links from being generated:

1. Authorization header used incorrect "Bearer" prefix - The Short.io API does not expect a Bearer token prefix. The current code sends Authorization: Bearer sk_... which returns 401 Unauthorized. The API expects just Authorization: sk_....
2. hardLinkDomain was hardcoded - The shortLinkDomain was hardcoded as 'short.io', ignoring the SHORT_IO_DOMAIN environment variable users set. This prevented custom domains (like trapweb.link) from being used.
3. Request body had wrong parameters - The convertLinkToShortLink method sent url, tenantId, and duplicate originalURL parameters, but the Short.io API only accepts originalURL and domain.

  These bugs caused short links to fail silently, returning undefined instead of shortened URLs in posts.

# Other information:

  - Remove 'Bearer' prefix from Authorization header (Short.io API doesn't use it)
  - Use SHORT_IO_DOMAIN env var for configurable domain
  - Fix convertLinkToShortLink request body to match Short.io API spec

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
