### PR TITLE
fix(linkedin): stream video uploads in 2MB ranges instead of buffering the whole file

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -19,6 +19,7 @@ import { Integration } from '@prisma/client';
 import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
 import { LinkedinDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/linkedin.dto';
 import imageToPDF from 'image-to-pdf';
+import { createReadStream, statSync } from 'fs';
 import { Readable } from 'stream';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
@@ -278,6 +279,11 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       endpoint = 'images';
     }
 
+    // Videos arrive as a path/URL (not a Buffer) so the file is never held in
+    // memory whole: the size comes from a HEAD request / stat, and each 2MB
+    // part is fetched with a ranged GET right before its PUT.
+    const videoSize = isVideo ? await this.videoSize(picture) : 0;
+
     const {
       value: { uploadUrl, image, video, document, uploadInstructions, ...all },
     } = await (
@@ -299,7 +305,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
                   : `urn:li:organization:${personId}`,
               ...(isVideo
                 ? {
-                    fileSizeBytes: picture.length,
+                    fileSizeBytes: videoSize,
                     uploadCaptions: false,
                     uploadThumbnail: false,
                   }
@@ -317,7 +323,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     if (isVideo) {
       // Only the Videos API uses multipart chunked uploads. Each 2MB part is
       // PUT separately and the returned etags are passed to finalizeUpload.
-      for (let i = 0; i < picture.length; i += 1024 * 1024 * 2) {
+      for (let i = 0; i < videoSize; i += 1024 * 1024 * 2) {
+        const end = Math.min(i + 1024 * 1024 * 2, videoSize) - 1;
         const upload = await this.fetch(
           sendUrlRequest,
           {
@@ -328,7 +335,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
               Authorization: `Bearer ${accessToken}`,
               'Content-Type': 'application/octet-stream',
             },
-            body: picture.slice(i, i + 1024 * 1024 * 2),
+            body: await this.videoChunk(picture, i, end),
           },
           'linkedin',
           0,
@@ -580,7 +587,9 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       postDetails.flatMap(
         (post) =>
           post.media?.map(async (media) => {
-            let mediaBuffer: Buffer;
+            // Videos are passed through as their path/URL: uploadPicture
+            // downloads them in 2MB ranges instead of buffering the whole file.
+            let mediaBuffer: Buffer | string;
 
             // Check if media has a buffer (from PDF conversion)
             if (
@@ -590,6 +599,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
               Buffer.isBuffer(media.buffer)
             ) {
               mediaBuffer = (media as any).buffer;
+            } else if (hasExtension(media.path, 'mp4')) {
+              mediaBuffer = media.path;
             } else {
               mediaBuffer = await this.prepareMediaBuffer(media.path);
             }
@@ -619,12 +630,61 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     }, {} as Record<string, string[]>);
   }
 
+  // Resolves the total byte size of the video without loading it into memory:
+  // a HEAD request for remote URLs, statSync for local files.
+  private async videoSize(path: string): Promise<number> {
+    if (path.indexOf('http') === 0) {
+      const head = await fetch(path, { method: 'HEAD' });
+      const length = head.headers.get('content-length');
+      if (!length) {
+        throw new BadBody(
+          'linkedin-error-upload',
+          '{}',
+          Buffer.from('{}'),
+          'Could not determine the video size for LinkedIn upload'
+        );
+      }
+      return Number(length);
+    }
+
+    return statSync(path).size;
+  }
+
+  // Returns only the [start, end] byte window of the video as a Buffer (a
+  // ranged GET for remote URLs, a ranged read for local files), so memory is
+  // bounded by the part size. A Buffer (not a stream) because this.fetch may
+  // retry the PUT, which would fail with a consumed one-shot stream body.
+  private async videoChunk(
+    path: string,
+    start: number,
+    end: number
+  ): Promise<Buffer> {
+    if (path.indexOf('http') === 0) {
+      const response = await fetch(path, {
+        headers: { Range: `bytes=${start}-${end}` },
+      });
+      // A 200 means the origin ignored the Range header and is sending the
+      // whole file: uploading it as this part would silently corrupt the
+      // video, so fail loudly instead.
+      if (response.status !== 206) {
+        throw new BadBody(
+          'linkedin-error-upload',
+          '{}',
+          Buffer.from('{}'),
+          `Media server ignored the ranged request (status ${response.status}); it must support HTTP Range requests for chunked LinkedIn uploads`
+        );
+      }
+      return Buffer.from(await response.arrayBuffer());
+    }
+
+    return this.streamToBuffer(createReadStream(path, { start, end }));
+  }
+
   private async prepareMediaBuffer(mediaUrl: string): Promise<Buffer> {
-    const isVideo = hasExtension(mediaUrl, 'mp4');
     const isGif = lookup(mediaUrl) === 'image/gif';
 
-    // GIFs and videos pass through untouched (sharp would break animation).
-    if (isVideo || isGif) {
+    // GIFs pass through untouched (sharp would break animation).
+    if (isGif) {
       return Buffer.from(await readOrFetch(mediaUrl));
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix / memory-footprint improvement.

# Why was this change needed?

LinkedIn video uploads downloaded the whole file into memory (readOrFetch -> arraybuffer) and then sliced it into the 2MB multipart PUTs, so every large video briefly held its full size in worker memory - multiplied under concurrent large-video posts. LinkedIn's Videos API upload is already chunked (2MB parts + etags + finalize), so the whole-file buffer was never necessary.

Videos now pass through as their path/URL instead of a Buffer: fileSizeBytes for initializeUpload comes from a HEAD request (statSync for local files), and each 2MB part is fetched with a ranged GET right before its PUT, mirroring the existing TikTok chunked-upload pattern. Parts are fetched as Buffers rather than streams because this.fetch may retry a PUT, which would fail with a consumed one-shot stream body. A non-206 response to a ranged GET fails loudly naming the media server instead of silently uploading corrupt parts - the origin must honor Range (R2 does; local storage does after #1784).

Images, GIFs and PDF carousels are unchanged: their upload URL is single-shot (chunking it would corrupt the file) and the sharp resize needs the whole buffer anyway; they are also small. linkedin.page extends LinkedinProvider and inherits the fix with no changes.

Memory verified with a loopback harness driving the real uploadPicture (fake HEAD/Range origin + fake LinkedIn API, process.memoryUsage sampled every 50ms): a 300MB video uploads as 150 x 2MB PUTs peaking at ~60MB external memory, vs ~934MB for the previous whole-file pattern run as a positive control in the same harness; delivered byte counts asserted. E2E verified against real LinkedIn on both profile and page channels: large multi-part videos posted and play to the end, and image / GIF / multi-image (PDF carousel) posts re-verified unaffected.

# Other information:

For self-hosters on STORAGE_PROVIDER=local this depends on #1784 (Range support in the local uploads route); without it the new guard fails the upload with a clear error instead of corrupting it. First of a planned series converting whole-file-buffering providers to streamed/ranged downloads (X/Twitter next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Checklist:

- [x] I have read the CONTRIBUTING guide.
- [x] I have signed the Contributor License Agreement (CLA).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
