### PR TITLE
fix(x): don't crash X analytics when a timeline page has no tweets

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -625,8 +625,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
     });
 
     return [
-      ...tweets.data.data,
-      ...(tweets.data.data.length === 100
+      ...tweets.tweets,
+      ...(tweets.tweets.length === 100
         ? await this.loadAllTweets(
             client,
             id,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, X provider analytics). `loadAllTweets` in `x.provider.ts` reads `tweets.tweets` - the twitter-api-v2 paginator getter, which is `_realData.data ?? []` - instead of `tweets.data.data`. X omits `data` entirely from the response when a timeline page contains no tweets, so the spread threw `TypeError: undefined is not iterable` and the whole analytics call for that channel failed. The two reads are otherwise identical. The pagination condition and the follow-up `client.v2.tweets` metrics call are deliberately unchanged.

# Why was this change needed?

In production we get:

```
TypeError: tweets.data.data is not iterable
    at XProvider.loadAllTweets (x.provider.js)
```

The X API omits the `data` key entirely when a userTimeline page has zero results, so `tweets.data.data` is `undefined` and spreading it throws. The twitter-api-v2 paginator only normalizes `data` to `[]` when merging subsequent pages, never on the first response.

There are two paths to this, both reproduced locally:

1. **First page empty** — an account with no original tweets in the analytics window (replies/retweets are excluded). Cosmetic: analytics is empty either way, but the error is logged.
2. **A later page empty** — X can return a `next_token` on an exactly-full final page and resolve it as a zero-result page. The throw then propagates up through the recursion and **discards all tweets already collected**, returning empty analytics for an account that has data. Reproduced with page size temporarily lowered to 5 and 5 tweets in the window:

```
[x-pagination-test] fetch #1, token: (none)
[x-pagination-test] fetch #2, token: 7140dibdnow9c7btwoxjd4o4e9f...
TypeError: tweets.data.data is not iterable
    at XProvider.loadAllTweets (x.provider.ts:635)
    at async XProvider.loadAllTweets (x.provider.ts:637)   <- recursion frame: page 1's tweets are lost
    at async XProvider.analytics (x.provider.ts:671)
```

Using the paginator's own `tweets` getter (`this._realData.data ?? []`) fixes both — same data, same `TweetV2[]` type, null-safe. With the fix, both scenarios verified to return the collected tweets cleanly with no error.

# Other information:

Related: #1766 (pagination condition in the same function).

# QA

1. [ ] Connect an X channel that has posted nothing in the last 100 days, or a brand-new account
2. [ ] Open Analytics and select that channel
3. [ ] The page renders with empty / zero series instead of an error toast
4. [ ] Backend logs contain no "undefined is not iterable" from `x.provider`
5. [ ] Select an X channel that does have recent tweets - its numbers are identical to before the change
6. [ ] Reload analytics for both channels to confirm the behaviour is stable

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
