### PR TITLE
fix(linkedin): remove prompt=none so personal OAuth grants scopes (#1580)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -151,7 +151,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     const codeVerifier = makeId(30);
     const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${
       process.env.LINKEDIN_CLIENT_ID
-    }&prompt=none&redirect_uri=${encodeURIComponent(
+    }&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin`
     )}&state=${state}&scope=${encodeURIComponent(this.scopes.join(' '))}`;
     return {


### PR DESCRIPTION
## Problem

The personal LinkedIn OAuth URL in `generateAuthUrl()` is built with `&prompt=none`. `prompt=none` tells LinkedIn to authenticate **silently**, without ever showing the consent screen. As a result, when a self-hosted user connects LinkedIn — or reconnects after new scopes/products are added to their LinkedIn app — LinkedIn reuses the previous (empty/older) grant and never asks the member to approve the currently requested scopes. The connect then fails downstream with `NotEnoughScopes`.

This is the root cause described in #1580 (and contributes to the failures in #1582).

## Fix

Remove `&prompt=none` from the authorization URL so LinkedIn shows the normal consent screen and actually grants the requested scopes.

```diff
-    }&prompt=none&redirect_uri=${encodeURIComponent(
+    }&redirect_uri=${encodeURIComponent(
```

One-line change, no behavior change other than showing consent (which is the expected UX for connecting an account).

## Verification

Tested on a self-hosted `latest` instance connecting a **personal** profile. With `prompt=none` removed (together with the scope fix in #1244), the consent screen appears, the account connects, and a real post publishes to the member feed successfully.

Closes #1580