### PR TITLE
fix(x): paginate X analytics timeline by next_token instead of page size

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -626,7 +626,7 @@ export class XProvider extends SocialAbstract implements SocialProvider {
 
     return [
       ...tweets.data.data,
-      ...(tweets.data.data.length === 100
+      ...(tweets.meta.next_token
         ? await this.loadAllTweets(
             client,
             id,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix / hardening (backend, X provider analytics). `loadAllTweets` in `x.provider.ts` recurses while `tweets.meta.next_token` is present instead of inferring "there is another page" from `tweets.data.data.length === 100`. X can return fewer items than `max_results` and still hand back a `next_token`, so analytics silently truncated the timeline and under-reported. The recursive call already passed `tweets.meta.next_token`, so only the condition changes. Note for the reviewer: this touches the same two lines as #1765 and should be rebased on top of it, so the page read also becomes the null-safe `tweets.tweets`.

# Why was this change needed?

`loadAllTweets` decides whether to fetch another page by checking `length === 100` (page is full) instead of whether X actually returned a `next_token`. That's the wrong contract: per the X API, `next_token` is present iff another page exists, and twitter-api-v2's own paginator (`canFetchNextPage`) keys off `meta.next_token` too.

If X ever returns a full final page without a `next_token`, the old check recurses with `undefined`, which falls back to the empty-token default, which omits `pagination_token` — refetching page 1 in an infinite loop until the stack blows or X rate-limits the key.

Testing locally (page size temporarily lowered to 5) showed X currently emits a `next_token` even on an exactly-full final page and resolves it as an empty next page — so today this loop path is instead surfaced as the empty-page crash fixed in #1765. This change makes pagination follow the documented contract regardless of which behavior X exhibits, and the two fixes compose: full page → token → empty page → clean stop with all collected tweets.

Verified locally with a lowered page size: 6 tweets in the window → fetch 1 (5 tweets + token) → fetch 2 (1 tweet, no token) → terminates, all 6 counted.

# Other information:

Related: #1765 (empty-page TypeError in the same function).

# QA

1. [ ] Connect an X channel with more than 100 tweets published in the last 100 days
2. [ ] Open Analytics for that channel over a 90-day range
3. [ ] Backend logs show more than one `userTimeline` request, so pagination was followed
4. [ ] The tweet count behind the analytics numbers matches the account's real post count for that range, instead of capping near a multiple of 100
5. [ ] Select an X channel with fewer than 100 tweets in range - exactly one request is made and the numbers are unchanged
6. [ ] Confirm the request count stays bounded and the call terminates rather than paginating forever

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
