### PR TITLE
fix(uploads): honor HTTP Range requests when serving local storage media

### DIFF
--- a/apps/frontend/src/app/(app)/api/uploads/[[...path]]/route.ts
+++ b/apps/frontend/src/app/(app)/api/uploads/[[...path]]/route.ts
@@ -36,20 +36,43 @@ export const GET = async (
   if (filePath !== base && !filePath.startsWith(base + sep)) {
     return new NextResponse('Not found', { status: 404 });
   }
-  const response = createReadStream(filePath);
   const fileStats = statSync(filePath);
   const contentType = mime.getType(filePath) || 'application/octet-stream';
+
+  // Honor ranged requests: providers that push media in chunks (TikTok video)
+  // fetch byte windows with a Range header and treat the response body as that
+  // window, so ignoring Range would corrupt their uploads.
+  const range = /^bytes=(\d+)-(\d*)$/.exec(request.headers.get('range') || '');
+  const start = range ? Number(range[1]) : 0;
+  const end = range && range[2] ? Number(range[2]) : fileStats.size - 1;
+
+  if (
+    range &&
+    (start >= fileStats.size || end >= fileStats.size || start > end)
+  ) {
+    return new NextResponse(null, {
+      status: 416,
+      headers: { 'Content-Range': `bytes */${fileStats.size}` },
+    });
+  }
+
+  const response = createReadStream(filePath, range ? { start, end } : {});
   const iterator = nodeStreamToIterator(response);
   const webStream = iteratorToStream(iterator);
   return new Response(webStream, {
+    status: range ? 206 : 200,
     headers: {
       'Content-Type': contentType,
       // Set the appropriate content-type header
-      'Content-Length': fileStats.size.toString(),
+      'Content-Length': (end - start + 1).toString(),
       // Set the content-length header
       'Last-Modified': fileStats.mtime.toUTCString(),
       // Set the last-modified header
       'Cache-Control': 'public, max-age=31536000, immutable', // Example cache-control header
+      'Accept-Ranges': 'bytes',
+      ...(range
+        ? { 'Content-Range': `bytes ${start}-${end}/${fileStats.size}` }
+        : {}),
     },
   });
 };

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -700,6 +700,17 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       const response = await fetch(path, {
         headers: { Range: `bytes=${start}-${end}` },
       });
+      // A 200 means the origin ignored the Range header and is sending the
+      // whole file: uploading it as this chunk would silently corrupt the
+      // video, so fail loudly instead.
+      if (response.status !== 206) {
+        throw new BadBody(
+          'tiktok-error-upload',
+          '{}',
+          Buffer.from('{}'),
+          `Media server ignored the ranged request (status ${response.status}); it must support HTTP Range requests for chunked TikTok uploads`
+        );
+      }
       return response.body;
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Self-hosters using STORAGE_PROVIDER=local cannot post videos larger than 64MB to TikTok since 9dd2c62d switched TikTok to chunked FILE_UPLOAD. The chunk uploader downloads the media in ranged GETs, but the local uploads route (apps/frontend/src/app/(app)/api/uploads/[[...path]]/route.ts) ignored the Range header and returned the whole file for every request. Each 10MB chunk PUT therefore carried the wrong bytes and TikTok's CDN rejects the upload with an opaque 502 in postSocial, with no hint the media server is at fault. Videos up to 64MB escaped only because they upload as a single chunk, where "whole file" happens to be the right window.

The route now serves 206 + Content-Range via a ranged createReadStream (416 for out-of-bounds, Accept-Ranges advertised, plain GETs unchanged), matching how R2 behaves. tiktokChunkStream additionally verifies the response is 206 and throws a clear BadBody naming the media server otherwise, so any future non-ranging origin fails loudly instead of corrupting uploads.

Verified end to end on local storage: a 70MB video (7 chunks) posts to TikTok and plays fully with the fix, and reproducibly 502s without it; ranged responses were byte-compared against the file on disk. R2/Cloudflare setups are unaffected (R2 already honors Range). This also unblocks converting other providers to ranged downloads (LinkedIn video is next, in a separate PR).

# Other information:

Broken since 9dd2c62d (2026-07-01). Providers that stream with a single full GET (YouTube, VK, Pinterest) never send Range and were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Checklist:

- [x] I have read the CONTRIBUTING guide.
- [x] I have signed the Contributor License Agreement (CLA).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
