### PR TITLE
feat(ai): support Atlas Cloud text provider config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,18 @@ EXTENSION_ID=""
 
 # Misc Settings
 OPENAI_API_KEY=""
+# Optional OpenAI-compatible provider for text AI features. If set, these
+# values are used for chat/copilot/post generation while image generation keeps
+# using OPENAI_API_KEY.
+# POSTIZ_AI_API_KEY=""
+# POSTIZ_AI_BASE_URL=""
+# POSTIZ_AI_MODEL=""
+# ATLASCLOUD_API_KEY=""
+# ATLAS_CLOUD_API_KEY=""
+# ATLASCLOUD_BASE_URL="https://api.atlascloud.ai/v1"
+# ATLAS_CLOUD_BASE_URL="https://api.atlascloud.ai/v1"
+# ATLASCLOUD_MODEL="deepseek-ai/deepseek-v4-pro"
+# ATLAS_CLOUD_MODEL="deepseek-ai/deepseek-v4-pro"
 NEXT_PUBLIC_DISCORD_SUPPORT=""
 NEXT_PUBLIC_POLOTNO=""
 # NOT_SECURED=false

--- a/apps/backend/src/api/routes/copilot.controller.ts
+++ b/apps/backend/src/api/routes/copilot.controller.ts
@@ -22,7 +22,15 @@ import { MastraService } from '@gitroom/nestjs-libraries/chat/mastra.service';
 import { Request, Response } from 'express';
 import { RequestContext } from '@mastra/core/di';
 import { CheckPolicies } from '@gitroom/backend/services/auth/permissions/permissions.ability';
-import { AuthorizationActions, Sections } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
+import {
+  AuthorizationActions,
+  Sections,
+} from '@gitroom/backend/services/auth/permissions/permission.exception.class';
+import {
+  createTextOpenAIClient,
+  getTextAiModel,
+  hasTextAiApiKey,
+} from '@gitroom/nestjs-libraries/openai/ai.provider.config';
 
 export type ChannelsContext = {
   integrations: string;
@@ -38,10 +46,7 @@ export class CopilotController {
   ) {}
   @Post('/chat')
   chatAgent(@Req() req: Request, @Res() res: Response) {
-    if (
-      process.env.OPENAI_API_KEY === undefined ||
-      process.env.OPENAI_API_KEY === ''
-    ) {
+    if (!hasTextAiApiKey()) {
       Logger.warn('OpenAI API key not set, chat functionality will not work');
       return;
     }
@@ -50,7 +55,8 @@ export class CopilotController {
       endpoint: '/copilot/chat',
       runtime: new CopilotRuntime(),
       serviceAdapter: new OpenAIAdapter({
-        model: 'gpt-4.1',
+        openai: createTextOpenAIClient() as any,
+        model: getTextAiModel(),
       }),
     });
 
@@ -64,10 +70,7 @@ export class CopilotController {
     @Res() res: Response,
     @GetOrgFromRequest() organization: Organization
   ) {
-    if (
-      process.env.OPENAI_API_KEY === undefined ||
-      process.env.OPENAI_API_KEY === ''
-    ) {
+    if (!hasTextAiApiKey()) {
       Logger.warn('OpenAI API key not set, chat functionality will not work');
       return;
     }
@@ -96,7 +99,8 @@ export class CopilotController {
       runtime,
       // properties: req.body.variables.properties,
       serviceAdapter: new OpenAIAdapter({
-        model: 'gpt-4.1',
+        openai: createTextOpenAIClient() as any,
+        model: getTextAiModel(),
       }),
     });
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,16 @@ services:
 
       # === Misc Settings
       OPENAI_API_KEY: ''
+      # Optional OpenAI-compatible provider for text AI features.
+      # POSTIZ_AI_API_KEY: ''
+      # POSTIZ_AI_BASE_URL: ''
+      # POSTIZ_AI_MODEL: ''
+      # ATLASCLOUD_API_KEY: ''
+      # ATLAS_CLOUD_API_KEY: ''
+      # ATLASCLOUD_BASE_URL: 'https://api.atlascloud.ai/v1'
+      # ATLAS_CLOUD_BASE_URL: 'https://api.atlascloud.ai/v1'
+      # ATLASCLOUD_MODEL: 'deepseek-ai/deepseek-v4-pro'
+      # ATLAS_CLOUD_MODEL: 'deepseek-ai/deepseek-v4-pro'
       NEXT_PUBLIC_DISCORD_SUPPORT: ''
       NEXT_PUBLIC_POLOTNO: ''
       API_LIMIT: 30

--- a/libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.insert.service.ts
@@ -1,18 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import { END, START, StateGraph } from '@langchain/langgraph';
-import { ChatOpenAI } from '@langchain/openai';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { agentCategories } from '@gitroom/nestjs-libraries/agent/agent.categories';
 import { z } from 'zod';
 import { agentTopics } from '@gitroom/nestjs-libraries/agent/agent.topics';
 import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
+import {
+  createTextChatOpenAI,
+  DEFAULT_OPENAI_INSERT_MODEL,
+} from '@gitroom/nestjs-libraries/openai/ai.provider.config';
 
-const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'gpt-4o-2024-08-06',
-  temperature: 0,
-});
+const model = createTextChatOpenAI(DEFAULT_OPENAI_INSERT_MODEL, 0);
 
 interface WorkflowChannelsState {
   messages: BaseMessage[];

--- a/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
@@ -5,7 +5,7 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import { END, START, StateGraph } from '@langchain/langgraph';
-import { ChatOpenAI, DallEAPIWrapper } from '@langchain/openai';
+import { DallEAPIWrapper } from '@langchain/openai';
 import { TavilySearch } from '@langchain/tavily';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
@@ -16,21 +16,22 @@ import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/me
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { GeneratorDto } from '@gitroom/nestjs-libraries/dtos/generator/generator.dto';
 import { generationError } from '@gitroom/nestjs-libraries/openai/generation.error';
+import {
+  createTextChatOpenAI,
+  DEFAULT_OPENAI_IMAGE_MODEL,
+  getImageAiApiKey,
+} from '@gitroom/nestjs-libraries/openai/ai.provider.config';
 
 const tools = !process.env.TAVILY_API_KEY
   ? []
   : [new TavilySearch({ maxResults: 3 })];
 const toolNode = new ToolNode(tools);
 
-const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'gpt-4.1',
-  temperature: 0.7,
-});
+const model = createTextChatOpenAI(undefined, 0.7);
 
 const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'chatgpt-image-latest',
