### PR TITLE
fix(calendar): surface the real publish error in the calendar tooltip

### DIFF
--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -59,6 +59,24 @@ import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validatio
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { Button } from '@gitroom/react/form/button';
 
+// Older posts stored the whole serialized workflow failure; extract the message
+const extractErrorMessage = (error?: string | null) => {
+  if (!error) {
+    return error;
+  }
+  try {
+    const parsed = JSON.parse(error);
+    return (
+      parsed?.cause?.failure?.message ||
+      parsed?.failure?.cause?.message ||
+      parsed?.message ||
+      error
+    );
+  } catch (e) {
+    return error;
+  }
+};
+
 // Extend dayjs with necessary plugins
 extend(isSameOrAfter);
 extend(isSameOrBefore);
@@ -1046,7 +1064,8 @@ const CalendarItem: FC<{
         <div
           className="absolute -top-[6px] -left-[6px] z-20 w-[18px] h-[18px] rounded-full bg-red-500 flex items-center justify-center text-white text-[11px] font-bold cursor-pointer"
           data-tooltip-id="tooltip"
-          data-tooltip-content={post.error || 'An error occurred while publishing this post'}
+          data-tooltip-class-name="!max-w-[400px] break-words"
+          data-tooltip-content={extractErrorMessage(post.error) || 'An error occurred while publishing this post'}
         >
           !
         </div>

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -178,6 +178,7 @@ export class PostsRepository {
         releaseURL: true,
         releaseId: true,
         state: true,
+        error: true,
         intervalInDays: true,
         group: true,
         creationMethod: true,
@@ -416,15 +417,24 @@ export class PostsRepository {
   }
 
   async changeState(id: string, state: State, err?: any, body?: any) {
+    // Workflow failures arrive as serialized ActivityFailure objects; surface
+    // the underlying provider message instead of the whole failure JSON
+    const errorMessage = !err
+      ? undefined
+      : typeof err === 'string'
+      ? err
+      : err?.cause?.failure?.message ||
+        err?.failure?.cause?.message ||
+        err?.message ||
+        JSON.stringify(err);
+
     const update = await this._post.model.post.update({
       where: {
         id,
       },
       data: {
         state,
-        ...(err
-          ? { error: typeof err === 'string' ? err : JSON.stringify(err) }
-          : {}),
+        ...(errorMessage ? { error: errorMessage } : {}),
       },
       include: {
         integration: {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

A user reported that failed posts show a red error indicator in the calendar, but the UI never surfaces the actual error, and refreshing doesn't reveal more diagnostics.

Three layers were involved:

1. The calendar tooltip renders `post.error`, but the `getPosts` query never selected the `error` column, so the tooltip always fell back to the generic "An error occurred while publishing this post".
2. Workflow failures reach `changeState` as serialized ActivityFailure objects, so `post.error` stored the entire failure dump (stack traces, activity metadata, server file paths) rather than the provider message. `changeState` now extracts the readable message; the `Errors` table keeps the raw failure for debugging.
3. Existing rows in production already hold the serialized blob, so the frontend also unwraps it when rendering (plain-text messages pass through unchanged). The tooltip is capped at 400px with wrapping so long messages stay readable.

Verified e2e by driving a real Temporal post workflow into a non-retryable `bad_body` failure locally: before, the tooltip showed the generic message; after, it shows only the provider message (e.g. "The file is corrupted and cannot be uploaded") for both newly stored and legacy error rows.

# Other information:

Surfaced by the same user report as #1802.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)