### PR TITLE
fix: persist last selected org on the user

### DIFF
--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -344,6 +344,13 @@ export class UsersController {
       return;
     }
 
+    const organizations = (
+      await this._orgService.getOrgsByUserId(user.id)
+    ).filter((f) => !f.users[0].disabled);
+    if (organizations.some((org) => org.id === id)) {
+      await this._userService.updateLastSelectedOrg(user.id, id);
+    }
+
     response.cookie('showorg', id, {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
       ...(!process.env.NOT_SECURED

--- a/apps/backend/src/services/auth/auth.middleware.ts
+++ b/apps/backend/src/services/auth/auth.middleware.ts
@@ -104,10 +104,16 @@ export class AuthMiddleware implements NestMiddleware {
       const organization = (
         await this._organizationService.getOrgsByUserId(user.id)
       ).filter((f) => !f.users[0].disabled);
+      const cookieOrg = organization.find((org) => org.id === orgHeader);
       const setOrg =
-        organization.find((org) => org.id === orgHeader) ||
+        cookieOrg ||
+        organization.find((org) => org.id === user.lastSelectedOrgId) ||
         organization.find((org) => org.subscription) ||
         organization[0];
+
+      if (cookieOrg && !user.lastSelectedOrgId) {
+        await this._userService.updateLastSelectedOrg(user.id, cookieOrg.id);
+      }
 
       if (!organization) {
         throw new HttpForbiddenException();

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -370,6 +370,7 @@ export class OrganizationRepository {
       },
       data: {
         inviteId: id,
+        lastSelectedOrgId: orgId,
       },
     });
 
@@ -504,6 +505,16 @@ export class OrganizationRepository {
   }
 
   async deleteTeamMember(orgId: string, userId: string) {
+    await this._user.model.user.updateMany({
+      where: {
+        id: userId,
+        lastSelectedOrgId: orgId,
+      },
+      data: {
+        lastSelectedOrgId: null,
+      },
+    });
+
     return this._userOrg.model.userOrganization.delete({
       where: {
         userId_organizationId: {

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -95,6 +95,7 @@ model User {
   updatedAt             DateTime             @updatedAt
   lastReadNotifications DateTime             @default(now())
   inviteId              String?
+  lastSelectedOrgId     String?
   activated             Boolean              @default(true)
   account               String?
   connectedAccount      Boolean              @default(false)

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
@@ -162,6 +162,17 @@ export class UsersRepository {
     });
   }
 
+  updateLastSelectedOrg(id: string, lastSelectedOrgId: string) {
+    return this._user.model.user.update({
+      where: {
+        id,
+      },
+      data: {
+        lastSelectedOrgId,
+      },
+    });
+  }
+
   getUserByProvider(providerId: string, provider: Provider) {
     return this._user.model.user.findFirst({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
@@ -131,6 +131,10 @@ export class UsersService {
     return this._usersRepository.activateUser(id);
   }
 
+  updateLastSelectedOrg(id: string, lastSelectedOrgId: string) {
+    return this._usersRepository.updateLastSelectedOrg(id, lastSelectedOrgId);
+  }
+
   updatePassword(id: string, password: string) {
     return this._usersRepository.updatePassword(id, password);
   }


### PR DESCRIPTION
# ⚠️ DO NOT MERGE until #2022 is merged

This PR is stacked on top of #2022 (prefer an org with a subscription as the default active org) and its base is that branch. Merge #2022 into staging first, then retarget this PR to staging and merge it.

# What kind of change does this PR introduce?

Bug fix (backend, auth middleware + org switcher). **Requires a schema migration**, see below. Adds `User.lastSelectedOrgId`, persists it from `POST /user/change-org` and from invite acceptance, and makes `AuthMiddleware` resolve the active org as: `showorg` cookie, then the persisted `lastSelectedOrgId`, then the subscription tiebreak from #2022, then the first org. Removing a member clears their persisted value if it pointed at that org. Nothing else about auth or impersonation changes.

# Why was this change needed?

The active org lived only in the device-local `showorg` cookie, so a multi-org user signing in on a fresh browser landed in a fallback org with no memory of their choice. #2022 makes that fallback sensible (a subscribed org first), but it cannot know which org the user actually last worked in. In practice: a member added to another org who signs in on a new device lands in their own org instead of the one they work in.

This PR stores the selection on the `User` record:

- `POST /user/change-org` (the org selector) persists the choice after validating membership, skipping orgs the user is disabled in.
- Invite acceptance persists the joined org (matching the `showorg` cookie the auth flow already sets).
- The auth middleware resolves the org as: cookie → persisted `lastSelectedOrgId` → subscribed org (#2022) → `organization[0]`, and lazily seeds `lastSelectedOrgId` from a valid cookie when it is still empty.
- Removing a member from an org clears their persisted value if it pointed at that org, so they fall back to their own org.

**Impersonation is excluded from persistence.** During impersonation the auth middleware replaces `req.user` with the impersonated account, so `POST /user/change-org` receives the customer, not the admin. Staging already returns early on that path (the impersonation org switch from #1866 moves the impersonation instead), before the `lastSelectedOrgId` write, so the customer's row is never touched. The separate guard from the earlier revision of this PR was dropped as unreachable.

# Schema migration

**This PR cannot be deployed without a migration.** It adds one new column, `User.lastSelectedOrgId` (nullable `String`), applied via `prisma db push` on deploy. The change is additive and nullable, no backfill, safe for running instances and for old clients during rollout. Cross-device persistence inherently needs server-side storage, so there is no cookie-only alternative; a nullable scalar on `User` is the smallest form it can take.

**No regression for existing users on deploy:**
- Accounts carrying a valid `showorg` cookie get `lastSelectedOrgId` lazily seeded from the cookie on their first request; they stay in the org they were using.
- Accounts with no cookie keep `null` and go through the #2022 fallback (subscribed org, else first org). The field fills in the first time they make an explicit org choice, which is the first moment it matters.

# Other information:

Restacked on 2026-09-04 onto #2022 and rebased onto current staging as a single squashed commit of the original three. Verified locally against the running middleware with a user in two orgs: no cookie and nothing persisted lands in the subscribed org; switching via change-org persists the choice and a fresh cookie-less login lands there; a cookie for another org wins without overwriting the persisted value; with the persisted value cleared, a request carrying a cookie seeds it.

The role-reassignment PR (#1746) was stacked on the previous revision of this branch and will need a rebase.

# QA

1. [ ] Deploy with `prisma db push` so `User.lastSelectedOrgId` exists.
2. [ ] Create user A with a paid org and user B with a fresh account; as A invite B and as B accept, so B is in two orgs.
3. [ ] As B, log out, clear cookies, log in: B lands in A's paid org (the #2022 fallback).
4. [ ] As B, switch to the personal org via the org switcher, then log out, clear cookies, and log in again: B lands in the personal org, showing the persisted choice beats the subscription fallback.
5. [ ] As B, with the personal org persisted, set the org switcher to A's org and reload a few times: A's org stays selected (cookie wins) and switching back later still works.
6. [ ] As A, remove B from the org. As B, log in fresh: B lands in the personal org with no error.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