+  apiKey: getImageAiApiKey(),
+  model: DEFAULT_OPENAI_IMAGE_MODEL,
 });
 
 interface WorkflowChannelsState {

--- a/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
@@ -6,7 +6,7 @@ import { END, START, StateGraph } from '@langchain/langgraph';
 import { AutoPost, Integration } from '@prisma/client';
 import { BaseMessage } from '@langchain/core/messages';
 import striptags from 'striptags';
-import { ChatOpenAI, DallEAPIWrapper } from '@langchain/openai';
+import { DallEAPIWrapper } from '@langchain/openai';
 import { JSDOM } from 'jsdom';
 import { z } from 'zod';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
@@ -19,6 +19,11 @@ import { TypedSearchAttributes } from '@temporalio/common';
 import {
   organizationId,
 } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
+import {
+  createTextChatOpenAI,
+  DEFAULT_OPENAI_IMAGE_MODEL,
+  getImageAiApiKey,
+} from '@gitroom/nestjs-libraries/openai/ai.provider.config';
 const parser = new Parser();
 
 interface WorkflowChannelsState {
@@ -35,15 +40,11 @@ interface WorkflowChannelsState {
   };
 }
 
-const model = new ChatOpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'gpt-4.1',
-  temperature: 0.7,
-});
+const model = createTextChatOpenAI(undefined, 0.7);
 
 const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'chatgpt-image-latest',
