### PR TITLE
fix(linkedin-page): list pages for Content Admins, not only Super Admins

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -138,7 +138,7 @@ export class LinkedinPageProvider
   async companies(accessToken: string) {
     const { elements, ...all } = await (
       await fetch(
-        'https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&role=ADMINISTRATOR&projection=(elements*(organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))',
+        'https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&state=APPROVED&projection=(elements*(role,organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))',
         {
           headers: {
             Authorization: `Bearer ${accessToken}`,
@@ -149,15 +149,19 @@ export class LinkedinPageProvider
       )
     ).json();
 
-    return (elements || []).map((e: any) => ({
-      id: e.organizationalTarget.split(':').pop(),
-      page: e.organizationalTarget.split(':').pop(),
-      username: e['organizationalTarget~'].vanityName,
-      name: e['organizationalTarget~'].localizedName,
-      picture:
-        e['organizationalTarget~'].logoV2?.['original~']?.elements?.[0]
-          ?.identifiers?.[0]?.identifier,
-    }));
+    return (elements || [])
+      .filter((e: any) =>
+        ['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR'].includes(e.role)
+      )
+      .map((e: any) => ({
+        id: e.organizationalTarget.split(':').pop(),
+        page: e.organizationalTarget.split(':').pop(),
+        username: e['organizationalTarget~'].vanityName,
+        name: e['organizationalTarget~'].localizedName,
+        picture:
+          e['organizationalTarget~'].logoV2?.['original~']?.elements?.[0]
+            ?.identifiers?.[0]?.identifier,
+      }));
   }
 
   async reConnect(

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -150,8 +150,10 @@ export class LinkedinPageProvider
     ).json();
 
     return (elements || [])
-      .filter((e: any) =>
-        ['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR'].includes(e.role)
+      .filter(
+        (e: any) =>
+          e['organizationalTarget~'] &&
+          ['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR'].includes(e.role)
       )
       .map((e: any) => ({
         id: e.organizationalTarget.split(':').pop(),


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

A user reported that a LinkedIn page they have Content Admin access to never appears in the page-selection list when connecting a LinkedIn Page channel.

The `companies()` call in the LinkedIn Page provider queried `organizationalEntityAcls` with `role=ADMINISTRATOR`, so only pages where the user is a Super Admin were returned. Per LinkedIn's docs (https://learn.microsoft.com/en-us/linkedin/marketing/community-management/organizations/organization-access-control-by-role?view=li-lms-2026-07), the `CONTENT_ADMINISTRATOR` role also has "access to create and manage Page content, including updates", so Content Admins can post but couldn't connect their page.

The query now fetches approved ACLs (`state=APPROVED`) with the role projected, and keeps pages where the user's role is `ADMINISTRATOR` or `CONTENT_ADMINISTRATOR` — the two roles LinkedIn documents as allowed to post page updates. The returned shape is unchanged, so the picker, `fetchPageInformation`, and existing connected channels are unaffected.

# Other information:

Tested end to end: with an account that is only a Content Admin of a LinkedIn page, the page now shows in the picker, the channel connects, and a post to that page published successfully.

Publishing authorization is still enforced by LinkedIn at post time; this filter only controls which pages are offered in the picker.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
