### PR TITLE
feat(agent): list posts via a tool aligned with the List Posts API

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -27,6 +27,7 @@ import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { GetPostsDto } from '@gitroom/nestjs-libraries/dtos/posts/get.posts.dto';
 import { ChangePostStatusDto } from '@gitroom/nestjs-libraries/dtos/posts/change.post.status.dto';
+import { UpdatePostSettingsDto } from '@gitroom/nestjs-libraries/dtos/posts/update.post.settings.dto';
 import {
   AuthorizationActions,
   Sections,
@@ -472,6 +473,21 @@ export class PublicIntegrationsController {
   ) {
     Sentry.metrics.count('public_api-request', 1);
     return this._postsService.getMissingContent(org.id, id);
+  }
+
+  @Put('/posts/:id/settings')
+  async updatePostSettings(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string,
+    @Body() body: UpdatePostSettingsDto
+  ) {
+    Sentry.metrics.count('public_api-request', 1);
+    return this._postsService.updatePostSettings(
+      org.id,
+      id,
+      body.settings,
+      'API'
+    );
   }
 
   @Put('/posts/:id/status')

--- a/libraries/nestjs-libraries/src/chat/load.tools.service.ts
+++ b/libraries/nestjs-libraries/src/chat/load.tools.service.ts
@@ -55,6 +55,7 @@ export class LoadToolsService {
       You are an agent that helps manage and schedule social media posts for users, you can:
         - Schedule posts into the future, or now, adding texts, images and videos
         - List the posts scheduled between two dates (postsListTool)
+        - Update the settings of a scheduled post or draft that was not published yet (postSettingsTool)
         - Generate pictures for posts
         - Generate videos for posts
         - Generate text for posts
@@ -78,12 +79,15 @@ export class LoadToolsService {
       - Make sure you always take the last information I give you about the socials, it might have changed.
       - Before scheduling a post, always make sure you ask the user confirmation by providing all the details of the post (text, images, videos, date, time, social media platform, account).
       - To find or inspect existing posts, use postsListTool with a UTC start and end date - it returns every post scheduled in that window. To cover "all my upcoming posts", pass a wide window starting now.
+      - To change the provider settings of an existing post that was not published yet (scheduled or draft), first find it with postsListTool, then use postSettingsTool with the post's id. It only updates the settings - the content and the publish date stay as they are - and only the keys you pass are changed (get them with the integrationSchema tool). Show the user which post and which settings will change and get their confirmation first.
+      - Never open the "modal with populated content" to edit an existing post - that modal only CREATES a new post, so using it to edit would duplicate the post. It is only for brand new posts.
+      - You can create, schedule and update posts, but you CANNOT delete posts - there is no delete capability. Never offer to delete a post. If the user asks you to delete one, tell them deletion is a destructive action and they should delete it themselves in the Postiz app (the calendar).
       - Between tools, we will reference things like: [output:name] and [input:name] to set the information right.
       - When outputting a date for the user, make sure it's human readable with time
       - The content of the post, HTML, Each line must be wrapped in <p> here is the possible tags: h1, h2, h3, u, strong, li, ul, p (you can\'t have u and strong together), don't use a "code" box
       ${renderArray(
         [
-          'If the user confirm, ask if they would like to get a modal with populated content without scheduling the post yet or if they want to schedule it right away.',
+          'When scheduling a NEW post, if the user confirms, ask whether they would like a modal with the populated content (without scheduling yet) or to schedule it right away. This modal is ONLY for brand new posts - never offer it for changes to an existing post; apply those directly with the relevant update tool.',
         ],
         !!ui
       )}

--- a/libraries/nestjs-libraries/src/chat/load.tools.service.ts
+++ b/libraries/nestjs-libraries/src/chat/load.tools.service.ts
@@ -54,6 +54,7 @@ export class LoadToolsService {
 
       You are an agent that helps manage and schedule social media posts for users, you can:
         - Schedule posts into the future, or now, adding texts, images and videos
+        - List the posts scheduled between two dates (postsListTool)
         - Generate pictures for posts
         - Generate videos for posts
         - Generate text for posts
@@ -76,6 +77,7 @@ export class LoadToolsService {
       - In every message I will send you the list of needed social medias (id and platform), if you already have the information use it, if not, use the integrationSchema tool to get it.
       - Make sure you always take the last information I give you about the socials, it might have changed.
       - Before scheduling a post, always make sure you ask the user confirmation by providing all the details of the post (text, images, videos, date, time, social media platform, account).
+      - To find or inspect existing posts, use postsListTool with a UTC start and end date - it returns every post scheduled in that window. To cover "all my upcoming posts", pass a wide window starting now.
       - Between tools, we will reference things like: [output:name] and [input:name] to set the information right.
       - When outputting a date for the user, make sure it's human readable with time
       - The content of the post, HTML, Each line must be wrapped in <p> here is the possible tags: h1, h2, h3, u, strong, li, ul, p (you can\'t have u and strong together), don't use a "code" box

--- a/libraries/nestjs-libraries/src/chat/tools/post.settings.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/post.settings.tool.ts
@@ -1,0 +1,93 @@
+import { AgentToolInterface } from '@gitroom/nestjs-libraries/chat/agent.tool.interface';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import { Injectable } from '@nestjs/common';
+import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
+
+@Injectable()
+export class PostSettingsTool implements AgentToolInterface {
+  constructor(private _postsService: PostsService) {}
+  name = 'postSettingsTool';
+
+  run() {
+    return createTool({
+      id: 'postSettingsTool',
+      mcp: {
+        annotations: {
+          title: 'Update Post Settings',
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      description: `
+Update the provider settings of an existing post (scheduled or draft) that was NOT published yet.
+Only the settings change - the content and the publish date stay exactly as they are.
+Find the post first (list your posts) and pass its "id" here.
+The settings are merged into the existing ones, so only pass the keys you want to change; anything you don't pass stays as it is.
+This relies on the integrationSchema tool [input:settings] to know which keys exist for the platform.
+If the tool returns errors, rerun it with the right parameters, don't ask again, just run it.
+`,
+      inputSchema: z.object({
+        id: z
+          .string()
+          .describe('The "id" of the post to update its settings'),
+        settings: z
+          .array(
+            z.object({
+              key: z.string().describe('Name of the settings key to change'),
+              value: z
+                .any()
+                .describe(
+                  'New value of the key, always prefer the id then label if possible'
+                ),
+            })
+          )
+          .describe(
+            'Settings keys to change, merged into the existing settings. This relies on the integrationSchema tool [input:settings]'
+          ),
+      }),
+      outputSchema: z.object({
+        output: z
+          .object({
+            postId: z.string(),
+            publishDate: z.string(),
+          })
+          .or(z.object({ errors: z.string() })),
+      }),
+      execute: async (inputData, context) => {
+        checkAuth(inputData, context);
+        const organizationId = JSON.parse(
+          (context?.requestContext as any)?.get('organization') as string
+        ).id;
+
+        const settings = (inputData.settings || []).reduce(
+          (acc: Record<string, any>, s: { key: string; value: any }) => ({
+            ...acc,
+            [s.key]: s.value,
+          }),
+          {} as Record<string, any>
+        );
+
+        try {
+          const output = await this._postsService.updatePostSettings(
+            organizationId,
+            inputData.id,
+            settings,
+            'MCP'
+          );
+
+          return { output };
+        } catch (err: any) {
+          return {
+            output: {
+              errors: err?.message || 'Failed to update the post settings',
+            },
+          };
+        }
+      },
+    });
+  }
+}

--- a/libraries/nestjs-libraries/src/chat/tools/posts.list.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/posts.list.tool.ts
@@ -1,0 +1,108 @@
+import { AgentToolInterface } from '@gitroom/nestjs-libraries/chat/agent.tool.interface';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import { Injectable } from '@nestjs/common';
+import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+const parseSettings = (settings: string | null) => {
+  try {
+    return JSON.parse(settings || '{}');
+  } catch (err) {
+    return {};
+  }
+};
+
+@Injectable()
+export class PostsListTool implements AgentToolInterface {
+  constructor(private _postsService: PostsService) {}
+  name = 'postsListTool';
+
+  run() {
+    return createTool({
+      id: 'postsListTool',
+      mcp: {
+        annotations: {
+          title: 'List Posts',
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+      description: `
+List the organization's posts scheduled to be published between two dates (the same data as the "List Posts" API endpoint).
+Returns every post in the window whatever its state (scheduled, draft, published, errored).
+"startDate" and "endDate" are required (UTC) - to list all upcoming posts, pass a wide window (for example from now to a year ahead).
+Each item has an "id", its publish date, state, content, channel and current provider settings.
+`,
+      inputSchema: z.object({
+        startDate: z
+          .string()
+          .describe('Start of the window (UTC), for example 2026-07-20T00:00:00'),
+        endDate: z
+          .string()
+          .describe('End of the window (UTC), for example 2026-08-20T00:00:00'),
+        customer: z
+          .string()
+          .optional()
+          .describe('Optional customer (group) id to filter the channels by'),
+      }),
+      outputSchema: z.object({
+        output: z.object({
+          posts: z.array(
+            z.object({
+              id: z
+                .string()
+                .describe('The post id'),
+              publishDate: z.string().describe('UTC time'),
+              state: z.string().describe('QUEUE, DRAFT, PUBLISHED or ERROR'),
+              content: z.string(),
+              settings: z
+                .any()
+                .describe('The post current provider settings'),
+              group: z.string(),
+              integrationId: z.string(),
+              platform: z.string(),
+              integrationName: z.string(),
+            })
+          ),
+        }),
+      }),
+      execute: async (inputData, context) => {
+        checkAuth(inputData, context);
+        const organizationId = JSON.parse(
+          (context?.requestContext as any)?.get('organization') as string
+        ).id;
+
+        const posts = await this._postsService.getPosts(organizationId, {
+          startDate: inputData.startDate,
+          endDate: inputData.endDate,
+          customer: inputData.customer,
+        } as any);
+
+        return {
+          output: {
+            posts: (posts || []).map((p: any) => ({
+              id: p.id,
+              publishDate: dayjs(p.publishDate)
+                .utc()
+                .format('YYYY-MM-DDTHH:mm:ss'),
+              state: p.state,
+              content: p.content || '',
+              settings: parseSettings(p.settings),
+              group: p.group,
+              integrationId: p.integration?.id,
+              platform: p.integration?.providerIdentifier,
+              integrationName: p.integration?.name,
+            })),
+          },
+        };
+      },
+    });
+  }
+}

--- a/libraries/nestjs-libraries/src/chat/tools/tool.list.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/tool.list.ts
@@ -9,6 +9,7 @@ import { IntegrationListTool } from '@gitroom/nestjs-libraries/chat/tools/integr
 import { GroupListTool } from '@gitroom/nestjs-libraries/chat/tools/group.list.tool';
 import { UploadFromUrlTool } from '@gitroom/nestjs-libraries/chat/tools/upload.from.url.tool';
 import { PostsListTool } from '@gitroom/nestjs-libraries/chat/tools/posts.list.tool';
+import { PostSettingsTool } from '@gitroom/nestjs-libraries/chat/tools/post.settings.tool';
 
 export const toolList = [
   IntegrationListTool,
@@ -17,6 +18,7 @@ export const toolList = [
   IntegrationTriggerTool,
   IntegrationSchedulePostTool,
   PostsListTool,
+  PostSettingsTool,
   GenerateVideoOptionsTool,
   VideoFunctionTool,
   GenerateVideoTool,

--- a/libraries/nestjs-libraries/src/chat/tools/tool.list.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/tool.list.ts
@@ -8,6 +8,7 @@ import { GenerateImageTool } from '@gitroom/nestjs-libraries/chat/tools/generate
 import { IntegrationListTool } from '@gitroom/nestjs-libraries/chat/tools/integration.list.tool';
 import { GroupListTool } from '@gitroom/nestjs-libraries/chat/tools/group.list.tool';
 import { UploadFromUrlTool } from '@gitroom/nestjs-libraries/chat/tools/upload.from.url.tool';
+import { PostsListTool } from '@gitroom/nestjs-libraries/chat/tools/posts.list.tool';
 
 export const toolList = [
   IntegrationListTool,
@@ -15,6 +16,7 @@ export const toolList = [
   IntegrationValidationTool,
   IntegrationTriggerTool,
   IntegrationSchedulePostTool,
+  PostsListTool,
   GenerateVideoOptionsTool,
   VideoFunctionTool,
   GenerateVideoTool,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -518,10 +518,15 @@ export class PostsRepository {
     body: PostBody,
     tags: { value: string; label: string }[],
     creationMethod: CreationMethod,
-    inter?: number
+    inter?: number,
+    // Keep the existing group instead of rotating it, so open clients
+    // (calendar) holding the group stay valid. Used by out-of-band updates
+    // (agent / MCP / public API); the dashboard keeps the rotate-and-sweep.
+    keepGroup = false
   ) {
     const posts: Post[] = [];
     const uuid = uuidv4();
+    const group = keepGroup && body.group ? body.group : uuid;
 
     for (const value of body.value) {
       const updateData = (type: 'create' | 'update') => ({
@@ -549,7 +554,7 @@ export class PostsRepository {
           : {}),
         content: value.content,
         delay: value.delay || 0,
-        group: uuid,
+        group,
         intervalInDays: inter ? +inter : null,
         approvedSubmitForOrder: APPROVED_SUBMIT_FOR_ORDER.NO,
         ...(type === 'create' ? { creationMethod } : {}),
@@ -640,11 +645,29 @@ export class PostsRepository {
         )?.id!
       : undefined;
 
-    if (body.group) {
+    if (body.group && !keepGroup) {
       await this._post.model.post.updateMany({
         where: {
           group: body.group,
           deletedAt: null,
+        },
+        data: {
+          parentPostId: null,
+          deletedAt: new Date(),
+        },
+      });
+    }
+
+    // keepGroup: the updated rows still carry the old group, so sweep only the
+    // rows dropped from it (removed comments) by id instead of by group.
+    if (body.group && keepGroup) {
+      await this._post.model.post.updateMany({
+        where: {
+          group: body.group,
+          deletedAt: null,
+          id: {
+            notIn: posts.map((p) => p.id),
+          },
         },
         data: {
           parentPostId: null,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -181,6 +181,7 @@ export class PostsRepository {
         intervalInDays: true,
         group: true,
         creationMethod: true,
+        settings: true,
         tags: {
           select: {
             tag: true,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -160,16 +160,10 @@ export class PostsRepository {
         integration: {
           deletedAt: null,
           organizationId: orgId,
+          ...(query.customer ? { customerId: query.customer } : {}),
         },
         deletedAt: null,
         parentPostId: null,
-        ...(query.customer
-          ? {
-              integration: {
-                customerId: query.customer,
-              },
-            }
-          : {}),
       },
       select: {
         id: true,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Injectable,
+  NotFoundException,
   ValidationPipe,
 } from '@nestjs/common';
 import { PostsRepository } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.repository';
@@ -876,7 +877,8 @@ export class PostsService {
   async createPost(
     orgId: string,
     body: CreatePostDto,
-    creationMethod: CreationMethod
+    creationMethod: CreationMethod,
+    keepGroup = false
   ): Promise<any[]> {
     const postList = [];
     for (const post of body.posts) {
@@ -907,7 +909,8 @@ export class PostsService {
         post,
         body.tags,
         creationMethod,
-        body.inter
+        body.inter,
+        keepGroup
       );
 
       if (!posts?.length) {
@@ -931,6 +934,153 @@ export class PostsService {
     }
 
     return postList;
+  }
+
+  // Update ONLY the provider settings of a not-yet-published post (scheduled or
+  // draft). The passed keys are merged into the existing settings; content and
+  // publish date stay as they are, so the running publish workflow is left
+  // untouched (type "update"). Shared by the agent/MCP tool and the public API
+  // PUT /posts/:id/settings so both go through one path.
+  async updatePostSettings(
+    orgId: string,
+    postId: string,
+    settings: Record<string, any>,
+    creationMethod: CreationMethod
+  ): Promise<{ postId: string; publishDate: string }> {
+    // Ordered as post -> comments, root includes integration and tags.
+    const ordered = await this.getPostsRecursively(postId, true, orgId, true);
+
+    const [root] = ordered;
+    if (!root) {
+      throw new NotFoundException('Post not found');
+    }
+
+    if (root.parentPostId) {
+      throw new BadRequestException(
+        'This id belongs to a comment, pass the id of the main post'
+      );
+    }
+
+    if (root.state !== 'QUEUE' && root.state !== 'DRAFT') {
+      throw new BadRequestException(
+        'Only scheduled posts that were not published yet (or drafts) can be updated'
+      );
+    }
+
+    if (
+      root.state === 'QUEUE' &&
+      dayjs.utc(root.publishDate).isBefore(dayjs.utc())
+    ) {
+      throw new BadRequestException(
+        'The publish time of this post already passed, it cannot be updated'
+      );
+    }
+
+    const integration = (root as any).integration;
+
+    let existingSettings: Record<string, any>;
+    try {
+      existingSettings = JSON.parse(root.settings || '{}');
+    } catch (err) {
+      existingSettings = {};
+    }
+
+    // Merge: only the passed keys change, everything else stays.
+    const mergedSettings = {
+      ...existingSettings,
+      ...(settings || {}),
+      __type: integration.providerIdentifier,
+    };
+
+    // Keep the existing content/ids so the posts are updated in place (the
+    // workflow identity is preserved) - only the settings differ.
+    const value = ordered.map((p) => {
+      let image = [];
+      try {
+        image = JSON.parse(p.image || '[]');
+      } catch (err) {}
+      return {
+        id: p.id,
+        content: p.content,
+        delay: p.delay || 0,
+        image,
+      };
+    });
+
+    // Same server-side validation as the dashboard / public create route.
+    const [validation] = await this.validatePosts(orgId, [
+      {
+        integration: { id: integration.id },
+        settings: mergedSettings,
+        value: value.map((p) => ({ content: p.content, image: p.image })),
+      },
+    ]);
+
+    if (validation.emptyContent) {
+      throw new BadRequestException(
+        `${validation.name}: Your post should have at least one character or one image.`
+      );
+    }
+
+    if (root.state !== 'DRAFT') {
+      if (!validation.valid) {
+        throw new BadRequestException(
+          `${validation.name}: ${
+            validation.settingsError || 'Please fix your settings'
+          }`
+        );
+      }
+
+      if (validation.errors !== true) {
+        throw new BadRequestException(
+          `${validation.name}: ${validation.errors}`
+        );
+      }
+
+      if (validation.tooLong) {
+        throw new BadRequestException(
+          `${validation.name}: The maximum characters is ${validation.maximumCharacters}`
+        );
+      }
+    }
+
+    const date = dayjs.utc(root.publishDate).format('YYYY-MM-DDTHH:mm:ss');
+
+    const [output] = await this.createPost(
+      orgId,
+      {
+        date,
+        // Settings-only update: keep the current state and leave the running
+        // publish workflow alone.
+        type: 'update',
+        shortLink: false,
+        tags: ((root as any).tags || []).map((t: any) => ({
+          value: t.tag.name,
+          label: t.tag.name,
+        })),
+        posts: [
+          {
+            integration,
+            group: root.group,
+            settings: mergedSettings,
+            value,
+          },
+        ],
+      } as any,
+      creationMethod,
+      // Keep the group stable: a client may have the calendar open while the
+      // settings are updated out of band, and the calendar links posts by group.
+      true
+    );
+
+    if (!output) {
+      throw new BadRequestException('Failed to update the post');
+    }
+
+    return {
+      postId: output.postId,
+      publishDate: date,
+    };
   }
 
   async separatePosts(content: string, len: number) {

--- a/libraries/nestjs-libraries/src/dtos/posts/update.post.settings.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/update.post.settings.dto.ts
@@ -1,0 +1,7 @@
+import { IsDefined, IsObject } from 'class-validator';
+
+export class UpdatePostSettingsDto {
+  @IsDefined()
+  @IsObject()
+  settings: Record<string, any>;
+}


### PR DESCRIPTION
## Why

A user had scheduled dozens of TikTok posts with the wrong settings and wanted an agent to batch-update them. To do that, an agent first has to *find* those posts. This PR adds `postsListTool` (agent / MCP) for exactly that — and aligns it with the existing public **List Posts** endpoint instead of introducing yet another divergent query.

This is the base of a two-PR stack; the follow-up #1752 ("update post settings") is stacked on this branch and should merge after it.

## Changes

- **`postsListTool`** (agent / MCP): lists the organization's posts scheduled between two dates. It calls the **same** `PostsService.getPosts` as the public `GET /public/v1/posts` endpoint — same inputs (`startDate`, `endDate`, optional `customer`) and the same source data — so the tool and the API can't drift.
- **`getPosts` now selects `settings`**, so both the tool and the public List Posts endpoint return each post's current provider settings. The agent needs this to tell which posts require a settings change.

## Public API impact

- `GET /public/v1/posts` now returns a `settings` field on each post. **Additive and backward-compatible** — existing consumers are unaffected, they just receive one extra field.

## Testing

Fully tested:
- **Public API** — via the updated CLI + skill.
- **Agent tools** — via the internal web-app agent and Claude Code (via the remote MCP).

## Related changes in other repos

- **postiz-docs**: documents the new `settings` field in the List Posts response and adds `postsListTool` to the MCP "Available Tools" list. _(PR link to be added.)_
- No postiz-agent change for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