+  apiKey: getImageAiApiKey(),
+  model: DEFAULT_OPENAI_IMAGE_MODEL,
 });
 
 const generateContent = z.object({

--- a/libraries/nestjs-libraries/src/openai/ai.provider.config.ts
+++ b/libraries/nestjs-libraries/src/openai/ai.provider.config.ts
@@ -1,0 +1,89 @@
+import { ChatOpenAI } from '@langchain/openai';
+import OpenAI from 'openai';
+
+export const DEFAULT_OPENAI_TEXT_MODEL = 'gpt-4.1';
+export const DEFAULT_OPENAI_INSERT_MODEL = 'gpt-4o-2024-08-06';
+export const DEFAULT_OPENAI_IMAGE_MODEL = 'chatgpt-image-latest';
+export const DEFAULT_ATLASCLOUD_BASE_URL = 'https://api.atlascloud.ai/v1';
+export const DEFAULT_ATLASCLOUD_TEXT_MODEL = 'deepseek-ai/deepseek-v4-pro';
+
+const firstNonEmpty = (...values: Array<string | undefined>) =>
+  values.find((value) => value?.trim())?.trim();
+
+const getConfiguredTextAiBaseURL = () =>
+  firstNonEmpty(
+    process.env.POSTIZ_AI_BASE_URL,
+    process.env.ATLASCLOUD_BASE_URL,
+    process.env.ATLAS_CLOUD_BASE_URL
+  );
+
+const hasAtlasCloudConfig = () => {
+  const baseURL = getConfiguredTextAiBaseURL();
+
+  return !!(
+    process.env.ATLASCLOUD_API_KEY ||
+    process.env.ATLAS_CLOUD_API_KEY ||
+    process.env.ATLASCLOUD_MODEL ||
+    process.env.ATLAS_CLOUD_MODEL ||
+    process.env.ATLASCLOUD_BASE_URL ||
+    process.env.ATLAS_CLOUD_BASE_URL ||
+    baseURL?.toLowerCase().includes('atlascloud.ai')
+  );
+};
+
+export const getTextAiBaseURL = () =>
+  getConfiguredTextAiBaseURL() ||
+  (hasAtlasCloudConfig() ? DEFAULT_ATLASCLOUD_BASE_URL : undefined);
+
+export const hasTextAiApiKey = () =>
+  !!firstNonEmpty(
+    process.env.POSTIZ_AI_API_KEY,
+    process.env.ATLASCLOUD_API_KEY,
+    process.env.ATLAS_CLOUD_API_KEY,
+    process.env.OPENAI_API_KEY
+  );
+
+export const getTextAiApiKey = () =>
+  firstNonEmpty(
+    process.env.POSTIZ_AI_API_KEY,
+    process.env.ATLASCLOUD_API_KEY,
+    process.env.ATLAS_CLOUD_API_KEY,
+    process.env.OPENAI_API_KEY
+  ) || 'sk-proj-';
+
+export const getTextAiModel = (defaultModel = DEFAULT_OPENAI_TEXT_MODEL) =>
+  firstNonEmpty(
+    process.env.POSTIZ_AI_MODEL,
+    process.env.ATLASCLOUD_MODEL,
+    process.env.ATLAS_CLOUD_MODEL
+  ) || (hasAtlasCloudConfig() ? DEFAULT_ATLASCLOUD_TEXT_MODEL : defaultModel);
+
+export const getImageAiApiKey = () => process.env.OPENAI_API_KEY || 'sk-proj-';
+
+export const createTextOpenAIClient = () => {
+  const baseURL = getTextAiBaseURL();
+
+  return new OpenAI({
+    apiKey: getTextAiApiKey(),
+    ...(baseURL ? { baseURL } : {}),
+  });
+};
+
+export const createImageOpenAIClient = () =>
+  new OpenAI({
+    apiKey: getImageAiApiKey(),
+  });
+
+export const createTextChatOpenAI = (
+  defaultModel = DEFAULT_OPENAI_TEXT_MODEL,
+  temperature?: number
+) => {
+  const baseURL = getTextAiBaseURL();
+
+  return new ChatOpenAI({
+    apiKey: getTextAiApiKey(),
+    model: getTextAiModel(defaultModel),
+    ...(typeof temperature === 'number' ? { temperature } : {}),
+    ...(baseURL ? { configuration: { baseURL } } : {}),
+  });
+};

--- a/libraries/nestjs-libraries/src/openai/openai.service.ts
+++ b/libraries/nestjs-libraries/src/openai/openai.service.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@nestjs/common';
-import OpenAI from 'openai';
 import { shuffle } from 'lodash';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
+import {
+  createImageOpenAIClient,
+  createTextOpenAIClient,
+  DEFAULT_OPENAI_IMAGE_MODEL,
+  getTextAiModel,
+} from '@gitroom/nestjs-libraries/openai/ai.provider.config';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-});
+const textOpenai = createTextOpenAIClient();
+const imageOpenai = createImageOpenAIClient();
 
 const PicturePrompt = z.object({
   prompt: z.string(),
@@ -22,9 +26,9 @@ export class OpenaiService {
     // gpt-image models always return base64 (b64_json) and do not accept the
     // `response_format` parameter, unlike the deprecated dall-e-3.
     const generate = (
-      await openai.images.generate({
+      await imageOpenai.images.generate({
         prompt,
-        model: 'chatgpt-image-latest',
+        model: DEFAULT_OPENAI_IMAGE_MODEL,
         size: isVertical ? '1024x1536' : '1024x1024',
       })
     ).data[0];
@@ -35,8 +39,8 @@ export class OpenaiService {
   async generatePromptForPicture(prompt: string) {
     return (
       (
-        await openai.chat.completions.parse({
-          model: 'gpt-4.1',
+        await textOpenai.chat.completions.parse({
+          model: getTextAiModel(),
           messages: [
             {
               role: 'system',
@@ -56,8 +60,8 @@ export class OpenaiService {
   async generateVoiceFromText(prompt: string) {
     return (
       (
-        await openai.chat.completions.parse({
-          model: 'gpt-4.1',
+        await textOpenai.chat.completions.parse({
+          model: getTextAiModel(),
           messages: [
             {
               role: 'system',
@@ -77,7 +81,7 @@ export class OpenaiService {
   async generatePosts(content: string) {
     const posts = (
       await Promise.all([
-        openai.chat.completions.create({
+        textOpenai.chat.completions.create({
           messages: [
             {
               role: 'assistant',
@@ -91,9 +95,9 @@ export class OpenaiService {
           ],
           n: 5,
           temperature: 1,
-          model: 'gpt-4.1',
+          model: getTextAiModel(),
         }),
-        openai.chat.completions.create({
+        textOpenai.chat.completions.create({
           messages: [
             {
               role: 'assistant',
@@ -107,7 +111,7 @@ export class OpenaiService {
           ],
           n: 5,
           temperature: 1,
-          model: 'gpt-4.1',
+          model: getTextAiModel(),
         }),
       ])
     ).flatMap((p) => p.choices);
@@ -133,7 +137,7 @@ export class OpenaiService {
     );
   }
   async extractWebsiteText(content: string) {
-    const websiteContent = await openai.chat.completions.create({
+    const websiteContent = await textOpenai.chat.completions.create({
       messages: [
         {
           role: 'assistant',
@@ -145,7 +149,7 @@ export class OpenaiService {
           content,
         },
       ],
-      model: 'gpt-4.1',
+      model: getTextAiModel(),
     });
 
     const { content: articleContent } = websiteContent.choices[0].message;
@@ -164,8 +168,8 @@ export class OpenaiService {
 
     const posts =
       (
-        await openai.chat.completions.parse({
-          model: 'gpt-4.1',
+        await textOpenai.chat.completions.parse({
+          model: getTextAiModel(),
           messages: [
             {
               role: 'system',
@@ -197,8 +201,8 @@ export class OpenaiService {
             try {
               return (
                 (
-                  await openai.chat.completions.parse({
-                    model: 'gpt-4.1',
+                  await textOpenai.chat.completions.parse({
+                    model: getTextAiModel(),
                     messages: [
                       {
                         role: 'system',
@@ -233,8 +237,8 @@ export class OpenaiService {
         const message = `You are an assistant that takes a text and break it into slides, each slide should have an image prompt and voice text to be later used to generate a video and voice, image prompt should capture the essence of the slide and also have a back dark gradient on top, image prompt should not contain text in the picture, generate between 3-5 slides maximum`;
         const parse =
           (
-            await openai.chat.completions.parse({
-              model: 'gpt-4.1',
+            await textOpenai.chat.completions.parse({
+              model: getTextAiModel(),
               messages: [
                 {
                   role: 'system',


### PR DESCRIPTION
## Summary
- add a shared text AI provider config helper for OpenAI-compatible chat providers, including Atlas Cloud env aliases
- route text generation, autopost, agent graph, insert classification, and Copilot runtime through the shared text client/model config
- keep OpenAI image generation on the existing OPENAI_API_KEY / chatgpt-image-latest path, and add optional env/docker config examples only

## Validation
- pnpm install --frozen-lockfile --ignore-scripts (passes with existing Node 24 vs project Node 22 engine warning)
- pnpm run prisma-generate
- pnpm exec tsc -p apps/backend/tsconfig.build.json --noEmit
- pnpm --filter ./apps/backend run build (passes with the same Node engine warning)
- pnpm exec prettier --check on changed TS/YAML files
- git diff --check / git diff --cached --check
- Atlas live model catalog: 437 total models, 59 visible Text models; confirmed deepseek-ai/deepseek-v4-pro, deepseek-ai/deepseek-v4-flash, and qwen/qwen3.5-flash

## Notes
- No README/docs/logo/sponsor/partner/credits changes.
- .env.example and docker-compose.yaml only add optional runtime configuration examples.