### PR TITLE
fix(public-api): return 404 instead of 500 when deleting a missing post

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -270,6 +270,9 @@ export class PublicIntegrationsController {
   ) {
     Sentry.metrics.count('public_api-request', 1);
     const getPostById = await this._postsService.getPost(org.id, id);
+    if (!getPostById.group) {
+      throw new HttpException({ msg: 'Post not found' }, 404);
+    }
     return this._postsService.deletePost(org.id, getPostById.group);
   }
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -505,8 +505,8 @@ export class PostsService {
         }))
       ),
       integrationPicture: posts[0]?.integration?.picture,
-      integration: posts[0].integrationId,
-      settings: JSON.parse(posts[0].settings || '{}'),
+      integration: posts[0]?.integrationId,
+      settings: JSON.parse(posts[0]?.settings || '{}'),
     };
   }
 
@@ -543,8 +543,8 @@ export class PostsService {
         }))
       ),
       integrationPicture: posts[0]?.integration?.picture,
-      integration: posts[0].integrationId,
-      settings: JSON.parse(posts[0].settings || '{}'),
+      integration: posts[0]?.integrationId,
+      settings: JSON.parse(posts[0]?.settings || '{}'),
     };
 
     return list;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, public API + posts service). `DELETE /public/v1/posts/:id` now returns 404 for an id that does not exist instead of a 500. Adds a `!getPostById.group` guard in `PublicIntegrationsController.deletePost`, and optional-chains `posts[0].integrationId` / `posts[0].settings` in `PostsService.getPostsByGroup` and `getPost` - `posts[0]` is `undefined` for an unknown id, so those property reads threw a TypeError that escaped as a 500. Deletion of posts that do exist is unchanged, as is the response shape on success.

# Why was this change needed?

A recent production deployment log showed 48 `ExceptionsHandler` errors in ~30 minutes, all the same trace:

```
TypeError: Cannot read properties of undefined (reading 'integrationId')
    at PostsService.getPost (posts.service.js:367)
    at async PublicIntegrationsController.deletePost (public.integrations.controller.js:160)
```

An API consumer was calling `DELETE /public/v1/posts/:id` with an id that doesn't exist (deleted or wrong org) roughly once per second, and each call 500'd instead of returning a 404: `getPostsRecursively` returns an empty array, so `posts[0].integrationId` throws.

This PR guards the `posts[0]` access in `getPost` and `getPostsList` (same unguarded line) and makes the public-api `deletePost` return `404 {"msg":"Post not found"}` when no post matches, using the same `HttpException` style as the rest of the controller.

Validated locally: the same curl returns `{"statusCode":500,...}` on main and `404 {"msg":"Post not found"}` on this branch; deleting an existing post by id still works.

# Other information:

Found while triaging prod backend logs; a sibling PR fixes the LinkedIn page analytics `timeRange` crash from the same log.

# QA

1. [ ] Start the backend and copy an organization API key from Settings -> Public API
2. [ ] Create a post from the calendar and note its id
3. [ ] `curl -X DELETE http://localhost:3000/public/v1/posts/<that id> -H "Authorization: <key>"` - returns 200 and the post disappears from the calendar
4. [ ] Run the exact same curl again - returns 404 with `{"msg":"Post not found"}`, not 500
5. [ ] `curl -X DELETE http://localhost:3000/public/v1/posts/00000000-0000-0000-0000-000000000000 -H "Authorization: <key>"` - returns 404, not 500
6. [ ] Backend logs show no unhandled TypeError coming from `getPostsByGroup`

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
