### PR TITLE
fix(billing): email the customer on cancellation instead of the internal address

### DIFF
--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -10,6 +10,7 @@ import { NotificationService } from '@gitroom/nestjs-libraries/database/prisma/n
 import { Request } from 'express';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
+import dayjs from 'dayjs';
 
 @ApiTags('Billing')
 @Controller('/billing')
@@ -134,14 +135,25 @@ export class BillingController {
     @GetUserFromRequest() user: User,
     @Body() body: { feedback: string }
   ) {
-    await this._notificationService.sendEmail(
-      process.env.EMAIL_FROM_ADDRESS,
-      'Subscription Cancelled',
-      `Organization ${org.name} has cancelled their subscription because: ${body.feedback}`,
-      user.email
-    );
+    const result = await this._stripeService.setToCancel(org.id);
 
-    return this._stripeService.setToCancel(org.id);
+    if (result.cancel_at) {
+      try {
+        await this._notificationService.sendEmail(
+          user.email,
+          'Your subscription has been cancelled',
+          `Your subscription has been cancelled. You will keep access to all features until ${dayjs(
+            result.cancel_at
+          ).format(
+            'MMMM D, YYYY'
+          )}.<br /><br />Changed your mind? You can resubscribe anytime from your <a href="${
+            process.env.FRONTEND_URL
+          }/billing">billing page</a>.`
+        );
+      } catch (err) {}
+    }
+
+    return result;
   }
 
   @Post('/prorate')

