### PR TITLE
feat(tiktok): comply with Direct Post audit UX requirements (creator_info-driven composer)

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.provider.tsx
@@ -2,7 +2,9 @@
 
 import {
   FC,
+  useEffect,
   useMemo,
+  useState,
 } from 'react';
 import {
   PostComment,
@@ -10,6 +12,7 @@ import {
 } from '@gitroom/frontend/components/new-launch/providers/high.order.provider';
 import { TikTokDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/tiktok.dto';
 import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
+import { useCustomProviderFunction } from '@gitroom/frontend/components/launches/helpers/use.custom.provider.function';
 import { Select } from '@gitroom/react/form/select';
 import { Checkbox } from '@gitroom/react/form/checkbox';
 import clsx from 'clsx';
@@ -24,6 +27,18 @@ const TikTokSettings: FC<{
   const { watch, register } = useSettings();
   const { value } = useIntegration();
   const t = useT();
+  const customFunc = useCustomProviderFunction();
+  // creator_info drives the privacy options, the interaction toggles and the
+  // posting limits shown below, as required by TikTok's UX guidelines for the
+  // Direct Post audit (https://developers.tiktok.com/doc/content-sharing-guidelines).
+  const [creator, setCreator] = useState<any>(undefined);
+
+  useEffect(() => {
+    customFunc
+      .get('creatorInfo')
+      .then((data) => setCreator(data))
+      .catch(() => setCreator(null));
+  }, []);
 
   const isTitle = useMemo(() => {
     return value?.[0]?.image?.some((p) => (p?.path?.indexOf?.('mp4') ?? -1) === -1);
@@ -31,10 +46,11 @@ const TikTokSettings: FC<{
 
   const hasMedia = (value?.[0]?.image?.length ?? 0) > 0;
   const isVideo = hasMedia && !isTitle;
+  const isPhoto = hasMedia && isTitle;
 
   const disclose = watch('disclose');
-  const brand_organic_toggle = watch('brand_organic_toggle');
   const brand_content_toggle = watch('brand_content_toggle');
+  const privacy_level = watch('privacy_level');
   const content_posting_method = watch('content_posting_method');
   const isUploadMode = content_posting_method === 'UPLOAD';
 
@@ -58,7 +74,7 @@ const TikTokSettings: FC<{
     );
   }, [hasMedia, isUploadMode, isVideo, t]);
 
-  const privacyLevel = [
+  const allPrivacyLevels = [
     {
       value: 'PUBLIC_TO_EVERYONE',
       label: t('public_to_everyone', 'Public to everyone'),
@@ -76,6 +92,16 @@ const TikTokSettings: FC<{
       label: t('self_only', 'Self only'),
     },
   ];
+  // TikTok requires showing only the privacy options the creator actually has
+  // (a private account has no PUBLIC_TO_EVERYONE, a public one has no
+  // FOLLOWER_OF_CREATOR). Fall back to the full list until creator_info loads.
+  const privacyLevel = useMemo(() => {
+    const options = creator?.privacyLevelOptions;
+    if (options?.length) {
+      return allPrivacyLevels.filter((p) => options.includes(p.value));
+    }
+    return allPrivacyLevels;
+  }, [creator, t]);
   const contentPostingMethod = [
     {
       value: 'DIRECT_POST',
@@ -106,6 +132,24 @@ const TikTokSettings: FC<{
   return (
     <div className="flex flex-col">
       {/*<CheckTikTokValidity picture={props?.values?.[0]?.image?.[0]?.path} />*/}
+      {creator && (
+        <div className="text-[14px] mb-[16px] flex flex-col gap-[4px]">
+          <div>
+            {t('posting_to_tiktok_account', 'Posting to TikTok account:')}{' '}
+            <span className="font-[600]">{creator.nickname}</span>
+            {creator.username ? <span> (@{creator.username})</span> : null}
+          </div>
+          {creator.maxVideoPostDurationSec ? (
+            <div>
+              {t(
+                'max_video_duration_allowed',
+                'Maximum video duration allowed for this account:'
+              )}{' '}
+              {creator.maxVideoPostDurationSec}s
+            </div>
+          ) : null}
+        </div>
+      )}
       {tiktokRestrictionNotice && (
         <div className="bg-tableBorder p-[10px] mb-[18px] rounded-[10px] flex gap-[10px] items-start text-[13px] text-balance">
           <div className="shrink-0 mt-[2px]">
@@ -131,12 +175,16 @@ const TikTokSettings: FC<{
           label={t('label_who_can_see_this_video', 'Who can see this video?')}
           disabled={isUploadMode}
           {...register('privacy_level', {
-            value: 'PUBLIC_TO_EVERYONE',
+            value: '',
           })}
         >
           <option value="">{t('select', 'Select')}</option>
           {privacyLevel.map((item) => (
-            <option key={item.value} value={item.value}>
+            <option
+              key={item.value}
+              value={item.value}
+              disabled={item.value === 'SELF_ONLY' && !!brand_content_toggle}
+            >
               {item.label}
             </option>
           ))}
@@ -189,22 +237,26 @@ const TikTokSettings: FC<{
           {t('tiktok_video_features', 'Video features')}
         </div>
         <div className="flex gap-[40px]">
-          <Checkbox
-            variant="hollow"
-            label={t('label_duet', 'Allow Duet')}
-            disabled={isUploadMode}
-            {...register('duet', {
-              value: false,
-            })}
-          />
-          <Checkbox
-            label={t('label_stitch', 'Allow Stitch')}
-            variant="hollow"
-            disabled={isUploadMode}
-            {...register('stitch', {
-              value: false,
-            })}
-          />
+          {!isPhoto && (
+            <Checkbox
+              variant="hollow"
+              label={t('label_duet', 'Allow Duet')}
+              disabled={isUploadMode || !!creator?.duetDisabled}
+              {...register('duet', {
+                value: false,
+              })}
+            />
+          )}
+          {!isPhoto && (
+            <Checkbox
+              label={t('label_stitch', 'Allow Stitch')}
+              variant="hollow"
+              disabled={isUploadMode || !!creator?.stitchDisabled}
+              {...register('stitch', {
+                value: false,
+              })}
+            />
+          )}
           <Checkbox
             label={t('video_made_with_ai', 'Video made with AI')}
             variant="hollow"
@@ -219,9 +271,9 @@ const TikTokSettings: FC<{
           <Checkbox
             label={t('label_comments', 'Allow Comments')}
             variant="hollow"
-            disabled={isUploadMode}
+            disabled={isUploadMode || !!creator?.commentDisabled}
             {...register('comment', {
-              value: true,
+              value: false,
             })}
           />
           <Checkbox
@@ -291,7 +343,7 @@ const TikTokSettings: FC<{
           <Checkbox
             variant="hollow"
             label={t('label_branded_content', 'Branded content')}
-            disabled={isUploadMode}
+            disabled={isUploadMode || privacy_level === 'SELF_ONLY'}
             {...register('brand_content_toggle', {
               value: false,
             })}
@@ -307,35 +359,40 @@ const TikTokSettings: FC<{
               'This video will be classified as Branded Content.'
             )}
           </div>
-          {(brand_organic_toggle || brand_content_toggle) && (
-            <div className="my-[10px] text-[14px] text-balance">
+          {privacy_level === 'SELF_ONLY' && (
+            <div className="text-balance my-[10px] text-[14px]">
               {t(
-                'by_posting_you_agree_to_tiktoks',
-                "By posting, you agree to TikTok's"
+                'branded_content_cannot_be_private',
+                'Branded content visibility cannot be set to "Self only".'
               )}
-              {[
-                brand_organic_toggle || brand_content_toggle ? (
-                  <a
-                    target="_blank"
-                    className="text-[#B69DEC] hover:underline"
-                    href="https://www.tiktok.com/legal/page/global/music-usage-confirmation/en"
-                  >
-                    {t('music_usage_confirmation', 'Music Usage Confirmation')}
-                  </a>
-                ) : undefined,
-                brand_content_toggle ? <> {t('and', 'and')} </> : undefined,
-                brand_content_toggle ? (
-                  <a
-                    target="_blank"
-                    className="text-[#B69DEC] hover:underline"
-                    href="https://www.tiktok.com/legal/page/global/bc-policy/en"
-                  >
-                    {t('branded_content_policy', 'Branded Content Policy')}
-                  </a>
-                ) : undefined,
-              ].filter((f) => f)}
             </div>
           )}
+        </div>
+        <div className="mt-[20px] text-[14px] text-balance">
+          {t(
+            'by_posting_you_agree_to_tiktoks',
+            "By posting, you agree to TikTok's"
+          )}{' '}
+          <a
+            target="_blank"
+            className="text-[#B69DEC] hover:underline"
+            href="https://www.tiktok.com/legal/page/global/music-usage-confirmation/en"
+          >
+            {t('music_usage_confirmation', 'Music Usage Confirmation')}
+          </a>
+          {brand_content_toggle ? (
+            <>
+              {' '}
+              {t('and', 'and')}{' '}
+              <a
+                target="_blank"
+                className="text-[#B69DEC] hover:underline"
+                href="https://www.tiktok.com/legal/page/global/bc-policy/en"
+              >
+                {t('branded_content_policy', 'Branded Content Policy')}
+              </a>
+            </>
+          ) : null}
         </div>
       </div>
     </div>

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/tiktok.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/tiktok.dto.ts
@@ -10,7 +10,10 @@ import { JSONSchema } from 'class-validator-jsonschema';
 // video_made_with_ai / duet / stitch are additionally video-only: TikTok's photo
 // post_info has no is_aigc, disable_duet or disable_stitch field.
 // Fields stay required here (existing clients depend on it); the constraints are
-// documented, not enforced.
+// documented, not enforced. The one exception is privacy_level, which is only
+// required on DIRECT_POST: TikTok's audit UX guidelines demand the user picks it
+// manually (no preselected default), so the composer starts it empty and UPLOAD
+// posts must not be blocked by it.
 export class TikTokDto {
   @ValidateIf((p) => p.title)
   @MaxLength(90)
@@ -20,6 +23,7 @@ export class TikTokDto {
   })
   title: string;
 
+  @ValidateIf((p) => p.content_posting_method !== 'UPLOAD')
   @IsIn([
     'PUBLIC_TO_EVERYONE',
     'MUTUAL_FOLLOW_FRIENDS',
@@ -29,7 +33,7 @@ export class TikTokDto {
   @IsString()
   @JSONSchema({
     description:
-      'Applied only when content_posting_method=DIRECT_POST. Ignored by TikTok on UPLOAD.',
+      'Required when content_posting_method=DIRECT_POST; must be chosen explicitly by the user (TikTok forbids preselecting it). Ignored by TikTok on UPLOAD.',
   })
   privacy_level:
     | 'PUBLIC_TO_EVERYONE'

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -412,6 +412,32 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
+  async creatorInfo(accessToken: string) {
+    const { data } = await (
+      await this.fetch(
+        'https://open.tiktokapis.com/v2/post/publish/creator_info/query/',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json; charset=UTF-8',
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      )
+    ).json();
+
+    return {
+      nickname: data?.creator_nickname,
+      username: data?.creator_username,
+      avatar: data?.creator_avatar_url,
+      privacyLevelOptions: data?.privacy_level_options || [],
+      commentDisabled: !!data?.comment_disabled,
+      duetDisabled: !!data?.duet_disabled,
+      stitchDisabled: !!data?.stitch_disabled,
+      maxVideoPostDurationSec: data?.max_video_post_duration_sec,
+    };
+  }
+
   private async uploadedVideoSuccess(
     id: string,
     publishId: string,


### PR DESCRIPTION
Fixes the composer gaps that make TikTok reject **Content Posting API - Direct Post** audits for Postiz-based apps (#1362). TikTok enforces its [Content Sharing UX guidelines](https://developers.tiktok.com/doc/content-sharing-guidelines) during the audit; the current composer violates several of them, so audits fail with "did not follow our UX Guidelines" (or a generic rejection) regardless of demo video quality.

### What changed

**Frontend (TikTok settings component):**
- `privacy_level` no longer preselects `PUBLIC_TO_EVERYONE`: it starts on "Select" and the user must pick one (TikTok explicitly rejects preselected privacy, especially public).
- Privacy options are filtered by the creator's real `privacy_level_options` from `creator_info` (a public account never has `FOLLOWER_OF_CREATOR`, a private one never has `PUBLIC_TO_EVERYONE`). The static list stays as a fallback while loading.
- New creator header: "Posting to TikTok account: {nickname} (@{username})" plus the account's `max_video_post_duration_sec`, both from `creator_info` (the guidelines require showing creator identity and posting limits).
- `comment` now defaults to unchecked (TikTok requires interaction toggles off by default); comment/duet/stitch are disabled when the creator has them disabled in `creator_info`; duet/stitch are hidden for photo posts (photo `post_info` has no such fields, matching the existing DTO docs).
- Branded content and "Self only" visibility now exclude each other in both directions (TikTok forbids private branded content), with an explanatory note.
- The compliance declaration ("By posting, you agree to TikTok's Music Usage Confirmation", plus Branded Content Policy when branded content is on) is always visible for direct posts. Previously it only rendered after enabling disclosure, but the guidelines require it for every post.

**Backend:**
- New `creatorInfo()` on `TiktokProvider` querying `/v2/post/publish/creator_info/query/`, exposed to the composer through the existing `/integrations/function` mechanism (same pattern as Pinterest `boards()`).
- It uses `this.fetch` instead of plain `fetch`, so an expired token throws `RefreshToken` and the dispatcher refreshes and retries. Note: `maxVideoLength()` has the same latent issue (plain `fetch` swallows auth errors and resolves with `undefined` data); left untouched to keep this diff focused, happy to fix it here too if you prefer.

**DTO:**
- `privacy_level` is only required when `content_posting_method !== 'UPLOAD'`: with no preselected default, upload-mode posts (where TikTok ignores privacy anyway, per the field's own docs) must not be blocked by an empty value.

### Testing

Deployed on a self-hosted instance (v2.21.10 base, same changes) connected to a real TikTok production app:
- `creatorInfo` returns real data end-to-end and the token-refresh path works (first call after token expiry refreshes and retries transparently).
- A public account correctly shows only its 3 real privacy options (`FOLLOWER_OF_CREATOR` absent).
- Creator line and max-duration limit render; consent line always visible; comment defaults to off.

Context: our own Direct Post audit was rejected with the stock composer; these changes were written against the audit checklist to make Postiz-based apps auditable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
