### PR TITLE
fix: trim trailing slashes from URL env vars

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -9,6 +9,10 @@ Runtime.install({ shutdownSignals: [] });
 
 process.env.TZ = 'UTC';
 
+for (const key of ['FRONTEND_URL', 'MAIN_URL', 'NEXT_PUBLIC_BACKEND_URL']) {
+  process.env[key] = process.env[key]?.replace(/\/+$/, '');
+}
+
 import cookieParser from 'cookie-parser';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -10,7 +10,9 @@ Runtime.install({ shutdownSignals: [] });
 process.env.TZ = 'UTC';
 
 for (const key of ['FRONTEND_URL', 'MAIN_URL', 'NEXT_PUBLIC_BACKEND_URL']) {
-  process.env[key] = process.env[key]?.replace(/\/+$/, '');
+  if (process.env[key]) {
+    process.env[key] = process.env[key].replace(/\/+$/, '');
+  }
 }
 
 import cookieParser from 'cookie-parser';

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -59,7 +59,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
             process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare'
           }
           environment={process.env.NODE_ENV!}
-          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!.replace(/\/+$/, '')}
+          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/+$/, '')!}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           stripeClient={process.env.STRIPE_PUBLISHABLE_KEY!}
           isChatBase={!!process.env.CHATBASE_TOKEN}

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -59,7 +59,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
             process.env.STORAGE_PROVIDER! as 'local' | 'cloudflare'
           }
           environment={process.env.NODE_ENV!}
-          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!}
+          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!.replace(/\/+$/, '')}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           stripeClient={process.env.STRIPE_PUBLISHABLE_KEY!}
           isChatBase={!!process.env.CHATBASE_TOKEN}

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -31,7 +31,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           }
           stripeClient=""
           environment={process.env.NODE_ENV!}
-          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!.replace(/\/+$/, '')}
+          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/+$/, '')!}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           billingEnabled={!!process.env.STRIPE_PUBLISHABLE_KEY}
           discordUrl={process.env.NEXT_PUBLIC_DISCORD_SUPPORT!}

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -31,7 +31,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           }
           stripeClient=""
           environment={process.env.NODE_ENV!}
-          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!}
+          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!.replace(/\/+$/, '')}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           billingEnabled={!!process.env.STRIPE_PUBLISHABLE_KEY}
           discordUrl={process.env.NEXT_PUBLIC_DISCORD_SUPPORT!}

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -33,7 +33,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           }
           stripeClient=""
           environment={process.env.NODE_ENV!}
-          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!}
+          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!.replace(/\/+$/, '')}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           billingEnabled={!!process.env.STRIPE_PUBLISHABLE_KEY}
           discordUrl={process.env.NEXT_PUBLIC_DISCORD_SUPPORT!}

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -33,7 +33,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           }
           stripeClient=""
           environment={process.env.NODE_ENV!}
-          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL!.replace(/\/+$/, '')}
+          backendUrl={process.env.NEXT_PUBLIC_BACKEND_URL?.replace(/\/+$/, '')!}
           plontoKey={process.env.NEXT_PUBLIC_POLOTNO!}
           billingEnabled={!!process.env.STRIPE_PUBLISHABLE_KEY}
           discordUrl={process.env.NEXT_PUBLIC_DISCORD_SUPPORT!}

--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -11,7 +11,9 @@ import * as dns from 'node:dns';
 dns.setDefaultResultOrder('ipv4first');
 
 for (const key of ['FRONTEND_URL', 'MAIN_URL', 'NEXT_PUBLIC_BACKEND_URL']) {
-  process.env[key] = process.env[key]?.replace(/\/+$/, '');
+  if (process.env[key]) {
+    process.env[key] = process.env[key].replace(/\/+$/, '');
+  }
 }
 
 async function bootstrap() {

--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -10,6 +10,10 @@ import { AppModule } from '@gitroom/orchestrator/app.module';
 import * as dns from 'node:dns';
 dns.setDefaultResultOrder('ipv4first');
 
+for (const key of ['FRONTEND_URL', 'MAIN_URL', 'NEXT_PUBLIC_BACKEND_URL']) {
+  process.env[key] = process.env[key]?.replace(/\/+$/, '');
+}
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableShutdownHooks();


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

A self-hoster configured `FRONTEND_URL=https://postiz.example.com/` (trailing slash). Providers append paths directly to it, so the OAuth `redirect_uri` sent to the platform gets a double slash (`https://postiz.example.com//integrations/social/...`). Meta enforces exact redirect_uri matching at the token exchange, so connecting instagram-standalone fails with a 409 on `/api/integrations/social-connect/instagram-standalone`. The same trailing slash also breaks CORS in split-origin setups, since the untrimmed value is used as the allowed origin in `main.ts`.

Rather than fixing ~37 concat sites, this normalizes `FRONTEND_URL`, `MAIN_URL` and `NEXT_PUBLIC_BACKEND_URL` once at backend/orchestrator startup, and trims the `backendUrl` passed into the frontend variable context.

Verified locally: with a trailing slash in `.env`, the generated TikTok authorize URL contained `%2F%2Fintegrations` before and a single `%2Fintegrations` after, and the frontend CORS breakage is resolved.

# Other information:

Reported by a self-hoster; workaround for existing deployments is removing the trailing slash from their env values.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)