--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -138,15 +138,18 @@ export class BillingController {
     const result = await this._stripeService.setToCancel(org.id);
 
     if (result.cancel_at) {
+      const isFutureCancel = dayjs(result.cancel_at).isAfter(dayjs(), 'day');
       try {
         await this._notificationService.sendEmail(
           user.email,
           'Your subscription has been cancelled',
-          `Your subscription has been cancelled. You will keep access to all features until ${dayjs(
-            result.cancel_at
-          ).format(
-            'MMMM D, YYYY'
-          )}.<br /><br />Changed your mind? You can resubscribe anytime from your <a href="${
+          `${
+            isFutureCancel
+              ? `Your subscription has been cancelled. You will keep access to all features until ${dayjs(
+                  result.cancel_at
+                ).format('MMMM D, YYYY')}.`
+              : 'Your subscription has been cancelled and access to paid features has ended.'
+          }<br /><br />Changed your mind? You can resubscribe anytime from your <a href="${
             process.env.FRONTEND_URL
           }/billing">billing page</a>.`
         );

--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -132,8 +132,7 @@ export class BillingController {
   @Post('/cancel')
   async cancel(
     @GetOrgFromRequest() org: Organization,
-    @GetUserFromRequest() user: User,
-    @Body() body: { feedback: string }
+    @GetUserFromRequest() user: User
   ) {
     const result = await this._stripeService.setToCancel(org.id);
 

--- a/apps/frontend/src/components/billing/main.billing.component.tsx
+++ b/apps/frontend/src/components/billing/main.billing.component.tsx
@@ -18,7 +18,6 @@ import { useUser } from '@gitroom/frontend/components/layout/user.context';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';
-import { Textarea } from '@gitroom/react/form/textarea';
 import { useFireEvents } from '@gitroom/helpers/utils/use.fire.events';
 import { useUtmUrl } from '@gitroom/helpers/utils/utm.saver';
 import { useTrack } from '@gitroom/react/helpers/use.track';
@@ -166,48 +165,6 @@ const Accept: FC<{ resolve: (res: boolean) => void }> = ({ resolve }) => {
     </div>
   );
 };
-const Info: FC<{
-  proceed: (feedback: string) => void;
-}> = (props) => {
-  const [feedback, setFeedback] = useState('');
-  const modal = useModals();
-  const events = useFireEvents();
-  const cancel = useCallback(() => {
-    props.proceed(feedback);
-    events('cancel_subscription');
-    modal.closeAll();
-  }, [modal, feedback]);
-
-  const t = useT();
-
-  return (
-    <div className="relative flex gap-[20px] flex-col flex-1 rounded-[4px]">
-      <div>
-        {t(
-          'would_you_mind_shortly_tell_us_what_we_could_have_done_better',
-          'Would you mind shortly tell us what we could have done better?'
-        )}
-      </div>
-      <div>
-        <Textarea
-          className="bg-newBgColorInner"
-          label={'Feedback'}
-          name="feedback"
-          disableForm={true}
-          value={feedback}
-          onChange={(e) => setFeedback(e.target.value)}
-        />
-      </div>
-      <div>
-        <Button disabled={feedback.length < 20} onClick={cancel}>
-          {feedback.length < 20
-            ? t('please_add_at_least', 'Please add at least 20 chars')
-            : t('cancel_subscription', 'Cancel Subscription')}
-        </Button>
-      </div>
-    </div>
-  );
-};
 export const MainBillingComponent: FC<{
   sub?: Subscription;
 }> = (props) => {
@@ -218,6 +175,7 @@ export const MainBillingComponent: FC<{
   const toast = useToaster();
   const user = useUser();
   const dub = useDubClickId();
+  const events = useFireEvents();
   const modal = useModals();
   const router = useRouter();
   const utm = useUtmUrl();
@@ -277,12 +235,6 @@ export const MainBillingComponent: FC<{
           const { cancel_at } = await (
             await fetch('/billing/cancel', {
               method: 'POST',
-              body: JSON.stringify({
-                feedback: '',
-              }),
-              headers: {
-                'Content-Type': 'application/json',
-              },
             })
           ).json();
           setSubscription((subs) => ({
@@ -336,30 +288,11 @@ export const MainBillingComponent: FC<{
               }
             }
 
-            const info = await new Promise((res) => {
-              modal.openModal({
-                title: t(
-                  'we_are_sorry_to_see_you_go',
-                  'We are sorry to see you go :('
-                ),
-                withCloseButton: true,
-                classNames: {
-                  modal: 'bg-transparent text-textColor',
-                },
-                children: <Info proceed={(e) => res(e)} />,
-              });
-            });
-
+            events('cancel_subscription');
             setLoading(true);
             const { cancel_at } = await (
               await fetch('/billing/cancel', {
                 method: 'POST',
-                body: JSON.stringify({
-                  feedback: info,
-                }),
-                headers: {
-                  'Content-Type': 'application/json',
-                },
               })
             ).json();
             setSubscription((subs) => ({


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (billing). `POST /billing/cancel` now runs the Stripe cancellation first and, only when the result carries a `cancel_at`, emails the **customer** a confirmation with their exact access-end date and a resubscribe link - instead of emailing the internal `EMAIL_FROM_ADDRESS` inbox on every toggle. The pre-cancellation feedback modal is removed and the endpoint no longer takes a request body; the response shape is unchanged.

## Motivation
Every subscription cancellation currently sends an email to the internal EMAIL_FROM_ADDRESS inbox, flooding it as volume grows — while the customer gets no confirmation at all. This flips that: the customer receives a cancellation confirmation with the exact date their access ends and a link back to the billing page to resubscribe.

## Changes
- `/billing/cancel` now calls `setToCancel` first and only sends the email when the result has a truthy `cancel_at` — since the endpoint is a toggle, reactivations and failed cancellations no longer trigger any email.
- The email goes to the customer (subject "Your subscription has been cancelled", formatted end date, resubscribe link) instead of EMAIL_FROM_ADDRESS.
- When the cancellation takes effect immediately (failed payment), the email says access has already ended instead of promising access until today's date.
- The send is wrapped in try/catch so a notification failure can't fail an already-completed Stripe cancellation. Response shape is unchanged (`{ id, cancel_at }`).
- The feedback step before cancellation is removed — the confirmation dialog leads directly to the cancellation, the `cancel_subscription` tracking event fires directly, and `/billing/cancel` no longer takes a request body.

## Testing
Verified locally against a Stripe test-mode subscription: cancel returns `{ id, cancel_at }` and queues exactly one email to the customer with the correct subject, end date, and billing link; nothing to EMAIL_FROM_ADDRESS; reactivation sends no email. Re-verified the full flow end-to-end after removing the feedback step (cancel and reactivate both work from the UI). `pnpm run build:backend` passes.

## Deployment
No DB changes required.

# QA

1. [ ] Point `STRIPE_SECRET_KEY` / `STRIPE_PUBLISHABLE_KEY` at Stripe test-mode keys, set `FRONTEND_URL`, and set `EMAIL_FROM_ADDRESS` to an inbox you can read. Start the stack with `pnpm run dev:docker` and `pnpm run dev`.
2. [ ] Log in with a user whose email you can read, go to `/billing` and subscribe to any paid tier using Stripe test card `4242 4242 4242 4242`.
3. [ ] Click "Cancel subscription" and confirm in the dialog. Expected: the flow goes straight from the confirmation to the cancellation - the "Would you mind shortly tell us what we could have done better?" feedback step with the 20-char textarea is gone.
4. [ ] Expected: the billing page shows the subscription as cancelling, and `POST /billing/cancel` returns `{ id, cancel_at }` (check the Network tab - the request body is now empty and the response shape is unchanged).
5. [ ] Open the logged-in user's mailbox. Expected: exactly one email, subject "Your subscription has been cancelled", body saying access is kept until the `cancel_at` date formatted as e.g. "March 4, 2026", with a "billing page" link pointing at `<FRONTEND_URL>/billing`.
6. [ ] Open the `EMAIL_FROM_ADDRESS` inbox. Expected: no "Subscription Cancelled" email arrived (before this change every cancellation landed here).
7. [ ] Click Reactivate on the same subscription. Expected: the subscription is active again and no email is sent to anyone (the endpoint is a toggle, and the reactivation result has no `cancel_at`).
8. [ ] Optional immediate-cancellation case: in the Stripe test dashboard let the subscription's invoice fail so the cancellation takes effect immediately. Expected: the email reads "Your subscription has been cancelled and access to paid features has ended." with no date promised.
9. [ ] Confirm the tracking event still fires: with the browser devtools open on the analytics call, cancelling emits `cancel_subscription` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
