### PR TITLE
feat(nostr): add account mention autocomplete in composer (#1603)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -7,7 +7,13 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
 import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
-import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
+import {
+  getPublicKey,
+  Relay,
+  finalizeEvent,
+  SimplePool,
+  nip19,
+} from 'nostr-tools';
 
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
@@ -24,7 +30,17 @@ const list = [
   'wss://vault.iris.to',
 ];
 
+// Relays that support NIP-50 full-text search over kind-0 profiles
+const searchList = ['wss://relay.nostr.band', 'wss://search.nos.today'];
+
 const pool = new SimplePool();
+
+type MentionResult = {
+  id: string;
+  label: string;
+  image: string;
+  doNotCache?: boolean;
+};
 
 export class NostrProvider extends SocialAbstract implements SocialProvider {
   override maxConcurrentJob = 5;
@@ -167,6 +183,68 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
       : post.message;
   }
 
+  /**
+   * Decode an npub, "nostr:npub…", or 64-char hex pubkey into hex.
+   * Returns undefined when the value is not a valid public key.
+   */
+  private decodePublicKey(value: string): string | undefined {
+    const candidate = value.trim().replace(/^nostr:/i, '');
+
+    if (/^[a-f0-9]{64}$/i.test(candidate)) {
+      return candidate.toLowerCase();
+    }
+
+    if (!candidate.toLowerCase().startsWith('npub1')) {
+      return undefined;
+    }
+
+    try {
+      const decoded = nip19.decode(candidate);
+      return decoded.type === 'npub' ? decoded.data : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private profileToMention(pubkey: string, content: any): MentionResult {
+    const npub = nip19.npubEncode(pubkey);
+    const label =
+      content.display_name ||
+      content.displayName ||
+      content.name ||
+      content.nip05 ||
+      `${npub.slice(0, 12)}…`;
+
+    return {
+      id: npub,
+      label: String(label),
+      image: content.picture || content.image || '',
+    };
+  }
+
+  /**
+   * NIP-27: every `nostr:npub1…` reference in content should also carry a
+   * `p` tag so mentioned users are notified by clients (NIP-10 / NIP-27).
+   */
+  private mentionedPubkeysTags(
+    content: string,
+    exclude: string[] = []
+  ): string[][] {
+    const seen = new Set<string>(exclude);
+    const tags: string[][] = [];
+
+    for (const match of content.matchAll(/(?:nostr:)?(npub1[a-z0-9]+)/gi)) {
+      const pubkey = this.decodePublicKey(match[1]);
+      if (!pubkey || seen.has(pubkey)) {
+        continue;
+      }
+      seen.add(pubkey);
+      tags.push(['p', pubkey]);
+    }
+
+    return tags;
+  }
+
   async post(
     id: string,
     accessToken: string,
@@ -175,11 +253,12 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     const { password } = AuthService.verifyJWT(accessToken) as any;
     const [firstPost] = postDetails;
 
+    const content = this.buildContent(firstPost);
     const textEvent = finalizeEvent(
       {
         kind: 1, // Text note
-        content: this.buildContent(firstPost),
-        tags: [],
+        content,
+        tags: this.mentionedPubkeysTags(content),
         created_at: Math.floor(Date.now() / 1000),
       },
       password
@@ -209,13 +288,16 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     const [commentPost] = postDetails;
     const replyToId = lastCommentId || postId;
 
+    const content = this.buildContent(commentPost);
     const textEvent = finalizeEvent(
       {
         kind: 1, // Text note
-        content: this.buildContent(commentPost),
+        content,
         tags: [
           ['e', replyToId, '', 'reply'],
           ['p', id],
+          // Avoid duplicating the reply-author p tag when they are also mentioned
+          ...this.mentionedPubkeysTags(content, [id]),
         ],
         created_at: Math.floor(Date.now() / 1000),
       },
@@ -232,5 +314,120 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         status: 'completed',
       },
     ];
+  }
+
+  /**
+   * Composer @-mention autocomplete for Nostr profiles.
+   * Supports exact npub/hex lookup and NIP-50 text search over kind-0 metadata.
+   * Returns results in the same shape as X/Bluesky providers so the existing
+   * TipTap mention UI works without frontend changes.
+   */
+  override async mention(
+    token: string,
+    d: { query: string },
+    id: string,
+    integration: Integration
+  ) {
+    const query = (d?.query || '').trim();
+    if (query.length < 1) {
+      return [];
+    }
+
+    try {
+      const exactPubkey = this.decodePublicKey(query);
+
+      if (exactPubkey) {
+        const evt = await pool.get(
+          list,
+          { kinds: [0], authors: [exactPubkey], limit: 1 },
+          { maxWait: 2500 }
+        );
+
+        if (evt) {
+          let content: any = {};
+          try {
+            content = JSON.parse(evt.content || '{}');
+          } catch {
+            content = {};
+          }
+          return [this.profileToMention(exactPubkey, content)];
+        }
+
+        // Still offer a selectable result when metadata is not found on relays
+        const npub = nip19.npubEncode(exactPubkey);
+        return [
+          {
+            id: npub,
+            label: `${npub.slice(0, 12)}…`,
+            image: '',
+            doNotCache: true,
+          },
+        ];
+      }
+
+      // NIP-50 profile search (kind 0 metadata events)
+      const events = await pool.querySync(
+        searchList,
+        { kinds: [0], search: query, limit: 30 },
+        { maxWait: 3000 }
+      );
+
+      const latestByAuthor = new Map<string, (typeof events)[number]>();
+      for (const event of events || []) {
+        const current = latestByAuthor.get(event.pubkey);
+        if (!current || event.created_at > current.created_at) {
+          latestByAuthor.set(event.pubkey, event);
+        }
+      }
+
+      const users: MentionResult[] = [];
+      for (const event of latestByAuthor.values()) {
+        let content: any = {};
+        try {
+          content = JSON.parse(event.content || '{}');
+        } catch {
+          continue;
+        }
+
+        const name =
+          content.display_name ||
+          content.displayName ||
+          content.name ||
+          content.nip05;
+        if (!name) {
+          continue;
+        }
+
+        users.push(this.profileToMention(event.pubkey, content));
+      }
+
+      return users.slice(0, 10);
+    } catch (err) {
+      console.log(err);
+    }
+
+    return [];
+  }
+
+  /**
+   * NIP-27 inline mention. `idOrHandle` is the npub stored as the mention id.
+   * Must not use `this` — called unbound via getIntegration.mentionFormat.
+   */
+  mentionFormat(idOrHandle: string, _name: string) {
+    const candidate = (idOrHandle || '').trim().replace(/^nostr:/i, '');
+
+    if (/^[a-f0-9]{64}$/i.test(candidate)) {
+      try {
+        return `nostr:${nip19.npubEncode(candidate.toLowerCase())}`;
+      } catch {
+        // fall through
+      }
+    }
+
+    if (candidate.toLowerCase().startsWith('npub1')) {
+      return `nostr:${candidate}`;
+    }
+
+    return `nostr:${candidate}`;
   }
 }


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) and sign the [CLA](https://contribute.postiz.com/p/postiz/cla) before submitting a PR. -->

# What kind of change does this PR introduce?

Feature — Nostr account mention autocomplete in the composer (parity with X/Twitter, Bluesky, Discord, LinkedIn).

**Fixes #1603**

# Why was this change needed?

Postiz already supports `@` mention autocomplete for several networks, but Nostr fell through to the base class default (`{ none: true }`), so the composer showed “We don't have autocomplete for this social media”. Nostr users then have to paste long `npub` values by hand, which is error-prone when scheduling posts.

This change wires Nostr into the existing generic mention pipeline (no frontend changes):

1. **`NostrProvider.mention()`** — profile suggestions when typing `@`
   - Exact match for `npub1…`, `nostr:npub1…`, or 64-char hex pubkeys (kind-0 lookup on existing publish relays)
   - Free-text search via NIP-50 (`kinds: [0], search`) against `relay.nostr.band` and `search.nos.today`
   - Returns `{ id: npub, label, image }` so the TipTap mention dropdown works unchanged
2. **`NostrProvider.mentionFormat()`** — inserts NIP-27 `nostr:npub1…` references (safe when called unbound via `getIntegration.mentionFormat`)
3. **Publish path** — `post()` / `comment()` add `['p', <hex>]` tags for every `nostr:npub` (or bare `npub`) reference in the content so mentioned users can be notified by clients (NIP-27 / NIP-10). Reply-author `p` tags are not duplicated on comments.

Existing X/Twitter (and other) mention behavior is untouched. No new dependencies (`nip19` is already part of `nostr-tools`).

# Other information:

- Single-file change: `libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts`
- Follows the same provider pattern as `x.provider.ts` / `bluesky.provider.ts`
- Claiming for **Lightning Bounties** on issue #1603 if applicable

# How tested

- Live NIP-50 smoke test against search relays (`search: "jack"`, limit 10) returned valid kind-0 profiles with display names, pictures, and correctly `nip19.npubEncode`d ids
- `mentionFormat` verified unbound for npub, hex, and `nostr:npub` inputs → always produces `nostr:npub1…`
- `p`-tag extraction verified from content containing `nostr:npub…` references
- Confirmed the composer already loads suggestions via `POST /integrations/mentions` and only needs a non-`{none:true}` provider implementation (no UI changes)
- Typecheck: no new errors introduced in `nostr.provider.ts` (pre-existing unrelated strictness errors remain in the monorepo)

Manual E2E (composer → schedule → publish with a connected Nostr channel) recommended in a full app environment.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue