### PR TITLE
fix(instagram): send collaborators on carousel container instead of child items

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -655,6 +655,12 @@ export class InstagramProvider
     const [accessToken] = token.split('___');
     const [firstPost] = postDetails;
     const isStory = firstPost.settings.post_type === 'story';
+    const collaborators =
+      firstPost?.settings?.collaborators?.length && !isStory
+        ? `&collaborators=${JSON.stringify(
+            firstPost?.settings?.collaborators.map((p) => p.label)
+          )}`
+        : ``;
     const isTrialReel = this.assetBoolean(firstPost.settings.is_trial_reel);
     const medias = await Promise.all(
       firstPost?.media?.map(async (m) => {
@@ -691,12 +697,10 @@ export class InstagramProvider
             )}`
           : ``;
 
-        const collaborators =
-          firstPost?.settings?.collaborators?.length && !isStory
-            ? `&collaborators=${JSON.stringify(
-                firstPost?.settings?.collaborators.map((p) => p.label)
-              )}`
-            : ``;
+        // collaborators are not allowed on carousel child items,
+        // they go on the carousel container instead
+        const itemCollaborators =
+          firstPost?.media?.length === 1 ? collaborators : ``;
 
         // audio_configuration is only supported for Reels (single video, not a story)
         // and only with Facebook Login (not Instagram Login / graph.instagram.com)
@@ -723,7 +727,7 @@ export class InstagramProvider
 
         const { id: photoId } = await (
           await this.fetch(
-            `https://${type}/v20.0/${id}/media?${mediaType}${isCarousel}${collaborators}${trialParams}${audioConfiguration}&access_token=${accessToken}${caption}`,
+            `https://${type}/v20.0/${id}/media?${mediaType}${isCarousel}${itemCollaborators}${trialParams}${audioConfiguration}&access_token=${accessToken}${caption}`,
             {
               method: 'POST',
             }
@@ -753,6 +757,13 @@ export class InstagramProvider
               : 'carousel',
           containers: medias,
           message: firstPost?.message || '',
+          ...(collaborators
+            ? {
+                collaborators: firstPost.settings.collaborators!.map(
+                  (p) => p.label
+                ),
+              }
+            : {}),
         },
       },
     ];
@@ -766,6 +777,7 @@ export class InstagramProvider
       containers: string[];
       message?: string;
       carouselId?: string;
+      collaborators?: string[];
     },
     integration: Integration
   ): Promise<PendingCheckResponse> {
@@ -832,6 +844,7 @@ export class InstagramProvider
       containers: string[];
       message?: string;
       carouselId?: string;
+      collaborators?: string[];
     },
     integration: Integration
   ): Promise<PendingCheckResponse> {
@@ -888,7 +901,11 @@ export class InstagramProvider
             pendingData.message || ''
           )}&media_type=CAROUSEL&children=${encodeURIComponent(
             pendingData.containers.join(',')
-          )}&access_token=${accessToken}`,
+          )}${
+            pendingData.collaborators?.length
+              ? `&collaborators=${JSON.stringify(pendingData.collaborators)}`
+              : ``
+          }&access_token=${accessToken}`,
           {
             method: 'POST',
           }

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -657,8 +657,10 @@ export class InstagramProvider
     const isStory = firstPost.settings.post_type === 'story';
     const collaborators =
       firstPost?.settings?.collaborators?.length && !isStory
-        ? `&collaborators=${JSON.stringify(
-            firstPost?.settings?.collaborators.map((p) => p.label)
+        ? `&collaborators=${encodeURIComponent(
+            JSON.stringify(
+              firstPost?.settings?.collaborators.map((p) => p.label)
+            )
           )}`
         : ``;
     const isTrialReel = this.assetBoolean(firstPost.settings.is_trial_reel);
@@ -903,7 +905,9 @@ export class InstagramProvider
             pendingData.containers.join(',')
           )}${
             pendingData.collaborators?.length
-              ? `&collaborators=${JSON.stringify(pendingData.collaborators)}`
+              ? `&collaborators=${encodeURIComponent(
+                  JSON.stringify(pendingData.collaborators)
+                )}`
               : ``
           }&access_token=${accessToken}`,
           {

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -596,6 +596,12 @@ export class InstagramProvider
     };
   }
 
+  // Instagram rejects collaborator handles that carry a leading @ with
+  // error_subcode 2207018, and the tag input stores whatever the user typed.
+  private stripHandle(handle: string) {
+    return handle.replace(/^@+/, '');
+  }
+
   // Single, read-only status check of a media container - the polling loops
   // that used to live inside post() are now driven by the post workflow.
   private async igContainerStatus(
@@ -659,7 +665,9 @@ export class InstagramProvider
       firstPost?.settings?.collaborators?.length && !isStory
         ? `&collaborators=${encodeURIComponent(
             JSON.stringify(
-              firstPost?.settings?.collaborators.map((p) => p.label)
+              firstPost?.settings?.collaborators.map((p) =>
+                this.stripHandle(p.label)
+              )
             )
           )}`
         : ``;
@@ -761,8 +769,8 @@ export class InstagramProvider
           message: firstPost?.message || '',
           ...(collaborators
             ? {
-                collaborators: firstPost.settings.collaborators!.map(
-                  (p) => p.label
+                collaborators: firstPost.settings.collaborators!.map((p) =>
+                  this.stripHandle(p.label)
                 ),
               }
             : {}),


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

Fixes #1547. Scheduling an Instagram carousel with collaborators always failed with "Collaborators are not allowed for carousel". That message suggests an IG limitation, but IG supports collaborators on carousels — the param just has to be sent on the parent CAROUSEL container creation call, not on each child media item (where IG rejects it with `param collaborators is not allowed`). The post failed entirely before anything was published, blocking a popular organic-reach feature.

Also folded in here (was #1966, now closed): Instagram rejects collaborator handles that carry a leading `@` with `OAuthException code 110 / error_subcode 2207018`. The tag input stores the text the user typed verbatim, so typing the handle the way Instagram displays it produced a hard publish failure reported only as "Unknown Error". A production post failed this way on 2026-08-21. It belongs in this PR because this branch reads the collaborator list from two places — the child/single container URL and the `collaborators` carried on `pendingData` for the carousel container — so fixing it separately would have left carousels sending the `@` through.

# Other information:

Verified end-to-end: a real 2-image carousel with a collaborator published successfully via the Graph API, with the collab invite delivered. Single-image posts and stories keep their existing behavior. The `handleErrors` translation for the old error is kept as a safety net.

The handle normalisation was verified separately against a live Instagram channel, driving the real `postPending` / `checkPostStatus` / `finalizePost` path with the collaborator entered as `@handle`. Before the change the carousel path threw `BadBody: Unknown Error` at carousel-container creation; after it, both a 2-image carousel and a single-image post published with the collaborator accepted. Creating a container with the same public handle returns HTTP 200 without the `@` and HTTP 400 with `2207018` when it is present, so the `@` alone is sufficient to cause the failure.

Complements #1876, which maps `2207018` to a curated message for the cases this cannot fix (genuinely private or misspelled handles).

Not fixed here: collaborator handles are still never validated, and the "max 3" limit is enforced only client-side.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
