### PR TITLE
fix(posts): clarify error message for missing posts array in request body

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.spec.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.spec.ts
@@ -1,0 +1,36 @@
+import { PostsService } from './posts.service';
+
+describe('PostsService.mapTypeToPost', () => {
+  const mockDep = {} as any;
+  const service = new PostsService(
+    mockDep,
+    mockDep,
+    mockDep,
+    mockDep,
+    mockDep,
+    mockDep,
+    mockDep,
+    mockDep
+  );
+
+  it('throws a clear error when posts array is missing', async () => {
+    await expect(
+      service.mapTypeToPost({ type: 'schedule', date: '2026-01-01' } as any, 'org-id')
+    ).rejects.toThrow('Request body must include a non-empty "posts" array');
+  });
+
+  it('throws a clear error when posts array is empty', async () => {
+    await expect(
+      service.mapTypeToPost({ type: 'schedule', date: '2026-01-01', posts: [] } as any, 'org-id')
+    ).rejects.toThrow('Request body must include a non-empty "posts" array');
+  });
+
+  it('throws the original error when posts exist but lack integration id', async () => {
+    await expect(
+      service.mapTypeToPost(
+        { type: 'schedule', date: '2026-01-01', posts: [{}] } as any,
+        'org-id'
+      )
+    ).rejects.toThrow('All posts must have an integration id');
+  });
+});

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -249,7 +249,13 @@ export class PostsService {
     organization: string,
     replaceDraft: boolean = false
   ): Promise<CreatePostDto> {
-    if (!body?.posts?.every((p) => p?.integration?.id)) {
+    if (!body?.posts || !Array.isArray(body.posts) || body.posts.length === 0) {
+      throw new BadRequestException(
+        'Request body must include a non-empty "posts" array'
+      );
+    }
+
+    if (!body.posts.every((p) => p?.integration?.id)) {
       throw new BadRequestException('All posts must have an integration id');
     }
 


### PR DESCRIPTION
Fixes #1776

## Problem
`POST /api/posts` was rejecting the reporter's request with `"All posts must have an integration id"` — a misleading message. The actual issue was that their request body didn't include a top-level `posts` array at all (per `CreatePostDto`), so `body.posts` was `undefined`. The existing check conflated two different failure cases into one message.

## Fix
Split the validation in `mapTypeToPost()` (posts.service.ts) into two checks:
1. First, verify `body.posts` exists, is an array, and is non-empty — with a new, accurate message: `"Request body must include a non-empty 'posts' array"`.
2. Then, keep the original check/message for the case it was actually meant for: posts exist but one or more are missing `integration.id`.

## Testing
Added `posts.service.spec.ts` covering both new cases plus the original one. I wasn't able to get this specific test running cleanly in my local environment due to unrelated Jest/TypeScript config issues in this NX monorepo (heap limits, module aliasing, and an ESM transform issue with a transitive dependency) — happy to adjust if it doesn't pass in CI.