### PR TITLE
feat(youtube): per-language localizations and subtitle (caption) tracks

### DIFF
--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/youtube.settings.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/youtube.settings.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsArray,
+  IsBoolean,
   IsDefined,
   IsIn,
   IsOptional,
@@ -63,6 +64,43 @@ export class YoutubeTagsSettings {
   label: string;
 }
 
+export class YoutubeLocalization {
+  @IsString()
+  @IsDefined()
+  language: string;
+
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  @IsDefined()
+  title: string;
+
+  @IsString()
+  @MaxLength(5000)
+  @IsOptional()
+  description?: string;
+}
+
+export class YoutubeCaption {
+  @IsString()
+  @IsDefined()
+  language: string;
+
+  @IsString()
+  @MaxLength(150)
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @MinLength(1)
+  @IsDefined()
+  srt: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isDraft?: boolean;
+}
+
 export class YoutubeSettingsDto {
   @IsString()
   @MinLength(2)
@@ -89,4 +127,20 @@ export class YoutubeSettingsDto {
   @IsYoutubeTagsLength()
   @Type(() => YoutubeTagsSettings)
   tags: YoutubeTagsSettings[];
+
+  @IsString()
+  @IsOptional()
+  defaultLanguage?: string;
+
+  @IsArray()
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => YoutubeLocalization)
+  localizations?: YoutubeLocalization[];
+
+  @IsArray()
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => YoutubeCaption)
+  captions?: YoutubeCaption[];
 }

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -16,6 +16,7 @@ import {
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import * as process from 'node:process';
+import { Readable } from 'stream';
 import dayjs from 'dayjs';
 import { GaxiosResponse } from 'gaxios/build/src/common';
 import Schema$Video = youtube_v3.Schema$Video;
@@ -195,6 +196,14 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
         type: 'bad-body',
         value:
           'We have uploaded your video but the thumbnail image is too wide.',
+      };
+    }
+
+    if (body.includes('captionExists')) {
+      return {
+        type: 'bad-body',
+        value:
+          'We have uploaded your video but a caption track for this language already exists.',
       };
     }
 
@@ -442,6 +451,9 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
               ...(settings?.tags?.length
                 ? { tags: settings.tags.map((p) => p.label) }
                 : {}),
+              ...(settings?.defaultLanguage
+                ? { defaultLanguage: settings.defaultLanguage }
+                : {}),
             },
             status: {
               privacyStatus: settings.type,
@@ -471,6 +483,52 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
           },
         })
       );
+    }
+
+    if (settings?.localizations?.length) {
+      await this.runInConcurrent(
+        async () =>
+          youtubeClient.videos.update({
+            part: ['localizations'],
+            requestBody: {
+              id: all?.data?.id!,
+              localizations: Object.fromEntries(
+                settings.localizations!.map((l) => [
+                  l.language,
+                  {
+                    title: l.title,
+                    ...(l.description ? { description: l.description } : {}),
+                  },
+                ])
+              ),
+            },
+          }),
+        true
+      );
+    }
+
+    if (settings?.captions?.length) {
+      for (const caption of settings.captions) {
+        await this.runInConcurrent(
+          async () =>
+            youtubeClient.captions.insert({
+              part: ['snippet'],
+              requestBody: {
+                snippet: {
+                  videoId: all?.data?.id!,
+                  language: caption.language,
+                  name: caption.name || '',
+                  isDraft: caption.isDraft ?? false,
+                },
+              },
+              media: {
+                mimeType: 'application/octet-stream',
+                body: Readable.from([caption.srt]),
+              },
+            }),
+          true
+        );
+      }
     }
 
     return [


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature — YouTube provider: per-language localizations (title / description) and subtitle (caption) tracks, both driven by the post settings.

# Why was this change needed?

Postiz can already publish a video to YouTube with a title, description, tags and a thumbnail, but only in a single language. A creator publishing to an international audience has to reopen YouTube Studio after every upload to paste translated titles and descriptions and to attach subtitle files by hand — which defeats the point of scheduling the post in the first place.

This PR makes a scheduled YouTube post complete on publication:

- **`defaultLanguage`** — declares which language the title and description are written in. This is what makes YouTube treat the other entries as *translations* rather than replacements.
- **`localizations[]`** — a translated `title` and optional `description` per language, applied with a single `videos.update` call on the `localizations` part after the upload.
- **`captions[]`** — subtitle tracks supplied as inline SRT, each applied with `captions.insert`. `isDraft` is supported, so a track can be uploaded without being published immediately.

No new OAuth scope is required: `youtube.force-ssl` is already requested by the provider and covers both `videos.update` and `captions.insert`. Existing channels keep working without reconnection.

# Other information:

- The new calls run after the upload, following the same pattern as the existing thumbnail block, and go through `runInConcurrent` like the rest of the provider.
- All three settings are optional. When they are absent the request bodies are identical to today's, so existing scheduled posts are unaffected.
- `captionExists` is mapped to a readable `bad-body` message — *"We have uploaded your video but a caption track for this language already exists."* YouTube rejects a second track for a language that already has one, and the raw error was opaque to the user.
- Validation lives in the DTO (`YoutubeLocalization`, `YoutubeCaption`) in the same class-validator style as the surrounding settings, with the title capped at 100 characters and the description at 5000 to match YouTube's own limits.

**Disclosure:** this change was written with AI assistance, which is why the "no AI" box below is left unchecked — the commit carries a `Co-Authored-By` trailer to that effect. The code has been reviewed and is running in production on a self-hosted instance. If that does not meet the project's contribution policy, feel free to close this PR; no hard feelings, and the reasoning above may still be useful.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
