### PR TITLE
feat(upload): reject mp4 uploads missing the moov atom

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -15,6 +15,8 @@ import {
 import {
   CustomFileValidationPipe,
   getMaxSize,
+  isCompleteMp4,
+  INCOMPLETE_MP4_ERROR,
 } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { ApiTags } from '@nestjs/swagger';
 import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.request';
@@ -136,6 +138,10 @@ export class PublicIntegrationsController {
 
     if (buffer.length > getMaxSize(detected.mime)) {
       throw new HttpException({ msg: 'File is too large.' }, 400);
+    }
+
+    if (detected.mime === 'video/mp4' && !isCompleteMp4(buffer)) {
+      throw new HttpException({ msg: INCOMPLETE_MP4_ERROR }, 400);
     }
 
     const mimetype = detected.mime;

--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -4,7 +4,11 @@ import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
-import { getMaxSize } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
+import {
+  getMaxSize,
+  isCompleteMp4,
+  INCOMPLETE_MP4_ERROR,
+} from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
 import { ssrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import { Readable } from 'stream';
@@ -100,6 +104,10 @@ so the attachment passes the upload-domain validation. Returns the hosted media 
             return {
               error: `File is too large: ${buffer.length} bytes (max ${maxSize} bytes).`,
             };
+          }
+
+          if (detected.mime === 'video/mp4' && !isCompleteMp4(buffer)) {
+            return { error: INCOMPLETE_MP4_ERROR };
           }
 
           const getFile = await this.storage.uploadFile({

--- a/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
+++ b/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
@@ -89,6 +89,10 @@ export function isCompleteMp4(buffer: Buffer): boolean {
         return false;
       }
       size = Number(largeSize);
+      // a largesize box header is 16 bytes, so smaller values are malformed
+      if (size < 16) {
+        return false;
+      }
     }
     if (size < 8) {
       return false;

--- a/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
+++ b/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
@@ -45,6 +45,10 @@ export class CustomFileValidationPipe implements PipeTransform {
       );
     }
 
+    if (detected.mime === 'video/mp4' && !isCompleteMp4(value.buffer)) {
+      throw new BadRequestException(INCOMPLETE_MP4_ERROR);
+    }
+
     value.mimetype = detected.mime;
     const safeBase = (value.originalname || 'upload')
       .replace(/\.[^./\\]*$/, '')
@@ -55,6 +59,43 @@ export class CustomFileValidationPipe implements PipeTransform {
     return value;
   }
 
+}
+
+export const INCOMPLETE_MP4_ERROR =
+  'Video file is corrupted or incomplete (missing moov atom). This usually means the file was uploaded before the encoder finished writing it — wait for the render to complete and upload it again.';
+
+// A playable mp4 must contain a top-level moov box (the index of the file).
+// Encoders write it last (or rewrite the file with it first for faststart),
+// so a file grabbed mid-encode has only ftyp + mdat and can't be played or
+// published anywhere.
+export function isCompleteMp4(buffer: Buffer): boolean {
+  let offset = 0;
+  while (offset + 8 <= buffer.length) {
+    let size: number = buffer.readUInt32BE(offset);
+    const type = buffer.toString('latin1', offset + 4, offset + 8);
+    if (type === 'moov') {
+      return true;
+    }
+    if (size === 0) {
+      // box extends to end of file
+      return false;
+    }
+    if (size === 1) {
+      if (offset + 16 > buffer.length) {
+        return false;
+      }
+      const largeSize = buffer.readBigUInt64BE(offset + 8);
+      if (largeSize > BigInt(Number.MAX_SAFE_INTEGER)) {
+        return false;
+      }
+      size = Number(largeSize);
+    }
+    if (size < 8) {
+      return false;
+    }
+    offset += size;
+  }
+  return false;
 }
 
 export function getMaxSize(mimeType: string): number {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (upload validation)

# Why was this change needed?

A customer's API automation uploads video renders before the generator finishes writing them. Postiz accepted the files, showed them as black tiles in the media gallery, and the posts failed days later at publish time with Pinterest's "The file is corrupted and cannot be uploaded" (investigated alongside #1802/#1803). Two failed posts' production files showed the identical unfinalized signature — `ftyp` + `free` + `mdat` with size 0 and **no `moov` box** — while a successfully published one had a proper `moov`.

**What this validates:** that a top-level `moov` box exists in an uploaded mp4. Per ISO/IEC 14496-12 (the ISO base media file format underlying mp4; publicly available at https://standards.iso.org/ittf/PubliclyAvailableStandards/ — Movie Box, §8.2.1: "exactly one MovieBox shall be present"), `moov` is mandatory: it is the file's index (codec config + sample tables), and nothing can decode a single frame without it. Encoders write it last (or rewrite with it first for faststart), so its absence is the definitive signature of a file grabbed mid-encode. The check hops top-level box headers only (no byte scanning, handles 64-bit `largesize`), so cost is a handful of reads regardless of file size.

**What it does not validate:** decodability — a structurally complete mp4 with a corrupt/empty track still passes (that would need ffprobe-level demuxing). It also does not cover the hosted web-UI path, which uploads browser → R2 via Uppy S3 multipart, so the server never sees the bytes. Covered are the paths automation uses: public API `/upload` and `/upload-from-url`, the agent `uploadFromUrlTool`, and the XHR/self-hosted routes through `CustomFileValidationPipe`. That asymmetry matches the failure mode: a human uploads a finished render (and would instantly see a black preview otherwise), while automation races the encoder — which is why this only ever surfaced via API/MCP.

Verified e2e on a local run: public API `/upload` → 201 for a valid mp4, 400 with the new message for a moov-less one; MCP `uploadFromUrlTool` → uploads a known-good production file, returns the graceful `{error}` for the customer's actual corrupt file.

# Other information:

Rejected uploads get an actionable message telling the user to wait for the render to complete and re-upload. Existing corrupted files already in storage are unaffected (they keep failing at publish time as today).

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)