### PR TITLE
feat(email): optional EMAIL_REPLY_TO_ADDRESS reply-to for all outgoing emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ CLOUDFLARE_REGION="auto"
 #RESEND_API_KEY="RzeTwHijvxvPUerScFcenUZUALuQJzSaGSMJ"
 #EMAIL_FROM_ADDRESS=""
 #EMAIL_FROM_NAME=""
+#EMAIL_REPLY_TO_ADDRESS=""
 #DISABLE_REGISTRATION=false
 
 # Where will social media icons be saved - local or cloudflare.

--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -131,14 +131,12 @@ export class BillingController {
   @Post('/cancel')
   async cancel(
     @GetOrgFromRequest() org: Organization,
-    @GetUserFromRequest() user: User,
     @Body() body: { feedback: string }
   ) {
     await this._notificationService.sendEmail(
       process.env.EMAIL_FROM_ADDRESS,
       'Subscription Cancelled',
-      `Organization ${org.name} has cancelled their subscription because: ${body.feedback}`,
-      user.email
+      `Organization ${org.name} has cancelled their subscription because: ${body.feedback}`
     );
 
     return this._stripeService.setToCancel(org.id);
@@ -195,18 +193,14 @@ export class BillingController {
   }
 
   @Post('/chatbase-refund')
-  async chatbaseRefund(
-    @GetUserFromRequest() user: User,
-    @GetOrgFromRequest() org: Organization
-  ) {
+  async chatbaseRefund(@GetOrgFromRequest() org: Organization) {
     const refund = await this._stripeService.chatbaseRefund(org.id);
 
     if (refund.refunded) {
       await this._notificationService.sendEmail(
         process.env.EMAIL_FROM_ADDRESS,
         'Refund issued from Chatbase',
-        `Organization ${org.name} received a refund of ${refund.amount} ${refund.currency} and their subscription was cancelled`,
-        user.email
+        `Organization ${org.name} received a refund of ${refund.amount} ${refund.currency} and their subscription was cancelled`
       );
     }
 

--- a/libraries/nestjs-libraries/src/database/prisma/notifications/notification.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/notifications/notification.service.ts
@@ -107,8 +107,8 @@ export class NotificationService {
     }
   }
 
-  async sendEmail(to: string, subject: string, html: string, replyTo?: string) {
-    await this._emailService.sendEmail(to, subject, html, 'top', replyTo);
+  async sendEmail(to: string, subject: string, html: string) {
+    await this._emailService.sendEmail(to, subject, html, 'top');
   }
 
   hasEmailProvider() {

--- a/libraries/nestjs-libraries/src/emails/node.mailer.provider.ts
+++ b/libraries/nestjs-libraries/src/emails/node.mailer.provider.ts
@@ -25,7 +25,8 @@ export class NodeMailerProvider implements EmailInterface {
     subject: string,
     html: string,
     emailFromName: string,
-    emailFromAddress: string
+    emailFromAddress: string,
+    replyTo?: string
   ) {
     const sends = await transporter.sendMail({
       from: `${emailFromName} <${emailFromAddress}>`, // sender address
@@ -33,6 +34,7 @@ export class NodeMailerProvider implements EmailInterface {
       subject: subject, // Subject line
       text: html, // plain text body
       html: html, // html body
+      ...(replyTo && { replyTo }),
     });
 
     return sends;

--- a/libraries/nestjs-libraries/src/services/email.service.ts
+++ b/libraries/nestjs-libraries/src/services/email.service.ts
@@ -133,7 +133,7 @@ export class EmailService {
           modifiedHtml,
           process.env.EMAIL_FROM_NAME,
           process.env.EMAIL_FROM_ADDRESS,
-          replyTo
+          replyTo || process.env.EMAIL_REPLY_TO_ADDRESS || undefined
         );
         console.log(sends);
         return;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature: a new optional env var EMAIL_REPLY_TO_ADDRESS. When set and non-empty, it adds a Reply-To header to all outgoing emails (welcome/activation, password reset, post published/failed, streak reminders, internal billing notifications, etc.).

# Why was this change needed?

We want replies to our emails to land at a monitored address instead of the from address. All emails funnel through EmailService.sendEmailSync, and both providers (Resend and NodeMailer) already support a replyTo argument, so the core change is a single line there plus the .env.example entry. A follow-up commit also fixed the NodeMailer provider, which was silently dropping the replyTo argument.

The last commit removes the only two explicit reply-to overrides, both internal emails in billing.controller.ts, so everything now uses the env default:

- Refund issued from Chatbase: the default reply-to lets us easily cut a ticket when needed, and the org name in the email body gives enough context.
- Subscription Cancelled: PR #1782 changes this email to go to the user instead of our internal address anyway, so the default reply-to is what we want here too instead of the user's address.

With no callers left, the replyTo param was dropped from NotificationService.sendEmail. The optional replyTo plumbing below it (EmailService, sendEmailWorkflow signal, email activity, providers) stays - it is the channel the env default flows through, and the workflow signal shape cannot change.

# Other information:

Verified e2e on localhost with Resend: with the env var set, the post-published email carried the correct Reply-To header; with the var unset, and again with it set to an empty string, no Reply-To header was added.

Deploy note: EMAIL_REPLY_TO_ADDRESS must be added to the production environment (the orchestrator is the process that actually sends) with the desired reply address for this to take effect.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)