### PR TITLE
fix(auth): match OIDC callback provider by pathname, not full URL

### DIFF
--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -90,7 +90,7 @@ export async function proxy(request: NextRequest) {
   const url = new URL(nextUrl).search;
   if (!nextUrl.pathname.startsWith('/auth') && !authCookie) {
     const providers = ['google', 'settings'];
-    const findIndex = providers.find((p) => nextUrl.href.indexOf(p) > -1);
+    const findIndex = providers.find((p) => nextUrl.pathname.indexOf(p) > -1);
     const additional = !findIndex
       ? ''
       : (url.indexOf('?') > -1 ? '&' : '?') +


### PR DESCRIPTION
### Problem

With `POSTIZ_GENERIC_OAUTH=true` wired to Google Workspace, signing in shows an infinite spinner and the backend logs `400 invalid_request: Could not determine client ID from request.`

### Root cause

`apps/frontend/src/proxy.ts` decides which OAuth provider handles a callback by substring-searching the **whole URL** (`nextUrl.href`) against `['google', 'settings']`:

```ts
const findIndex = providers.find((p) => nextUrl.href.indexOf(p) > -1);
```

A Google OIDC callback returns to `/settings`, but its query string carries `iss=https://accounts.google.com` and `googleapis.com` scopes. So `"google"` matches before `"settings"`, the middleware tags the login `provider=GOOGLE` (the native YouTube-Data provider) instead of `provider=GENERIC`, and the backend runs the token exchange with the empty `YOUTUBE_CLIENT_*` credentials -> `400 Could not determine client ID` -> endless spinner.

This is Google-specific: other OIDC providers (Authentik, Keycloak, Pocket-ID, etc.) don't put a provider name in the callback query, so they are unaffected. Same symptom as reported in #1566 (and likely #877 / #1114).

### Fix

Match against `nextUrl.pathname` (`/settings`) instead of the full href, so the query string can't mis-trigger a provider:

```ts
const findIndex = providers.find((p) => nextUrl.pathname.indexOf(p) > -1);
```

One line, no behaviour change for the non-Google providers. We run this as a small overlay patch in production and it fixed Google Workspace login end to end.

Fixes #1566.