### PR TITLE
Fix AI video generation hanging forever when the provider reports failure

### DIFF
--- a/apps/frontend/src/components/launches/ai.video.tsx
+++ b/apps/frontend/src/components/launches/ai.video.tsx
@@ -60,8 +60,15 @@ export const Modal: FC<{
 
       if (image.status == 200 || image.status == 201) {
         onChange(await image.json());
+      } else {
+        toaster.show('Video generation failed', 'warning');
       }
-    } catch (e) {}
+    } catch (e) {
+      toaster.show(
+        'Video generation failed or timed out — if it completes, it will appear in your media library',
+        'warning'
+      );
+    }
 
     setLocked(false);
     setLoading(false);

--- a/libraries/nestjs-libraries/src/chat/tools/generate.video.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/generate.video.tool.ts
@@ -55,26 +55,35 @@ export class GenerateVideoTool implements AgentToolInterface {
         ),
       }),
       outputSchema: z.object({
-        url: z.string(),
+        url: z.string().optional(),
+        error: z.string().optional(),
       }),
       execute: async (inputData, context) => {
         checkAuth(inputData, context);
         const org = JSON.parse((context?.requestContext as any)?.get('organization') as string);
-        const value = await this._mediaService.generateVideo(org, {
-          type: inputData.identifier,
-          output: inputData.output,
-          customParams: inputData.customParams.reduce(
-            (all: Record<string, any>, current: { key: string; value: any }) => ({
-              ...all,
-              [current.key]: current.value,
-            }),
-            {} as Record<string, any>
-          ),
-        });
+        try {
+          const value = await this._mediaService.generateVideo(org, {
+            type: inputData.identifier,
+            output: inputData.output,
+            customParams: inputData.customParams.reduce(
+              (all: Record<string, any>, current: { key: string; value: any }) => ({
+                ...all,
+                [current.key]: current.value,
+              }),
+              {} as Record<string, any>
+            ),
+          });
 
-        return {
-          url: value.path,
-        };
+          return {
+            url: value.path,
+          };
+        } catch (err) {
+          return {
+            error: `Video generation failed: ${
+              err instanceof Error ? err.message : String(err)
+            }. The user's video credit was not used.`,
+          };
+        }
       },
     });
   }

--- a/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
+++ b/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
@@ -48,6 +48,7 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
           Authorization: `Bearer ${process.env.KIEAI_API_KEY}`,
         },
         method: 'POST',
+        signal: AbortSignal.timeout(30000),
         body: JSON.stringify({
           prompt: customParams.prompt,
           imageUrls: customParams?.images?.map((p) => p.path) || [],
@@ -62,8 +63,13 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
     }
 
     const taskId = value.data.taskId;
-    let videoUrl = [];
-    while (videoUrl.length === 0) {
+    let attempts = 0;
+    const maxAttempts = 180; // ~30 minutes at 10s interval
+    while (true) {
+      if (attempts++ >= maxAttempts) {
+        throw new Error('Video generation timed out');
+      }
+
       console.log('waiting for video to be ready');
       const data = await (
         await fetch(
@@ -73,18 +79,34 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${process.env.KIEAI_API_KEY}`,
             },
+            signal: AbortSignal.timeout(30000),
           }
         )
       ).json();
 
-      if (data.code !== 200 && data.code !== 400) {
-        throw new Error(`Failed to get video info`);
+      if (data.code !== 200) {
+        throw new Error(data?.msg || `Failed to get video info`);
       }
 
-      videoUrl = data?.data?.response?.resultUrls || [];
+      // successFlag: 0 = generating, 1 = success, anything else = failed
+      const successFlag = data?.data?.successFlag;
+      if (successFlag !== 0 && successFlag !== 1) {
+        throw new Error(
+          data?.data?.errorMessage ||
+            `Video generation failed (status ${successFlag})`
+        );
+      }
+
+      const videoUrl = data?.data?.response?.resultUrls || [];
+      if (videoUrl.length > 0) {
+        return videoUrl[0];
+      }
+
+      if (successFlag === 1) {
+        throw new Error('Video generation succeeded but no video URL returned');
+      }
+
       await timer(10000);
     }
-
-    return videoUrl[0];
   }
 }

--- a/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
+++ b/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
@@ -63,6 +63,7 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
     }
 
     const taskId = value.data.taskId;
+    console.log('veo3 taskId', taskId);
     let attempts = 0;
     const maxAttempts = 180; // ~30 minutes at 10s interval
     while (true) {

--- a/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
+++ b/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
@@ -59,7 +59,7 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
     ).json();
 
     if (value.code !== 200 && value.code !== 201) {
-      throw new Error(`Failed to generate video`);
+      throw new Error(value?.msg || `Failed to generate video`);
     }
 
     const taskId = value.data.taskId;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A production user approved an AI video generation in the agent chat and got: "..." spinner forever, their approval message gone after refresh, and 1 of their 30 monthly video credits burned.

Root cause: kie.ai runs content moderation asynchronously — `/veo/generate` returns 200 + taskId and the rejection only appears later through `record-info`. The veo3 poll loop's only exit condition was non-empty `resultUrls`: it never inspected `successFlag`, explicitly whitelisted top-level `code: 400`, had no attempt cap and no socket timeout. A failed task therefore polled forever. The never-settling promise meant `useCredit`'s catch-based refund never ran (credit burned), the CopilotKit SSE stream never closed (eternal spinner), and Mastra never persisted the turn (that's the vanishing approval message).

Fix, keeping all provider-specific logic inside the veo3 provider:

- `veo3.ts`: bounded polling matching the HeyGen provider (180 × 10s ≈ 30 min, then throw). Keep polling only on `successFlag: 0`; any other flag throws with the provider's `errorMessage` (2/3 = failed; unknown values fail fast). Success reported without a URL throws. Top-level `code !== 200` throws with the provider `msg` (safety wording then surfaces via `generationError`). `AbortSignal.timeout(30000)` on both fetches so a stalled socket can't hang. Once the callback rejects, the existing `useCredit` refund works untouched.
- `generate.video.tool.ts`: try/catch returning an `{ error }` result (outputSchema fields made optional, same shape as `upload.from.url.tool.ts`) instead of throwing — the agent run completes, the stream closes cleanly, the turn is persisted.
- `ai.video.tsx`: the create-post modal no longer swallows errors — warning toaster on non-2xx, and on fetch rejection (network drop, where the backend may still finish and save to the media library).

Verified with a local mock kie.ai: baseline repro on the old code (failed task → endless polling with the credit row leaked unrefunded) and post-fix (code:400 / successFlag:2 / deadline paths all throw promptly with the credit refunded; chat replies with the failure message and the turn survives refresh; modal shows the toaster). Real happy-path generation verified end to end: 76s, video uploaded and saved to the media library, exactly one credit consumed.

# Other information:

Follow-up commit: log the kie.ai taskId when a generation starts. While debugging the production report we could not correlate our logs with kie.ai's task history because the taskId was never recorded; with it logged, a failed generation can be looked up directly via kie.ai's record-info endpoint or dashboard.

Deliberately out of scope: out-of-app notification for timed-out generations, eager persistence of the user chat message before tool execution, error boundary around the copilot stream handler.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
