### PR TITLE
feat(oauth): PUBLIC_OAUTH_URL to decouple redirect_uri from FRONTEND_URL

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -119,6 +119,25 @@ export abstract class SocialAbstract {
     return value || false;
   }
 
+  /**
+   * Absolute callback URL sent to the provider as `redirect_uri`.
+   *
+   * Defaults to `FRONTEND_URL`, but can be overridden with `PUBLIC_OAUTH_URL`
+   * when the frontend is not reachable from the internet (private network,
+   * VPN-only deployment) while the provider requires a publicly verifiable
+   * redirect URI. The override must then redirect back to `FRONTEND_URL`.
+   *
+   * The `redirectmeto.com` prefix keeps local http development working, since
+   * most providers reject non-https redirect URIs.
+   */
+  protected oauthRedirectUri(identifier: string) {
+    const base = process.env.PUBLIC_OAUTH_URL || process.env.FRONTEND_URL || '';
+    const prefix =
+      base.indexOf('https') === -1 ? 'https://redirectmeto.com/' : '';
+
+    return `${prefix}${base}/integrations/social/${identifier}`;
+  }
+
   /** Reads the pixel dimensions of an image via sharp (works for http or local paths). */
   protected async getImageDimensions(
     path: string

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -320,11 +320,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
         'https://www.tiktok.com/v2/auth/authorize/' +
         `?client_key=${process.env.TIKTOK_CLIENT_ID}` +
         `&redirect_uri=${encodeURIComponent(
-          `${
-            process?.env?.FRONTEND_URL?.indexOf('https') === -1
-              ? 'https://redirectmeto.com/'
-              : ''
-          }${process?.env?.FRONTEND_URL}/integrations/social/tiktok`
+          this.oauthRedirectUri(this.identifier)
         )}` +
         `&state=${state}` +
         `&response_type=code` +
@@ -345,11 +341,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       code: params.code,
       grant_type: 'authorization_code',
       code_verifier: params.codeVerifier,
-      redirect_uri: `${
-        process?.env?.FRONTEND_URL?.indexOf('https') === -1
-          ? 'https://redirectmeto.com/'
-          : ''
-      }${process?.env?.FRONTEND_URL}/integrations/social/tiktok`,
+      redirect_uri: this.oauthRedirectUri(this.identifier),
     };
 
     const { access_token, refresh_token, scope } = await (


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature — an optional `PUBLIC_OAUTH_URL` environment variable that decouples the OAuth `redirect_uri` from `FRONTEND_URL`.

# Why was this change needed?

Every provider builds its `redirect_uri` from `FRONTEND_URL`. That is fine when the frontend is publicly reachable, but it makes a self-hosted install impossible to connect when the frontend is deliberately *not* exposed to the internet — behind a VPN, on a private network, or behind a zero-trust proxy.

Providers such as TikTok only accept a redirect URI on a domain they can verify by fetching a file over the public internet, and a private hostname can never be verified. The only workaround today is to point `FRONTEND_URL` at a public domain, which breaks the auth cookie and every generated link, because `FRONTEND_URL` is used for far more than OAuth.

With `PUBLIC_OAUTH_URL`, the operator can publish a small public endpoint that redirects back to the private frontend and declare that public URL as the redirect URI, while `FRONTEND_URL` keeps pointing at the real frontend.

Behaviour is strictly unchanged when the variable is unset: `oauthRedirectUri()` falls back to `FRONTEND_URL`, including the existing `redirectmeto.com` prefix that keeps local http development working.

# Other information:

- The helper is added to `SocialAbstract`, next to the existing `assetBoolean` / `checkScopes` helpers, so any provider can adopt it.
- Only `tiktok.provider.ts` uses it here, replacing the expression that was duplicated inline in `generateAuthUrl` and `authenticate`. This was kept deliberately minimal rather than touching every provider at once.
- Happy to extend it to the remaining providers in a follow-up if you would rather they were all consistent.

**Disclosure:** this change was written with AI assistance, which is why the "no AI" box below is left unchecked — the commit carries a `Co-Authored-By` trailer to that effect. The code has been reviewed and is running in production on a self-hosted instance. If that does not meet the project's contribution policy, feel free to close this PR; no hard feelings, and the reasoning above may still be useful.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
