### PR TITLE
fix: keep agent chat history when CopilotKit clobbers the message state

### DIFF
--- a/apps/backend/src/api/routes/copilot.controller.ts
+++ b/apps/backend/src/api/routes/copilot.controller.ts
@@ -128,6 +128,7 @@ export class CopilotController {
         threadId,
       });
     } catch (err) {
+      Logger.warn(`Could not recall messages for thread ${threadId}: ${err}`);
       return { messages: [] };
     }
   }

--- a/apps/frontend/src/components/agents/agent.chat.tsx
+++ b/apps/frontend/src/components/agents/agent.chat.tsx
@@ -95,6 +95,7 @@ You can also use me as an MCP Server, check Settings >> Public API
 const LoadMessages: FC<{ id: string }> = ({ id }) => {
   const { messages, setMessages } = useCopilotMessagesContext();
   const fetch = useFetch();
+  const currentId = useRef<string | null>(null);
   const loaded = useRef<{ id: string; messages: CopilotMessage[] } | null>(
     null
   );
@@ -108,7 +109,7 @@ const LoadMessages: FC<{ id: string }> = ({ id }) => {
       });
     });
 
-    if (loaded.current?.id !== idToSet) {
+    if (currentId.current !== idToSet) {
       return;
     }
 
@@ -117,11 +118,13 @@ const LoadMessages: FC<{ id: string }> = ({ id }) => {
   }, []);
 
   useEffect(() => {
-    loaded.current = { id, messages: [] };
+    currentId.current = id;
     if (id === 'new') {
+      loaded.current = { id, messages: [] };
       setMessages([]);
       return;
     }
+    loaded.current = null;
     loadMessages(id);
   }, [id]);
 

--- a/apps/frontend/src/components/agents/agent.chat.tsx
+++ b/apps/frontend/src/components/agents/agent.chat.tsx
@@ -6,6 +6,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { CopilotChat, CopilotKitCSSProperties } from '@copilotkit/react-ui';
@@ -27,7 +28,10 @@ import {
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { useParams } from 'next/navigation';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
-import { TextMessage } from '@copilotkit/runtime-client-gql';
+import {
+  Message as CopilotMessage,
+  TextMessage,
+} from '@copilotkit/runtime-client-gql';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
 import dayjs from 'dayjs';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
@@ -89,29 +93,54 @@ You can also use me as an MCP Server, check Settings >> Public API
 };
 
 const LoadMessages: FC<{ id: string }> = ({ id }) => {
-  const { setMessages } = useCopilotMessagesContext();
+  const { messages, setMessages } = useCopilotMessagesContext();
   const fetch = useFetch();
+  const loaded = useRef<{ id: string; messages: CopilotMessage[] } | null>(
+    null
+  );
 
   const loadMessages = useCallback(async (idToSet: string) => {
     const data = await (await fetch(`/copilot/${idToSet}/list`)).json();
-    console.log(data);
-    setMessages(
-      data.messages.map((p: any) => {
-        return new TextMessage({
-          content: p.content.content,
-          role: p.role,
-        });
-      })
-    );
+    const list = data.messages.map((p: any) => {
+      return new TextMessage({
+        content: p.content.content,
+        role: p.role,
+      });
+    });
+
+    if (loaded.current?.id !== idToSet) {
+      return;
+    }
+
+    loaded.current = { id: idToSet, messages: list };
+    setMessages(list);
   }, []);
 
   useEffect(() => {
+    loaded.current = { id, messages: [] };
     if (id === 'new') {
       setMessages([]);
       return;
     }
     loadMessages(id);
   }, [id]);
+
+  // CopilotKit resolves loadAgentState to an empty list for Mastra local agents
+  // and can clobber the messages we hold, depending on which request resolves last
+  useEffect(() => {
+    if (loaded.current?.id !== id) {
+      return;
+    }
+
+    if (messages.length) {
+      loaded.current.messages = messages;
+      return;
+    }
+
+    if (loaded.current.messages.length) {
+      setMessages(loaded.current.messages);
+    }
+  }, [messages, id]);
 
   return null;
 };


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A customer reported their agent chat was "frozen and not responding" — they refreshed and reopened the browser and still got nothing. Reproduced by switching between two long agent conversations: at some point the conversation stops rendering and the page sits on the new-conversation welcome text instead of the selected thread. The input still works, but with no visible thread it reads as broken.

