### PR TITLE
fix(tiktok): resume the in-flight publish on re-run to prevent duplicate posts

### DIFF
--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -227,6 +227,7 @@ export class PostActivity {
     // workflow loaded before running this activity means the current cycle
     // hasn't published yet (repeatable posts re-run with the same post id).
     const [firstPost] = posts;
+    let inFlight: string | undefined;
     if (firstPost) {
       const current = await this._postService.getPostReleaseId(firstPost.id);
       if (current?.releaseId && current.releaseId !== firstPost.releaseId) {
@@ -239,6 +240,12 @@ export class PostActivity {
           },
         ];
       }
+
+      // A previous attempt initiated a publish but died before observing its
+      // outcome — pass the provider publish id along so the provider can
+      // resume polling it instead of publishing again. The marker's TTL guards
+      // repeatable posts: a leftover from an earlier cycle has already expired.
+      inFlight = (await this._postService.getPostInFlight(firstPost.id)) || undefined;
     }
 
     const newPosts = await this._postService.updateTags(
@@ -250,7 +257,7 @@ export class PostActivity {
       integration.internalId,
       integration.token,
       await Promise.all(
-        (newPosts || []).map(async (p) => ({
+        (newPosts || []).map(async (p, index) => ({
           id: p.id,
           message: stripHtmlValidation(
             getIntegration.editor,
@@ -266,18 +273,28 @@ export class PostActivity {
             JSON.parse(p.image || '[]'),
             getIntegration?.convertToJPEG || false
           ),
+          ...(index === 0 && inFlight ? { inFlight } : {}),
         }))
       ),
       integration,
       async (response) => {
+        if (response.status === 'in-progress') {
+          // The publish is initiated but not confirmed — record it only as a
+          // resume hint for a possible retry; the post is not published yet,
+          // so it must not be marked PUBLISHED.
+          await this._postService.setPostInFlight(response.id, response.postId);
+          return;
+        }
+
         // Persist the remote id the moment the platform confirms the
         // publish, so a crash or retry after this point cannot publish a
-        // duplicate.
+        // duplicate; drop the resume marker now that we're done with it.
         await this._postService.updatePost(
           response.id,
           response.postId,
           response.releaseURL
         );
+        await this._postService.clearPostInFlight(response.id);
       }
     );
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -85,6 +85,24 @@ export class PostsService {
     return this._postRepository.getPostReleaseId(id);
   }
 
+  // The in-flight publish id is transient de-duplication state, not a durable
+  // record, so it lives in Redis (with a TTL) rather than the DB. A provider
+  // records it at its publish boundary; a re-run reads it back to resume the
+  // in-flight publish instead of initiating a duplicate. The 2-hour TTL makes
+  // stale markers self-expire, so a later repeat-post cycle never resumes an
+  // old publish (polling never exceeds ~9 minutes).
+  async setPostInFlight(id: string, inFlightId: string) {
+    await ioRedis.set(`post:inflight:${id}`, inFlightId, 'EX', 2 * 60 * 60);
+  }
+
+  getPostInFlight(id: string) {
+    return ioRedis.get(`post:inflight:${id}`);
+  }
+
+  async clearPostInFlight(id: string) {
+    await ioRedis.del(`post:inflight:${id}`);
+  }
+
   async getMissingContent(
     orgId: string,
     postId: string,
@@ -942,6 +960,11 @@ export class PostsService {
   }
 
   async changeState(id: string, state: State, err?: any, body?: any) {
+    // A terminal error ends the current publish attempt — drop the in-flight
+    // marker so it can't leak into a later cycle before its TTL expires.
+    if (state === 'ERROR') {
+      await this.clearPostInFlight(id);
+    }
     return this._postRepository.changeState(id, state, err, body);
   }
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -960,11 +960,6 @@ export class PostsService {
   }
 
   async changeState(id: string, state: State, err?: any, body?: any) {
-    // A terminal error ends the current publish attempt — drop the in-flight
-    // marker so it can't leak into a later cycle before its TTL expires.
-    if (state === 'ERROR') {
-      await this.clearPostInFlight(id);
-    }
     return this._postRepository.changeState(id, state, err, body);
   }
 

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -90,6 +90,10 @@ export interface ISocialMediaIntegration {
     // Called the moment the platform confirms a publish, so the caller can
     // persist the remote id before any later step can fail — a retry after
     // a post-publish failure must not publish a duplicate.
+    // A provider may also report an *unconfirmed* publish with
+    // status 'in-progress' (postId = the provider's in-flight publish id):
+    // the publish has been initiated but may still fail, so the caller must
+    // only record it as a resume hint, never as a completed publish.
     progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]>; // Schedules a new post
 
@@ -116,6 +120,11 @@ export type PostDetails<T = any> = {
   settings: T;
   media?: MediaContent[];
   poll?: PollDetails;
+  // The provider publish id of a publish that is already in flight for this
+  // post (from a previous attempt that died mid-poll). When set, a provider
+  // that supports it should resume observing that publish instead of
+  // initiating a new one.
+  inFlight?: string;
 };
 
 export type PollDetails = {

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -407,11 +407,18 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
-  private async uploadedVideoSuccess(
+  // Observes an in-flight publish to its terminal state. FAILED comes back as
+  // a discriminated result (nothing was published — the caller decides whether
+  // to re-init or surface the error); poll-exhaustion throws, and token /
+  // network errors from this.fetch propagate untouched.
+  private async pollPublishStatus(
     id: string,
     publishId: string,
     accessToken: string
-  ): Promise<{ url: string; id: string }> {
+  ): Promise<
+    | { status: 'complete'; url: string; id: string }
+    | { status: 'failed'; response: any }
+  > {
     // eslint-disable-next-line no-constant-condition
     for (const i of Array(27).keys()) {
       // ~9 minutes at 20s interval
@@ -438,6 +445,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
       if (status === 'SEND_TO_USER_INBOX') {
         return {
+          status: 'complete',
           url: 'https://www.tiktok.com/messages?lang=en',
           id: 'missing',
         };
@@ -445,6 +453,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
 
       if (status === 'PUBLISH_COMPLETE') {
         return {
+          status: 'complete',
           url: !publicaly_available_post_id
             ? `https://www.tiktok.com/@${id}`
             : `https://www.tiktok.com/@${id}/video/` +
@@ -456,13 +465,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       }
 
       if (status === 'FAILED') {
-        const handleError = this.handleErrors(JSON.stringify(post));
-        throw new BadBody(
-          'titok-error-upload',
-          JSON.stringify(post),
-          Buffer.from(JSON.stringify(post)),
-          handleError?.value || ''
-        );
+        return { status: 'failed', response: post };
       }
 
       await timer(20000);
@@ -474,6 +477,26 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       Buffer.from(JSON.stringify({})),
       'TikTok refused to publish your post'
     );
+  }
+
+  private async uploadedVideoSuccess(
+    id: string,
+    publishId: string,
+    accessToken: string
+  ): Promise<{ url: string; id: string }> {
+    const result = await this.pollPublishStatus(id, publishId, accessToken);
+
+    if (result.status === 'failed') {
+      const handleError = this.handleErrors(JSON.stringify(result.response));
+      throw new BadBody(
+        'titok-error-upload',
+        JSON.stringify(result.response),
+        Buffer.from(JSON.stringify(result.response)),
+        handleError?.value || ''
+      );
+    }
+
+    return { url: result.url, id: result.id };
   }
 
   private postingMethod(
@@ -776,9 +799,43 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     id: string,
     accessToken: string,
     postDetails: PostDetails<TikTokDto>[],
-    integration: Integration
+    integration: Integration,
+    progress?: (response: PostResponse) => Promise<unknown> | unknown
   ): Promise<PostResponse[]> {
     const [firstPost] = postDetails;
+
+    // A previous attempt already initiated this publish (init + bytes) but
+    // died before observing the outcome. TikTok completes the publish
+    // server-side, so a fresh init would create a duplicate — resume
+    // observing the in-flight publish instead. FAILED means nothing was
+    // published, so we fall through to a fresh init below; token / network
+    // errors propagate so the next attempt resumes again.
+    if (firstPost?.inFlight) {
+      const resumed = await this.pollPublishStatus(
+        integration.profile!,
+        firstPost.inFlight,
+        accessToken
+      );
+
+      if (resumed.status === 'complete') {
+        await progress?.({
+          id: firstPost.id,
+          postId: String(resumed.id),
+          releaseURL: resumed.url,
+          status: 'success',
+        });
+
+        return [
+          {
+            id: firstPost.id,
+            releaseURL: resumed.url,
+            postId: String(resumed.id),
+            status: 'success',
+          },
+        ];
+      }
+    }
+
     const isPhoto = !hasExtension(firstPost?.media?.[0]?.path, 'mp4');
     const videoPath = firstPost?.media?.[0]?.path!;
 
@@ -811,6 +868,17 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       )
     ).json();
 
+    // The publish boundary: from here on TikTok owns the publish and a retry
+    // must resume observing it, not init again. Reported before the byte
+    // upload on purpose — a crash mid-upload leaves TikTok waiting for bytes,
+    // and the resume path's poll ends in FAILED → clean re-init.
+    await progress?.({
+      id: firstPost.id,
+      postId: publish_id,
+      releaseURL: '',
+      status: 'in-progress',
+    });
+
     // Videos: stream the bytes to the upload_url returned by the init call.
     if (!isPhoto && upload_url && videoSize) {
       await this.uploadTikTokVideoBytes(
@@ -826,6 +894,13 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       publish_id,
       accessToken
     );
+
+    await progress?.({
+      id: firstPost.id,
+      postId: String(videoId),
+      releaseURL: url,
+      status: 'success',
+    });
 
     return [
       {


### PR DESCRIPTION
## What this fixes

Confirmed production incident: TikTok's ~24h access token expired during `postSocial`'s status polling — after the publish init + video upload had already succeeded. The workflow's token-refresh loop re-ran `postSocial` from scratch → second init → **two identical TikTok posts**, green workflow, success email. TikTok completes a publish server-side once init + bytes are in; our polling is pure observation, so a re-run must resume observing the in-flight publish, never initiate a new one.

The TikTok provider now reports the `publish_id` via an `'in-progress'` progress status the moment init returns (before the byte upload). A re-run picks it up and polls that publish to completion instead of re-initing; `FAILED` falls through to a clean fresh init (nothing was published), and token/network errors propagate so the next re-run resumes again.

## Why Redis, not the DB (supersedes #1682)

#1682 (closed) implemented this with two nullable `Post` columns. The `publish_id` is only needed **within the scope of publishing the post** — transient de-duplication state, not a long-term record — so it shouldn't be DB-persisted. It lives in Redis under `post:inflight:<postId>` with a **2h TTL**, deleted eagerly on success and TTL-expired otherwise, following the existing ioRedis analytics-cache pattern (5cca81e0). (The marker is deliberately NOT cleared on ERROR: the workflow keeps retrying after marking ERROR for timeout/generic failures, and a re-run must still resume — caught by the Sentry review below, fixed in the second commit.) The TTL aligns with the project's other Redis retention (OAuth connect state and analytics caches: 1h) and comfortably exceeds any single publish saga (~9-min poll window plus retries). **No schema change, no migration, no deploy ordering.**

## Verification (real TikTok test channel)

Injected `access_token_invalid` after init+upload: the re-run resumed the **same** `publish_id` (marker value never changed — no second init) → exactly one TikTok post, state `PUBLISHED`, `releaseId` equal to the crashed attempt's publish_id, marker cleared. The same run also crossed a *genuine* expired-token refresh at init, exercising the real production path end to end. MockRedis fallback (no `REDIS_URL`) verified safe.

Stacked on #1681 (`fix/instagram-publish-boundary`) — reuses its `progress` callback; rebase onto main after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
