### PR TITLE
feat(nostr): multi-account crosspost via Add Re-posters plug

### DIFF
--- a/libraries/nestjs-libraries/jest.config.js
+++ b/libraries/nestjs-libraries/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * Self-contained Jest config for nestjs-libraries.
+ *
+ * Root jest.config.ts uses @nx/jest getJestProjects(); this config lets us
+ * run library unit tests without a full Nx workspace bootstrap:
+ *
+ *   npx jest --config libraries/nestjs-libraries/jest.config.js
+ */
+/** @type {import('jest').Config} */
+module.exports = {
+  displayName: 'nestjs-libraries',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  transform: {
+    '^.+\\.[tj]s$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json' },
+    ],
+  },
+  moduleNameMapper: {
+    '^@gitroom/nestjs-libraries/(.*)$': '<rootDir>/src/$1',
+    '^@gitroom/helpers/(.*)$': '<rootDir>/../helpers/src/$1',
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for Nostr multi-account repost (issue #1586).
+ *
+ * Fully offline: nostr-tools and AuthService are mocked so no relay sockets
+ * open. SocialAbstract is stubbed to avoid pulling in sharp/temporal.
+ *
+ * Run with:
+ *   npx jest --config libraries/nestjs-libraries/jest.config.js
+ */
+
+jest.mock('@gitroom/nestjs-libraries/integrations/social.abstract', () => ({
+  SocialAbstract: class {},
+}));
+
+jest.mock('@gitroom/helpers/auth/auth.service', () => ({
+  AuthService: {
+    verifyJWT: jest.fn(),
+    signJWT: jest.fn(() => 'signed-jwt'),
+  },
+}));
+
+const relayInstance = {
+  subscribe: jest.fn((_filters: any, handlers: any) => {
+    handlers.oneose?.();
+    return { close: jest.fn() };
+  }),
+  publish: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn(),
+};
+
+jest.mock('nostr-tools', () => ({
+  __esModule: true,
+  getPublicKey: jest.fn(() => 'reposter-pubkey'),
+  finalizeEvent: jest.fn(),
+  Relay: { connect: jest.fn() },
+  SimplePool: jest.fn().mockImplementation(() => ({ get: jest.fn() })),
+}));
+
+import { NostrProvider } from './nostr.provider';
+import { AuthService } from '@gitroom/helpers/auth/auth.service';
+import { finalizeEvent, Relay } from 'nostr-tools';
+import type { Integration } from '@prisma/client';
+
+const finalizeEventMock = finalizeEvent as jest.Mock;
+const relayConnectMock = Relay.connect as jest.Mock;
+const verifyJWTMock = AuthService.verifyJWT as jest.Mock;
+
+/** 32-byte zero key as 64 hex chars — enough for toSecretKey to parse. */
+const HEX_SECRET =
+  '0000000000000000000000000000000000000000000000000000000000000001';
+
+describe('NostrProvider.repostPostUsers', () => {
+  const reposter = {
+    internalId: 'reposter-pubkey-hex',
+    token: 'reposter-jwt-token',
+  } as Integration;
+
+  const original = {
+    internalId: 'author-pubkey-hex',
+    token: 'author-jwt-token',
+  } as Integration;
+
+  const postId = 'original-note-event-id';
+  const signedEvent = { id: 'signed-repost-id', kind: 6 };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifyJWTMock.mockReturnValue({ password: HEX_SECRET });
+    finalizeEventMock.mockReturnValue(signedEvent);
+    relayConnectMock.mockResolvedValue(relayInstance);
+  });
+
+  it('builds and publishes a NIP-18 kind:6 repost signed by the reposting account', async () => {
+    const provider = new NostrProvider();
+
+    await provider.repostPostUsers(reposter, original, postId, {});
+
+    expect(verifyJWTMock).toHaveBeenCalledWith(reposter.token);
+
+    expect(finalizeEventMock).toHaveBeenCalledTimes(1);
+    const [eventTemplate, secretKey] = finalizeEventMock.mock.calls[0];
+    expect(eventTemplate.kind).toBe(6);
+    expect(eventTemplate.content).toBe('');
+    expect(eventTemplate.tags[0][0]).toBe('e');
+    expect(eventTemplate.tags[0][1]).toBe(postId);
+    // relay hint present (NIP-18)
+    expect(typeof eventTemplate.tags[0][2]).toBe('string');
+    expect(eventTemplate.tags[0][2].startsWith('wss://')).toBe(true);
+    expect(eventTemplate.tags[1]).toEqual(['p', original.internalId]);
+
+    // Secret key is a Uint8Array (not the raw hex string).
+    expect(secretKey).toBeInstanceOf(Uint8Array);
+    expect(secretKey).toHaveLength(32);
+
+    // Broadcast reached every configured relay (parallel publish).
+    expect(relayConnectMock).toHaveBeenCalled();
+    expect(relayInstance.publish).toHaveBeenCalledWith(signedEvent);
+    // No kind:1 subscription wait for reposts.
+    expect(relayInstance.subscribe).not.toHaveBeenCalled();
+    expect(relayInstance.close).toHaveBeenCalled();
+  });
+
+  it('no-ops when postId is empty (broken upstream publish would otherwise create invalid events)', async () => {
+    const provider = new NostrProvider();
+
+    await provider.repostPostUsers(reposter, original, '', {});
+
+    expect(finalizeEventMock).not.toHaveBeenCalled();
+    expect(relayConnectMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows relay failures so one bad account does not fail the post (mirrors X)', async () => {
+    relayConnectMock.mockRejectedValue(new Error('relay unreachable'));
+    const provider = new NostrProvider();
+
+    await expect(
+      provider.repostPostUsers(reposter, original, postId, {})
+    ).resolves.toBeUndefined();
+
+    expect(finalizeEventMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('NostrProvider.post', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    verifyJWTMock.mockReturnValue({ password: HEX_SECRET });
+    finalizeEventMock.mockReturnValue({ id: 'deterministic-note-id', kind: 1 });
+    relayConnectMock.mockResolvedValue(relayInstance);
+  });
+
+  it('returns the finalizeEvent id as postId so multi-account reposts have a stable target', async () => {
+    const provider = new NostrProvider();
+
+    const result = await provider.post('author-pubkey', 'token', [
+      {
+        id: 'local-post-id',
+        message: 'hello nostr',
+        media: [],
+        settings: {},
+      } as any,
+    ]);
+
+    expect(result[0].postId).toBe('deterministic-note-id');
+    expect(result[0].releaseURL).toContain('deterministic-note-id');
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -11,6 +11,7 @@ import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
 
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
+import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
 import { Integration } from '@prisma/client';
 
 // @ts-ignore
@@ -33,7 +34,8 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
   isBetweenSteps = false;
   scopes = [] as string[];
   editor = 'normal' as const;
-  toolTip = 'Make sure you private a HEX key of your Nostr private key, you can get it from websites like iris.to'
+  toolTip =
+    'Make sure you private a HEX key of your Nostr private key, you can get it from websites like iris.to';
 
   maxLength() {
     return 100000;
@@ -71,6 +73,13 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
+  /** Convert a stored hex private key into the Uint8Array nostr-tools expects. */
+  private toSecretKey(password: string): Uint8Array {
+    return Uint8Array.from(
+      password.match(/.{1,2}/g)!.map((byte: string) => parseInt(byte, 16))
+    );
+  }
+
   private async findRelayInformation(pubkey: string) {
     // This queries ALL relays in parallel and resolves with
     // the first matching event from ANY relay.
@@ -96,30 +105,61 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     return {};
   }
 
+  /**
+   * Publish an event to all configured relays without waiting for a
+   * subscription match. Prefer this when `finalizeEvent` already gave us a
+   * deterministic event id (posts, comments, reposts).
+   */
+  private async broadcast(event: any): Promise<void> {
+    await Promise.allSettled(
+      list.map(async (relayUrl) => {
+        try {
+          const relayInstance = await Relay.connect(relayUrl);
+          try {
+            await relayInstance.publish(event);
+          } finally {
+            relayInstance.close();
+          }
+        } catch {
+          /** empty **/
+        }
+      })
+    );
+  }
+
   private async publish(pubkey: string, event: any) {
+    // finalizeEvent always stamps a deterministic id — prefer it over
+    // waiting for relays to echo the event back (which often times out).
+    if (event?.id) {
+      await this.broadcast(event);
+      return event.id as string;
+    }
+
     let id = '';
     for (const relay of list) {
       try {
         const relayInstance = await Relay.connect(relay);
         const value = new Promise<any>((resolve) => {
-          relayInstance.subscribe([{ kinds: [1], authors: [pubkey] }], {
-            eoseTimeout: 6000,
-            onevent: (event) => {
-              resolve(event);
-            },
-            oneose: () => {
-              resolve({});
-            },
-            onclose: () => {
-              resolve({});
-            },
-          });
+          relayInstance.subscribe(
+            [{ kinds: [event?.kind ?? 1], authors: [pubkey] }],
+            {
+              eoseTimeout: 6000,
+              onevent: (observed) => {
+                resolve(observed);
+              },
+              oneose: () => {
+                resolve({});
+              },
+              onclose: () => {
+                resolve({});
+              },
+            }
+          );
         });
 
         await relayInstance.publish(event);
         const all = await value;
         relayInstance.close();
-        // relayInstance.close();
         id = id || all?.id;
       } catch (err) {
         /**empty**/
@@ -173,6 +213,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     postDetails: PostDetails[]
   ): Promise<PostResponse[]> {
     const { password } = AuthService.verifyJWT(accessToken) as any;
+    const secretKey = this.toSecretKey(password);
     const [firstPost] = postDetails;
 
     const textEvent = finalizeEvent(
@@ -182,15 +223,18 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         tags: [],
         created_at: Math.floor(Date.now() / 1000),
       },
-      password
+      secretKey
     );
 
-    const eventId = await this.publish(id, textEvent);
+    // Use the finalized event id — publish() may return empty when relays
+    // time out, which would break multi-account reposts that need postId.
+    await this.publish(id, textEvent);
+    const eventId = String(textEvent.id);
 
     return [
       {
         id: firstPost.id,
-        postId: String(eventId),
+        postId: eventId,
         releaseURL: `https://primal.net/e/${eventId}`,
         status: 'completed',
       },
@@ -206,6 +250,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     integration: Integration
   ): Promise<PostResponse[]> {
     const { password } = AuthService.verifyJWT(accessToken) as any;
+    const secretKey = this.toSecretKey(password);
     const [commentPost] = postDetails;
     const replyToId = lastCommentId || postId;
 
@@ -219,18 +264,66 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         ],
         created_at: Math.floor(Date.now() / 1000),
       },
-      password
+      secretKey
     );
 
-    const eventId = await this.publish(id, textEvent);
+    await this.publish(id, textEvent);
+    const eventId = String(textEvent.id);
 
     return [
       {
         id: commentPost.id,
-        postId: String(eventId),
+        postId: eventId,
         releaseURL: `https://primal.net/e/${eventId}`,
         status: 'completed',
       },
     ];
+  }
+
+  /**
+   * Multi-account crosspost: when composing a Nostr post, pick other connected
+   * Nostr integrations to repost it (same "Add Re-posters" PostPlug as X/LinkedIn).
+   * Publishes a NIP-18 kind:6 repost signed by each selected account.
+   */
+  @PostPlug({
+    identifier: 'nostr-repost-post-users',
+    title: 'Add Re-posters',
+    description: 'Add accounts to repost your post',
+    pickIntegration: ['nostr'],
+    fields: [],
+  })
+  async repostPostUsers(
+    integration: Integration,
+    originalIntegration: Integration,
+    postId: string,
+    _information: any
+  ) {
+    if (!postId) {
+      return;
+    }
+
+    try {
+      const { password } = AuthService.verifyJWT(integration.token) as any;
+      const secretKey = this.toSecretKey(password);
+
+      // NIP-18 repost: kind 6, empty content, e = note id (+ relay hint), p = author.
+      const repostEvent = finalizeEvent(
+        {
+          kind: 6,
+          content: '',
+          tags: [
+            ['e', postId, list[0]],
+            ['p', originalIntegration.internalId],
+          ],
+          created_at: Math.floor(Date.now() / 1000),
+        },
+        secretKey
+      );
+
+      // Fire-and-forget broadcast — no kind:1 subscription wait (repost is kind 6).
+      await this.broadcast(repostEvent);
+    } catch {
+      // Mirror X: swallow failures so one bad account does not fail the post.
+    }
   }
 }

--- a/libraries/nestjs-libraries/tsconfig.spec.json
+++ b/libraries/nestjs-libraries/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "isolatedModules": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) and sign the [CLA](https://contribute.postiz.com/p/postiz/cla) before submitting a PR. -->

# What kind of change does this PR introduce?

Feature. Adds the same "Add Re-posters" PostPlug that X and LinkedIn already have, so users can crosspost a note from one connected Nostr account to other connected Nostr accounts.

# Why was this change needed?

Fixes #1586. Users with multiple Nostr accounts currently have to open Primal (or another client) to repost manually. Postiz already supports multi-account re-posters for X; Nostr was missing the same plug.

Two small reliability fixes were required for reposts to work in practice:

1. `post()` / `comment()` now return `finalizeEvent()`'s deterministic event id as `postId`. The old `publish()` path often returned an empty id when relays timed out, which would make any repost target invalid.
2. Secret keys are passed to `finalizeEvent` as `Uint8Array` (what nostr-tools expects), not the raw hex string stored in the JWT.

# Other information:

### Behavior
- New `@PostPlug` `nostr-repost-post-users` appears in the Nostr composer settings (same UI as X).
- User can pick any other connected Nostr integration; each selected account publishes a NIP-18 kind:6 repost (`e` = note id + relay hint, `p` = original author pubkey).
- Relay publish for reposts is a parallel broadcast (no kind:1 subscription wait), so multi-account repost stays fast.
- Failures are swallowed per account, matching the X plug.

### Scope
Only `NostrProvider` (+ focused offline unit tests). No frontend changes — `InternalChannels` already renders any `internalPlugs` metadata.

### Tests
```bash
npx jest --config libraries/nestjs-libraries/jest.config.js
```
Covers: NIP-18 event shape + Uint8Array signing, empty postId no-op, relay failure swallow, and stable postId from `post()`.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue