### PR TITLE
fix(auth): case-insensitive email lookups for login, forgot password and impersonation

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -118,11 +118,13 @@ export class OrganizationRepository {
                 {
                   name: {
                     contains: name,
+                    mode: 'insensitive',
                   },
                 },
                 {
                   email: {
                     contains: name,
+                    mode: 'insensitive',
                   },
                 },
                 {

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
@@ -111,7 +111,10 @@ export class UsersRepository {
   getUserByEmail(email: string) {
     return this._user.model.user.findFirst({
       where: {
-        email,
+        email: {
+          equals: email,
+          mode: 'insensitive',
+        },
         providerName: Provider.LOCAL,
       },
       include: {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

Local registration lowercases emails only since dcb1b018, so accounts created before that can have mixed-case emails stored. The email lookup used by login, forgot-password and the signup duplicate check was an exact match, so any casing difference between what the user types and what is stored makes those flows silently miss the account — forgot-password even reports success without sending anything, so the user just never receives a reset email. The admin impersonation search had the same issue via case-sensitive contains filters, making such accounts unfindable in support. Email addresses are case-insensitive in practice for every real provider, so matching insensitively is safe.

# Other information:

IMPORTANT — do NOT deploy before deduplicating existing users: because the old duplicate check was case-sensitive, the DB may contain multiple LOCAL accounts for the same mailbox differing only by casing (e.g. RRR@gmail.com and rrr@gmail.com). With this change, findFirst matches all of them and silently picks one, so login/forgot-password could start resolving to the wrong account. Before deploying: find LOCAL users grouped by lower(email) with more than one row, and merge/remove the duplicates. Deploying without this cleanup risks users logging into or resetting the password of a sibling duplicate account.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla)
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)