### PR TITLE
fix(mcp): stop OAuth discovery metadata from breaking key-in-URL MCP connectors

### DIFF
--- a/libraries/nestjs-libraries/src/chat/oauth-middleware.ts
+++ b/libraries/nestjs-libraries/src/chat/oauth-middleware.ts
@@ -38,7 +38,13 @@ export function createOAuthMiddleware(options: OAuthMiddlewareOptions) {
 
   const protectedResourceMetadata = generateProtectedResourceMetadata(oauth);
   const wellKnownPath = '/.well-known/oauth-protected-resource';
-  const resourceMetadataUrl = new URL(wellKnownPath, oauth.resource).toString();
+  // RFC 9728 path-inserted form (/.well-known/oauth-protected-resource/mcp-oauth):
+  // the root well-known must stay 404 so clients don't demand OAuth for other paths
+  const resourcePath = new URL(oauth.resource).pathname;
+  const resourceMetadataUrl = new URL(
+    wellKnownPath + (resourcePath === '/' ? '' : resourcePath),
+    oauth.resource,
+  ).toString();
 
   return async function oauthMiddleware(
     req: http.IncomingMessage,

--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -45,10 +45,11 @@ export const startMcp = async (app: INestApplication) => {
 
   const server = new MCPServer(serverConfig);
 
+  const oauthResource = new URL('/mcp-oauth', process.env.NEXT_PUBLIC_BACKEND_URL!).toString();
   const oauthMiddleware = createOAuthMiddleware({
     oauth: {
-      resource: new URL('/mcp-oauth', process.env.NEXT_PUBLIC_BACKEND_URL!).toString(),
-      authorizationServers: [process.env.NEXT_PUBLIC_BACKEND_URL!],
+      resource: oauthResource,
+      authorizationServers: [oauthResource],
       validateToken: async (token: string) => {
         const org = await resolveAuth(token);
         if (!org) {
@@ -67,12 +68,25 @@ export const startMcp = async (app: INestApplication) => {
     });
   }
 
-  app.use('/.well-known/oauth-protected-resource', async (req: Request, res: Response) => {
+  app.use('/.well-known/oauth-protected-resource', async (req: Request, res: Response, next: () => void) => {
+    // Only the /mcp-oauth resource is OAuth-protected. Answering discovery on
+    // any other path (including the root, which clients fall back to) makes
+    // them demand OAuth for /mcp/:id too
+    if (req.path !== '/mcp-oauth') {
+      next();
+      return;
+    }
+
     const url = new URL('/.well-known/oauth-protected-resource', process.env.NEXT_PUBLIC_BACKEND_URL);
     await oauthMiddleware(req, res, url);
   });
 
-  app.use('/.well-known/oauth-authorization-server', async (req: Request, res: Response) => {
+  app.use('/.well-known/oauth-authorization-server', async (req: Request, res: Response, next: () => void) => {
+    if (req.path !== '/mcp-oauth') {
+      next();
+      return;
+    }
+
     res.setHeader('Access-Control-Allow-Origin', '*');
     if (req.method === 'OPTIONS') {
       res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
@@ -84,7 +98,9 @@ export const startMcp = async (app: INestApplication) => {
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('Cache-Control', 'max-age=3600');
     res.json({
-      issuer: process.env.NEXT_PUBLIC_BACKEND_URL,
+      // RFC 8414: metadata served at /.well-known/oauth-authorization-server/mcp-oauth
+      // belongs to the path-based issuer <backend>/mcp-oauth
+      issuer: oauthResource,
       authorization_endpoint: `${process.env.FRONTEND_URL}/oauth/authorize`,
       token_endpoint: `${process.env.NEXT_PUBLIC_OVERRIDE_BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL}/oauth/token`,
       response_types_supported: ['code'],


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

claude.ai custom connectors using the API-key-in-URL form
(https://mcp.postiz.com/mcp/<api-key>) stopped connecting, failing with
"Automatic client registration isn't supported by Postiz. Edit the
connector and add an OAuth Client ID." Reported by a customer and
reproduced.

The MCP endpoint itself was fine - a direct initialize POST returns
200. The problem was our OAuth discovery metadata: the well-known
routes added in ac109bf5 prefix-match every subpath and answered 200 at
the domain root, claiming the entire domain is OAuth-protected when
only /mcp-oauth is.

This became load-bearing when claude.ai adopted the MCP 2025-11-25 spec
revision (SEP-985: clients fall back to probing well-known URIs,
path-inserted then root - https://modelcontextprotocol.io/specification/2025-11-25/changelog).
claude.ai now probes discovery on every Connect, even after a
successful unauthenticated initialize, and hard-fails when it finds
authorization-server metadata without dynamic client registration
(https://claude.com/docs/connectors/building/troubleshooting). Anthropic
closed requests to relax this as "not planned"
(https://github.com/anthropics/claude-ai-mcp/issues/402,
https://github.com/anthropics/claude-ai-mcp/issues/457).

The fix scopes OAuth discovery to the path-inserted well-knowns of the
one OAuth resource (/mcp-oauth); the root and all other subpaths return
404, so key-in-URL connectors are seen as the no-auth servers they are.
The issuer moves to <backend>/mcp-oauth, which also makes the AS
metadata RFC 8414-compliant. Tokens are opaque, endpoints unchanged, so
existing OAuth clients are unaffected.

Verified end-to-end against real claude.ai through a cloudflared tunnel
watching every request: before - initialize 200, path-inserted probe
404, claude.ai falls back to root, sees OAuth metadata, fails; after -
all probes 404, connector connects, tools/list succeeds.

# Other information:

The full claude.ai OAuth connect flow against /mcp-oauth was not
re-tested live (needs a registered OAuth client); its discovery chain
is curl-verified. Worth re-checking an existing OAuth connector after
deploy. Post-deploy smoke check:
curl -i https://mcp.postiz.com/.well-known/oauth-protected-resource/mcp/anything
should return 404.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
