### PR TITLE
fix: duplicate useToaster import breaking the frontend build on main

### DIFF
--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -16,7 +16,6 @@ import { ImportDebugPostModal } from '@gitroom/frontend/components/launches/impo
 import { useForm, FormProvider } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';
 import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/admin.add.team.member.dto';
-import { useToaster } from '@gitroom/react/toaster/toaster';
 
 interface Charge {
   id: string;


### PR DESCRIPTION
## Why

The frontend build of `main` (CI `build.yml` and deployments) has been failing since the #1743 merge with:

```
./apps/frontend/src/components/layout/impersonate.tsx:19:10
the name `useToaster` is defined multiple times
```

#1730 and #1743 each added the same `useToaster` import to `impersonate.tsx` next to different neighboring lines. Each PR was green against the `main` it was based on, and merging both kept both import lines without any textual conflict — a semantic conflict git can't see. The first build of the combined result was post-merge, where nothing gates or alerts, so the deployment was the first place it surfaced.

## What changed

Removes the duplicate import line — one-line deletion, no behavior change. `pnpm run build:frontend` passes locally on this branch.

## Other information

Discussed separately: enabling the merge queue (`build.yml` already has the `merge_group:` trigger) or required up-to-date status checks would prevent this class of stale-checks merge breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)