### PR TITLE
fix(linkedin-page): connecting a company page hijacks the personal LinkedIn channel

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -254,7 +254,9 @@ export class LinkedinPageProvider
     ).json();
 
     return {
-      id: id,
+      // namespaced placeholder so the in-between row never collides with the
+      // personal LinkedIn channel row (same org + same member sub)
+      id: `${this.identifier}_${id}`,
       accessToken,
       refreshToken,
       expiresIn,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, LinkedIn Page connect flow). `LinkedinPageProvider.authenticate` returns `${this.identifier}_${id}` as the in-between placeholder id instead of the raw LinkedIn member `sub`. `Integration` is unique on `[organizationId, internalId]` only, with no `providerIdentifier` in the key, so the placeholder row created while picking a company page collided with - and overwrote - the user's existing personal LinkedIn channel. The placeholder is transient (page selection replaces it with the real page id), so no migration is needed and existing connected channels are untouched. The token exchange, scope check and posting paths are unchanged.

# Why was this change needed?

Production user report: adding a LinkedIn company page removed their personal LinkedIn channel and retargeted all their scheduled personal posts to the page (one already-published personal post now displays as the page).

Root cause: integrations upsert on `(organizationId, internalId)` only, and `linkedin-page`'s `authenticate()` returns the personal member `sub` — the exact same id the `linkedin` provider returns. So step 1 of a page connect matches the existing personal row and converts it in place; `saveProviderPage` then rewrites it to the selected page. If the page is *already* connected, it's worse: `updateIntegration`'s `existing` branch soft-deletes the hijacked personal row and every post on it.

The fix makes `linkedin-page`'s `authenticate()` return a provider-namespaced placeholder (`linkedin-page_<sub>`) so the step-1 in-between row can never collide with the personal channel. The placeholder is deterministic (repeat attempts reuse one in-between row) and never survives a completed connect — `saveProviderPage` overwrites it with the real organization id.

Verified consequences of the id change:
- `rootInternalId` grouping: new page rows group under the placeholder instead of the personal sub, so `oneTimeToken` propagation no longer crosses personal↔page. Safe: both providers request identical scopes on the same client, and LinkedIn does not rotate refresh tokens (fixed 365-day validity), so each row's stored refresh token stays valid independently.
- Refresh/reConnect unaffected: page rows keep `rootInternalId ≠ internalId`, so `refreshProcess` still calls `reConnect` with the page id, and the controller's refresh guard is satisfied via `reConnect`'s early return.
- `checkPreviousConnections` (trial-abuse check) now looks up the namespaced value on page connects, so it won't match pre-fix rows in other orgs — slightly loosened across the fix boundary; acceptable.
- Pre-fix abandoned in-between rows (`internalId = <sub>`) won't be reused by post-fix retries; one extra harmless orphan row.

E2e on a real LinkedIn account (personal + one company page): reproduced the hijack on unfixed code (personal row converted, its queued and published posts soft-deleted — the destructive already-connected-page variant), then on this branch the same flow left the personal row byte-untouched across page connect, re-connect, two abandoned connects, and a page token refresh; both channels publish correctly afterwards. Untested: connecting a second company page (only one page admin available) — identical code path to the first-page case.

# Other information:

History note: this bug is a regression of a previously fixed problem. 4806b82c (Dec 2024) namespaced the page id as `p_<sub>` but paired it with a generic `internalId.split('_').pop()` to derive `rootInternalId`; that parsing mangled any provider id legitimately containing `_` (wrong token-propagation groups, false 412s in `checkPreviousConnections`), so fa5d7f4c removed both the parsing and the prefix — re-arming this hijack. This PR restores only the prefix half: the placeholder is opaque, compared by exact match everywhere and overwritten (never parsed) by `saveProviderPage`, so ids containing `_` are unaffected.

Timeline: the `p_` namespacing shipped Dec 30, 2024 (4806b82c) and protected against this collision for ~16 months; fa5d7f4c removed it on Apr 22, 2026, and the hijack reports started ~3 months later.

On the shared `rootInternalId` design: it dates from LinkedIn's "access token reuse" behavior, where re-authorizing returned the same token string, so all rows of one member held one token and syncing a refresh to the group kept them working. That behavior is off for our app — verified live during e2e: four authorizations minutes apart returned four distinct tokens, all concurrently valid, and a June-issued personal token still published after all four new grants (i.e. new page grants do not revoke or replace sibling tokens). Each row stores its own refresh credentials, so rows outside a sync group self-heal via the refresh flow either way. The propagation mechanism itself is untouched by this PR — existing channels keep their grouping; only newly connected pages stop grouping with the personal row.

Forward-looking fix only; already-converted rows can't be automatically restored. The structural fix (`@@unique([organizationId, internalId, providerIdentifier])`) is a production schema migration and will be filed separately.

# QA

1. [ ] Connect a personal LinkedIn channel, note its name and avatar, and schedule a post to it so it has history
2. [ ] Go to Channels -> Add Channel -> LinkedIn Page and authenticate with the same LinkedIn account
3. [ ] Pick a company page and finish the flow
4. [ ] Both channels are listed separately, and the personal LinkedIn channel still shows its own name, avatar and scheduled post
5. [ ] Publish a post to each and confirm each lands on the right destination - personal feed versus company page
6. [ ] Run the LinkedIn Page connect a second time with the same account and confirm no existing channel is overwritten

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
