### PR TITLE
fix(uploads): don't let Transloadit override local storage uploads

### DIFF
--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -87,7 +87,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           googleAdsTrialTracking={process.env.NEXT_PUBLIC_TRACKING_TRIAL}
           language={language}
           transloadit={
-            process.env.TRANSLOADIT_AUTH && process.env.TRANSLOADIT_TEMPLATE
+            // Transloadit templates export to the R2 bucket and save-media builds the
+            // path from CLOUDFLARE_BUCKET_URL, so it only works with cloudflare
+            // storage; with local storage it would silently lose uploads.
+            process.env.STORAGE_PROVIDER === 'cloudflare' &&
+            process.env.TRANSLOADIT_AUTH &&
+            process.env.TRANSLOADIT_TEMPLATE
               ? [
                   process.env.TRANSLOADIT_AUTH!,
                   process.env.TRANSLOADIT_TEMPLATE!,

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -55,7 +55,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           sentryDsn={process.env.NEXT_PUBLIC_SENTRY_DSN!}
           extensionId={process.env.EXTENSION_ID || ''}
           transloadit={
-            process.env.TRANSLOADIT_AUTH && process.env.TRANSLOADIT_TEMPLATE
+            // Transloadit templates export to the R2 bucket and save-media builds the
+            // path from CLOUDFLARE_BUCKET_URL, so it only works with cloudflare
+            // storage; with local storage it would silently lose uploads.
+            process.env.STORAGE_PROVIDER === 'cloudflare' &&
+            process.env.TRANSLOADIT_AUTH &&
+            process.env.TRANSLOADIT_TEMPLATE
               ? [
                   process.env.TRANSLOADIT_AUTH!,
                   process.env.TRANSLOADIT_TEMPLATE!,

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -57,7 +57,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           sentryDsn={process.env.NEXT_PUBLIC_SENTRY_DSN!}
           extensionId={process.env.EXTENSION_ID || ''}
           transloadit={
-            process.env.TRANSLOADIT_AUTH && process.env.TRANSLOADIT_TEMPLATE
+            // Transloadit templates export to the R2 bucket and save-media builds the
+            // path from CLOUDFLARE_BUCKET_URL, so it only works with cloudflare
+            // storage; with local storage it would silently lose uploads.
+            process.env.STORAGE_PROVIDER === 'cloudflare' &&
+            process.env.TRANSLOADIT_AUTH &&
+            process.env.TRANSLOADIT_TEMPLATE
               ? [
                   process.env.TRANSLOADIT_AUTH!,
                   process.env.TRANSLOADIT_TEMPLATE!,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Setting TRANSLOADIT_AUTH + TRANSLOADIT_TEMPLATE makes the media-library uploader pick the Transloadit plugin unconditionally, overriding STORAGE_PROVIDER. Transloadit only works with cloudflare storage: the template exports into the R2 bucket, and /media/save-media hardcodes the saved path from CLOUDFLARE_BUCKET_URL (with local storage it would produce "undefined/<name>").

With STORAGE_PROVIDER=local plus Transloadit vars, uploads are silently lost. Reproduced on a dev machine: the upload spinner starts and then just disappears - no library entry, no file in UPLOAD_DIRECTORY, no request to the backend, no error or toast anywhere. Instrumenting the uploader showed why: the file uploads to Transloadit and the assembly completes (ASSEMBLY_COMPLETED), but the uploader's complete handler checks storageProvider === 'local' before the Transloadit branch, reads p.response.body (a shape Transloadit results don't have), and never calls /media/save-media. The file ends up in Transloadit's cloud and nowhere else. Meanwhile media keeps appearing in the R2 bucket despite storage being "local", which is confusing in itself.

The fix gates the transloadit value passed to the frontend variables context on STORAGE_PROVIDER === 'cloudflare' (all three layouts), so local storage always uses the plain XHR -> /media/upload-server path and the broken combination becomes unreachable. Validated on the same dev setup: with Transloadit vars set and STORAGE_PROVIDER=local, uploads now land in UPLOAD_DIRECTORY and appear in the media library, ignoring Transloadit entirely. The backend images-slides Transloadit usage (video generation) uses different env vars, is storage-independent, and is unaffected.

# Other information:

Found while testing local storage for the ranged-uploads work (#1784). Affects any self-hoster with both configured - silent data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Checklist:

- [x] I have read the CONTRIBUTING guide.
- [x] I have signed the Contributor License Agreement (CLA).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
