### PR TITLE
fix(linkedin-page): skip analytics elements without a timeRange

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -347,6 +347,10 @@ export class LinkedinPageProvider
 
     const analytics = [...elements2, ...elements, ...elements3].reduce(
       (all, current) => {
+        if (!current?.timeRange?.start) {
+          return all;
+        }
+
         if (
           typeof current?.totalPageStatistics?.views?.allPageViews
             ?.pageViews !== 'undefined'
@@ -464,7 +468,10 @@ export class LinkedinPageProvider
     // Process share statistics into time series data
     const analytics = (shareElements || []).reduce(
       (all, current) => {
-        if (typeof current?.totalShareStatistics !== 'undefined') {
+        if (
+          typeof current?.totalShareStatistics !== 'undefined' &&
+          current?.timeRange?.start
+        ) {
           const dateStr = dayjs(current.timeRange.start).format('YYYY-MM-DD');
 
           all['Impressions'].push({


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, LinkedIn Page provider analytics). Both reducers in `LinkedinPageProvider.analytics` now skip elements that have no `timeRange.start`: the page-statistics reducer returns early, and the share-statistics reducer adds the guard to its existing `totalShareStatistics` condition. LinkedIn mixes lifetime aggregate rows, which carry no `timeRange`, into the same element arrays; `dayjs(undefined).format('YYYY-MM-DD')` turned those into today's date, so a lifetime total was plotted as a single day and distorted the series. Which metrics are read and the LinkedIn API calls themselves are unchanged.

# Why was this change needed?

A recent production deployment log showed 67 occurrences (in ~1.5 hours) of this unhandled error:

```
TypeError: Cannot read properties of undefined (reading 'start')
    at analytics.reduce.Impressions (linkedin.page.provider.js:268)
    at LinkedinPageProvider.postAnalytics (linkedin.page.provider.js:266)
    at async PostsService.checkPostAnalytics (posts.service.js:...)
```

LinkedIn's `organizationalEntityShareStatistics` API sometimes returns elements without a `timeRange` (aggregate/lifetime stats). The `postAnalytics` reducer guards `totalShareStatistics` but then reads `current.timeRange.start` unguarded, so LinkedIn Page post analytics crash whenever such an element appears. The page-level `analytics` reducer has the same unguarded reads, so it gets the same guard.

Elements without a `timeRange` are now skipped — same outcome as before for well-formed responses, no crash for aggregate elements.

Validated by stubbing `shareElements` with one element missing `timeRange` plus one normal element and invoking `postAnalytics` directly: main crashes with the exact production error; this branch returns analytics containing only the well-formed element.

# Other information:

Found while triaging prod backend logs, same triage as #1768.

# QA

1. [ ] Connect a LinkedIn Page channel that has some published post history
2. [ ] Open Analytics and select that LinkedIn Page channel
3. [ ] The impressions / views / clicks charts render with points spread across the selected range
4. [ ] There is no single outsized point stacked on today's date
5. [ ] Switch the range between 7, 30 and 90 days - the series shifts with the range instead of always spiking on today
6. [ ] Compare a couple of daily values against LinkedIn's own page analytics for the same dates

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
