### PR TITLE
fix: accepting a redundant invite to an organization the user already belongs to errors out

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -219,6 +219,18 @@ export class OrganizationRepository {
       return false;
     }
 
+    const checkIfMemberExists =
+      await this._userOrg.model.userOrganization.findFirst({
+        where: {
+          userId,
+          organizationId: orgId,
+        },
+      });
+
+    if (checkIfMemberExists) {
+      return false;
+    }
+
     const checkForSubscription =
       await this._organization.model.organization.findFirst({
         where: {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, organizations / team invites). `OrganizationRepository.addUserToOrg` now looks for an existing `userOrganization` row for that user and organization before creating one, and returns `false` when it finds one - the same value it already returns for an invite that was previously redeemed, and which `POST /users/join-org` already handles as a clean no-op. Without the check the create hit the `@@unique([userId, organizationId])` constraint on `UserOrganization` and surfaced as an uncaught 500. The first-time invite path, the subscription-tier check and the stored membership data are all unchanged.

## Why

When a user who is already a member of an organization clicks another still-valid invite link, `addUserToOrg` only dedupes on the invite id ("has this specific invite already been redeemed?") and never checks membership. The membership create then hits the `userId_organizationId` unique constraint and the request fails with an uncaught error.

Two pre-existing flows trigger it, both involving two separate invites for the same user and ending in that same uncaught error:

1. The second invite is sent **before** the user joins via the first one, and clicked after they joined.
2. The second invite is sent (e.g. resent by the org owner, who gets no already-a-member indication) **after** the user has already joined, and then clicked.

Membership data stays correct either way — the unique index blocks the duplicate — the bug is the uncaught error instead of a graceful no-op.

## What changed

`addUserToOrg` now checks for an existing `userOrganization` row for that user + organization before creating one, and returns `false` — the same value it already returns for a redeemed invite, which the join flow handles as a clean no-op (the user just lands back in the app).

# QA

1. [ ] Log in as an organization owner, go to Settings -> Team, invite user B by email and copy the invite link
2. [ ] In a second browser, accept the invite as user B - B joins the organization
3. [ ] Back as the owner, send B a second invite for the same organization and copy that link
4. [ ] Open the second link as user B - B lands back in the app with no error, and `POST /users/join-org` returns 200 with `{"id": null}`
5. [ ] Settings -> Team still lists user B exactly once
6. [ ] Backend logs contain no Prisma P2002 unique-constraint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
