### PR TITLE
feat: admin can add a team member to the impersonated organization

### DIFF
--- a/apps/backend/src/api/routes/settings.controller.ts
+++ b/apps/backend/src/api/routes/settings.controller.ts
@@ -1,9 +1,19 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpException,
+  Param,
+  Post,
+} from '@nestjs/common';
 import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.request';
-import { Organization } from '@prisma/client';
+import { GetUserFromRequest } from '@gitroom/nestjs-libraries/user/user.from.request';
+import { Organization, User } from '@prisma/client';
 import { CheckPolicies } from '@gitroom/backend/services/auth/permissions/permissions.ability';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { AddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/add.team.member.dto';
+import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/admin.add.team.member.dto';
 import { ShortlinkPreferenceDto } from '@gitroom/nestjs-libraries/dtos/settings/shortlink-preference.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthorizationActions, Sections } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
@@ -34,6 +44,19 @@ export class SettingsController {
     @Body() body: AddTeamMemberDto
   ) {
     return this._organizationService.inviteTeamMember(org.id, body);
+  }
+
+  @Post('/team/add')
+  async addTeamMember(
+    @GetUserFromRequest() user: User,
+    @GetOrgFromRequest() org: Organization,
+    @Body() body: AdminAddTeamMemberDto
+  ) {
+    if (!user.isSuperAdmin) {
+      throw new HttpException('Unauthorized', 400);
+    }
+
+    return this._organizationService.addTeamMemberByEmail(org, body);
   }
 
   @Delete('/team/:id')

--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -12,6 +12,10 @@ import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 import { Button } from '@gitroom/react/form/button';
 import { ImportDebugPostModal } from '@gitroom/frontend/components/launches/import-debug-post.modal';
+import { useForm, FormProvider } from 'react-hook-form';
+import { classValidatorResolver } from '@hookform/resolvers/class-validator';
+import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/admin.add.team.member.dto';
+import { useToaster } from '@gitroom/react/toaster/toaster';
 
 interface Charge {
   id: string;
@@ -411,6 +415,92 @@ const AddAnnouncement = () => {
   );
 };
 
+const AddTeamMemberModal: FC<{ close: () => void }> = ({ close }) => {
+  const fetch = useFetch();
+  const toast = useToaster();
+  const t = useT();
+  const [saving, setSaving] = useState(false);
+  const resolver = useMemo(() => {
+    return classValidatorResolver(AdminAddTeamMemberDto);
+  }, []);
+  const form = useForm({
+    values: {
+      email: '',
+      role: '',
+    },
+    resolver,
+    mode: 'onChange',
+  });
+
+  const submit = useCallback(
+    async (values: { email: string; role: string }) => {
+      setSaving(true);
+      try {
+        const response = await fetch('/settings/team/add', {
+          method: 'POST',
+          body: JSON.stringify(values),
+        });
+        if (!response.ok) {
+          toast.show(
+            (await response.json()).message ||
+              t('could_not_add_member', 'Could not add the member'),
+            'warning'
+          );
+          return;
+        }
+        toast.show(t('member_added', 'Member added'));
+        close();
+      } finally {
+        setSaving(false);
+      }
+    },
+    []
+  );
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(submit)}>
+        <div className="flex flex-col gap-[10px] min-w-[400px]">
+          <Input
+            label="Email"
+            placeholder={t('enter_email', 'Enter email')}
+            name="email"
+          />
+          <Select label="Role" name="role">
+            <option value="">{t('select_role', 'Select Role')}</option>
+            <option value="USER">{t('user', 'User')}</option>
+            <option value="ADMIN">{t('admin', 'Admin')}</option>
+          </Select>
+          <Button type="submit" loading={saving} className="rounded-[4px]">
+            {t('add_team_member', 'Add Team Member')}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
+
+const AddTeamMember = () => {
+  const { openModal } = useModals();
+  const t = useT();
+
+  const handleClick = useCallback(() => {
+    openModal({
+      title: t('add_team_member', 'Add Team Member'),
+      children: (close) => <AddTeamMemberModal close={close} />,
+    });
+  }, []);
+
+  return (
+    <div
+      className="px-[10px] rounded-[4px] bg-teal-700 text-white cursor-pointer whitespace-nowrap"
+      onClick={handleClick}
+    >
+      {t('add_team_member', 'Add Team Member')}
+    </div>
+  );
+};
+
 const ViewErrors = () => {
   const t = useT();
   const handleClick = useCallback(() => {
@@ -540,6 +630,7 @@ export const Impersonate = () => {
                   </div>
                 </div>
                 {user?.tier?.current === 'FREE' && <Subscription />}
+                {user?.tier?.team_members && <AddTeamMember />}
                 {billingEnabled && <ManageBilling />}
               </div>
             ) : (

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -203,6 +203,14 @@ export class OrganizationRepository {
     });
   }
 
+  getUsersByEmail(email: string) {
+    return this._user.model.user.findMany({
+      where: {
+        email,
+      },
+    });
+  }
+
   async addUserToOrg(
     userId: string,
     id: string,

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
@@ -1,8 +1,10 @@
 import { CreateOrgUserDto } from '@gitroom/nestjs-libraries/dtos/auth/create.org.user.dto';
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { OrganizationRepository } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.repository';
 import { NotificationService } from '@gitroom/nestjs-libraries/database/prisma/notifications/notification.service';
 import { AddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/add.team.member.dto';
+import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/admin.add.team.member.dto';
+import { pricing } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/pricing';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import dayjs from 'dayjs';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
@@ -91,6 +93,62 @@ export class OrganizationService {
       );
     }
     return { url };
+  }
+
+  async addTeamMemberByEmail(org: Organization, body: AdminAddTeamMemberDto) {
+    const tier =
+      // @ts-ignore
+      org?.subscription?.subscriptionTier ||
+      (!process.env.STRIPE_PUBLISHABLE_KEY ? 'ULTIMATE' : 'FREE');
+
+    if (!pricing[tier].team_members) {
+      throw new HttpException(
+        'The organization plan does not include team members',
+        400
+      );
+    }
+
+    const users = await this._organizationRepository.getUsersByEmail(
+      body.email
+    );
+    if (!users.length) {
+      throw new HttpException('No Postiz account found for this email', 400);
+    }
+
+    if (users.length > 1) {
+      throw new HttpException(
+        'Multiple accounts exist for this email (different login providers)',
+        400
+      );
+    }
+
+    const [user] = users;
+
+    const userOrgs = await this._organizationRepository.getOrgsByUserId(
+      user.id
+    );
+    if (userOrgs.some((current) => current.id === org.id)) {
+      throw new HttpException(
+        'User is already a member of this organization',
+        400
+      );
+    }
+
+    const added = await this._organizationRepository.addUserToOrg(
+      user.id,
+      makeId(5),
+      org.id,
+      body.role as 'USER' | 'ADMIN'
+    );
+
+    if (!added) {
+      throw new HttpException(
+        'Could not add the user to the organization',
+        400
+      );
+    }
+
+    return { added: true };
   }
 
   async deleteTeamMember(org: Organization, userId: string) {

--- a/libraries/nestjs-libraries/src/dtos/settings/admin.add.team.member.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/settings/admin.add.team.member.dto.ts
@@ -1,0 +1,11 @@
+import { IsDefined, IsEmail, IsIn, IsString } from 'class-validator';
+
+export class AdminAddTeamMemberDto {
+  @IsDefined()
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @IsIn(['USER', 'ADMIN'])
+  role: string;
+}


### PR DESCRIPTION
## Why

Support flow: while helping a user (already in a thread with them), an admin needs to attach an existing Postiz account to that user's organization without the invitation-email round trip and without approval from the added account. Since team invitations are stateless JWT links (nothing is stored in the DB), "approving" an already-sent invitation is the same operation as adding the member directly — so this also covers the case where the org owner already sent an invite that the user never completed.

## What changed

- **Impersonation bar**: a new **Add Team Member** button, shown only while impersonating and only when the impersonated organization's plan includes team members (`pricing[tier].team_members` — TEAM and above). Opens a modal with email + role (USER/ADMIN), mirroring the existing team invite form.
- **Backend**: superadmin-only `POST /settings/team/add` → `OrganizationService.addTeamMemberByEmail`, which gates on the plan, looks the email up across **all** auth providers, and returns clear errors for: no account with that email, multiple accounts sharing the email on different providers (refuses to guess rather than attach the wrong account), and already-a-member. The add itself reuses the existing `addUserToOrg` path.
- **No emails are sent by design** — the admin performs this inside a support thread with the users involved, and the regular invite-acceptance flow sends no notification emails either, so behavior stays consistent.

Manually verified on the admin panel: an existing account is added successfully and appears in the org's team, and a non-existing email fires an error toast.

## Other information

- #1742 hardens the related pre-existing invite path (clicking a leftover invite link after already being a member — e.g. after an admin add — used to error).
- Heads-up: `feat/admin-activate-user` (PR to come) also touches `impersonate.tsx`; whichever lands second will have a trivial merge conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)