### PR TITLE
fix(pinterest): upload the mp4 file for video pins instead of the first media item

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -270,12 +270,9 @@ export class PinterestProvider
         })
       ).json();
 
-      const { data, status } = await axios.get(
-        postDetails?.[0]?.media?.[0]?.path!,
-        {
-          responseType: 'stream',
-        }
-      );
+      const { data, status } = await axios.get(findMp4.path, {
+        responseType: 'stream',
+      });
 
       const formData = Object.keys(upload_parameters)
         .filter((f) => f)

--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -270,7 +270,7 @@ export class PinterestProvider
         })
       ).json();
 
-      const { data, status } = await axios.get(findMp4.path, {
+      const { data } = await axios.get(findMp4.path, {
         responseType: 'stream',
       });
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

A user reported Pinterest publishing failing 80-90% of the time with "An error occurred while posting on Pinterest: The file is corrupted and cannot be uploaded", while retrying the same asset sometimes succeeded.

Root cause: in `PinterestProvider.post()` the video path finds the mp4 with `findMp4`, but then streams `postDetails[0].media[0].path` to Pinterest's video upload URL. Pinterest video pins require two attachments (video + cover image), so whenever the cover image is attached before the video, the image bytes get uploaded to the video endpoint, Pinterest media processing returns `status: failed`, and the provider raises the corrupted-file error. Whether a post failed depended purely on attachment order, which explains the intermittent pattern.

Verified e2e against the real Pinterest API: a video pin with the cover image selected first reproduced the corrupted-file error on main, and published successfully with this fix.

# Other information:

The failure happens before any pin is created, so there is no cleanup concern for existing users; failed posts can simply be retried after this lands.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)