The cause is a race between two independent writers to CopilotKit's message state, both triggered by a `threadId` change:

1. `LoadMessages` (`agent.chat.tsx`) fetches `GET /copilot/:id/list` and calls `setMessages` with the history.
2. CopilotKit's `CopilotMessages` provider runs its own `loadAgentState` on the same trigger. We register Mastra local agents (`MastraAgent.getLocalAgents` in `copilot.controller.ts`), and for those the runtime resolves the agent's client to `null` — so `loadAgentState` always returns an empty list and unconditionally calls `setMessages([])`.

Last writer wins. `CopilotChat` always prepends `labels.initial`, so an empty array renders as exactly the new-conversation welcome text — which is why this looked like a frozen or empty chat rather than an error. Both requests succeed, nothing throws, and `showDevConsole={false}` routes any genuine CopilotKit error onto a swallowed path, so there was nothing in the console to go on.

While verifying, the two requests turned out to be close enough that the ordering is genuinely nondeterministic: in one instrumented run the wipe landed 6ms after our fetch, and it hit roughly a third of thread loads on a development machine with no artificial delay at all.

# Why this implementation

What was ruled out first:

- `@copilotkit/*` is pinned at `1.10.6`. Upgrading or patching it is out of scope.
- The offending effect is internal to the `CopilotMessages` provider and is not configurable, so it cannot be disabled.
- `setThreadId()` throws when `threadId` is supplied via props.
- Anything depending on which request resolves first is not a fix, because the ordering is not stable. One observed case had React batch our write together with the wipe into a single commit, so our history never rendered even once — an approach based on winning the race would have missed that case entirely.
- Approaches leaning on CopilotKit's internal refs (`lastLoadedThreadId`, `lastLoadedMessages`) would work today, but they are invisible to a reviewer and would break silently on a patch bump.

So rather than competing for the write, this reacts to the outcome: remember the last non-empty list seen for the current thread, and if the state goes empty, put it back. That is ordering-independent by construction — it does not matter which request resolves last. It settles in one extra render and cannot loop, because the condition is false as soon as `messages` is non-empty. Legitimately empty threads and `/agents/new` are unaffected, since we only restore a list that has content.

Tracking the last non-empty list, rather than just the list we fetched, matters: a wipe can land after the user has already sent something, and restoring the fetched list would discard their message.

The second commit hardens the bookkeeping after review feedback. `loaded` is now null until the thread's own fetch resolves, so there is no window in which it could be populated from a different thread, and staleness is tracked separately in `currentId`. That path is not reachable today — `/agents/[id]` is a dynamic route segment, so clicking a thread remounts the subtree and `id` never changes on a live instance — but the fix should not depend on that implicitly. `/agents/new` keeps an empty-but-present state, since an empty list is correct there and a message sent before the wipe must still be restored.

The backend change is small and separate. `getMessagesList` caught `recall` errors and returned an empty list silently, which produced an empty chat indistinguishable from this race — it is why diagnosis took code reading rather than log reading. It now logs the error and still degrades to an empty list rather than 500-ing the chat.

# Other information:

Verified by forcing the losing ordering with a temporary server-side delay on `loadAgentState`, with temporary instrumentation on the message state. Without the fix, the chat stays on the welcome text indefinitely. With it:

- the history is restored roughly 5s after the click — i.e. the moment the wipe lands — every time;
- repeated fast switching between threads never shows one thread's messages under another's id;
- a message sent in a new chat before the wipe survives it, and the reply streams in normally on top of it.

Known follow-up, deliberately not in this PR: `agent.chat.tsx` maps `p.content.content`, but Mastra's `MastraMessageContentV2` declares `content` as optional with `parts[]` as the canonical field. Parts-only messages therefore map to `TextMessage({ content: undefined })` and render as blank bubbles. That is a different symptom — blank bubbles inside a populated thread, not a blank thread — and needs its own investigation against real payloads.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue
