### PR TITLE
fix(facebook): publish Reels via the Reels Publishing API, not /videos

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -566,30 +566,72 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       finalId = lastPostId;
       finalUrl = `https://www.facebook.com/stories/${lastPostId}`;
     } else if (hasExtension(firstPost?.media?.[0]?.path, 'mp4')) {
-      const {
-        id: videoId,
-        permalink_url,
-        ...all
-      } = await (
+      // Facebook Reels must be published through the dedicated Reels Publishing
+      // API (/video_reels: start -> upload -> finish with video_state=PUBLISHED).
+      // Posting a vertical video to the plain /videos endpoint only ingests it
+      // and leaves it as a draft, so the Page owner just gets a "your reel is
+      // ready, share it with your followers" notification and it never
+      // auto-publishes. Mirror the video_stories hosted-upload flow above.
+      const { video_id, upload_url } = await (
         await this.fetch(
-          `https://graph.facebook.com/v20.0/${id}/videos?access_token=${accessToken}&fields=id,permalink_url`,
+          `https://graph.facebook.com/v20.0/${id}/video_reels?upload_phase=start&access_token=${accessToken}`,
           {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              file_url: firstPost?.media?.[0]?.path!,
-              description: firstPost.message,
-              published: true,
-            }),
           },
-          'upload mp4'
+          'start reel upload'
         )
       ).json();
 
-      finalUrl = 'https://www.facebook.com/reel/' + videoId;
-      finalId = videoId;
+      await this.fetch(
+        upload_url,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `OAuth ${accessToken}`,
+            file_url: firstPost?.media?.[0]?.path!,
+          },
+        },
+        'upload reel'
+      );
+
+      let videoStatus = 'in_progress';
+      let attempts = 0;
+      const maxAttempts = 54; // ~9 minutes at 10s interval
+      while (videoStatus !== 'upload_complete' && videoStatus !== 'ready') {
+        if (attempts++ >= maxAttempts) {
+          throw new Error('Video processing timed out');
+        }
+
+        const { status } = await (
+          await this.fetch(
+            `https://graph.facebook.com/v20.0/${video_id}?fields=status&access_token=${accessToken}`,
+            undefined,
+            '',
+            0,
+            true
+          )
+        ).json();
+        videoStatus = status?.video_status || 'in_progress';
+        if (videoStatus === 'error') {
+          throw new Error('Video processing failed');
+        }
+        if (videoStatus !== 'upload_complete' && videoStatus !== 'ready') {
+          await timer(10000);
+        }
+      }
+
+      await this.fetch(
+        `https://graph.facebook.com/v20.0/${id}/video_reels?upload_phase=finish&video_id=${video_id}&video_state=PUBLISHED&description=${encodeURIComponent(
+          firstPost.message || ''
+        )}&access_token=${accessToken}`,
+        {
+          method: 'POST',
+        },
+        'publish reel'
+      );
+
+      finalUrl = 'https://www.facebook.com/reel/' + video_id;
+      finalId = video_id;
     } else {
       const uploadPhotos = !firstPost?.media?.length
         ? []


### PR DESCRIPTION
## Problem

Scheduled Facebook Reels never auto-publish. Instead, the Page owner just gets a **"Your reel is ready — share it with your followers"** notification and has to publish manually in the Facebook app. This affects every self-hosted install posting FB Reels.

## Cause

The `mp4` branch of `FacebookProvider.post()` uploads reels to the legacy `/{page-id}/videos` endpoint with `published: true`, then cosmetically labels the returned URL as `facebook.com/reel/...`:

```ts
await this.fetch(
  `https://graph.facebook.com/v20.0/${id}/videos?...`,
  { method: 'POST', body: JSON.stringify({ file_url, description, published: true }) },
  'upload mp4'
);
finalUrl = 'https://www.facebook.com/reel/' + videoId;
```

A vertical video sent to `/videos` is ingested as a **draft**. Facebook then routes it into the "ready to share" flow and waits for a manual publish — it is never auto-published as a Reel. The upload always succeeds, which is why it looks like it "worked" but nothing goes live.

## Fix

Use Facebook's dedicated [Reels Publishing API](https://developers.facebook.com/docs/video-api/guides/reels-publishing/), mirroring the existing `video_stories` hosted-upload flow already in this file:

1. `POST /{page-id}/video_reels?upload_phase=start` → `{ video_id, upload_url }`
2. Upload the hosted `file_url`
3. Poll `status.video_status` until `upload_complete`/`ready` (with a ~9 min timeout, same as stories)
4. `POST upload_phase=finish` with **`video_state=PUBLISHED`**

Postiz's scheduler already invokes `post()` at the target publish time, so `PUBLISHED` (publish now) is correct rather than `SCHEDULED`.

## Notes

- No new imports, permissions, or scopes required (`pages_manage_posts` already covers it).
- Single-file change, scoped to the reels branch; text/photo/story paths untouched.
- Verified in a self-hosted deployment: reels now publish automatically with no notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)