### PR TITLE
feat(accounts): clarify which account/org is active for same-email users

### DIFF
--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -897,6 +897,15 @@ const SwitchUser = () => {
         id: curr.user.id,
         name: curr.user.name,
         email: curr.user.email,
+        orgs: (data || [])
+          .filter((org: any) => org.user.id === curr.user.id)
+          .map(
+            (org: any) =>
+              `${org.organization?.name} (${org.role} / ${
+                org.organization?.subscription?.subscriptionTier || 'FREE'
+              })`
+          )
+          .join(', '),
       }));
   }, [data, currentUser?.id]);
 
@@ -991,6 +1000,7 @@ const SwitchUser = () => {
                 {item.id.split('-').at(-1)} -{' '}
                 {item.name ? `${item.name} - ` : ''}
                 {item.email}
+                {item.orgs ? ` - ${item.orgs}` : ''}
               </div>
             ))}
           </div>
@@ -1054,6 +1064,9 @@ export const Impersonate = () => {
         id: curr.id,
         name: curr.user.name,
         email: curr.user.email,
+        orgName: curr.organization?.name,
+        role: curr.role,
+        tier: curr.organization?.subscription?.subscriptionTier || 'FREE',
       }),
       []
     );
@@ -1120,7 +1133,8 @@ export const Impersonate = () => {
                     className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer"
                   >
                     {t('user_1', 'user:')}
-                    {user.id.split('-').at(-1)} - {user.name} - {user.email}
+                    {user.id.split('-').at(-1)} - {user.name} - {user.email} -{' '}
+                    {user.orgName} ({user.role} / {user.tier})
                   </div>
                 ))}
               </div>

--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -989,12 +989,12 @@ const SwitchUser = () => {
             className="bg-primary/80 fixed start-0 top-0 w-full h-full z-[998]"
             onClick={() => setName('')}
           />
-          <div className="absolute top-[100%] start-0 w-full bg-sixth border border-customColor6 text-textColor z-[999]">
+          <div className="absolute top-[100%] start-0 w-max min-w-full max-w-[90vw] bg-sixth border border-customColor6 text-textColor z-[999]">
             {mapData.map((item: any) => (
               <div
                 onClick={pick(item)}
                 key={item.id}
-                className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer"
+                className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer whitespace-nowrap truncate"
               >
                 {t('user_1', 'user:')}
                 {item.id.split('-').at(-1)} -{' '}
@@ -1125,12 +1125,12 @@ export const Impersonate = () => {
                 className="bg-primary/80 fixed start-0 top-0 w-full h-full z-[998]"
                 onClick={() => setName('')}
               />
-              <div className="absolute top-[100%] w-full start-0 bg-sixth border border-customColor6 text-textColor z-[999]">
+              <div className="absolute top-[100%] w-max min-w-full max-w-[90vw] start-0 bg-sixth border border-customColor6 text-textColor z-[999]">
                 {mapData?.map((user: any) => (
                   <div
                     onClick={setUser(user.id)}
                     key={user.id}
-                    className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer"
+                    className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer whitespace-nowrap truncate"
                   >
                     {t('user_1', 'user:')}
                     {user.id.split('-').at(-1)} - {user.name} - {user.email} -{' '}

--- a/apps/frontend/src/components/layout/impersonate.tsx
+++ b/apps/frontend/src/components/layout/impersonate.tsx
@@ -885,24 +885,24 @@ const SwitchUser = () => {
     // one row per user-organization: dedupe by user id, drop the impersonated user
     const seen = new Set<string>();
     return (data || [])
-      .filter((curr: any) => curr.user.id !== currentUser?.id)
+      .filter((curr: any) => curr?.user?.id !== currentUser?.id)
       .filter((curr: any) => {
-        if (seen.has(curr.user.id)) {
+        if (seen.has(curr?.user?.id)) {
           return false;
         }
-        seen.add(curr.user.id);
+        seen.add(curr?.user?.id);
         return true;
       })
       .map((curr: any) => ({
-        id: curr.user.id,
-        name: curr.user.name,
-        email: curr.user.email,
+        id: curr?.user?.id,
+        name: curr?.user?.name,
+        email: curr?.user?.email,
         orgs: (data || [])
-          .filter((org: any) => org.user.id === curr.user.id)
+          .filter((org: any) => org?.user?.id === curr?.user?.id)
           .map(
             (org: any) =>
-              `${org.organization?.name} (${org.role} / ${
-                org.organization?.subscription?.subscriptionTier || 'FREE'
+              `${org?.organization?.name} (${org?.role} / ${
+                org?.organization?.subscription?.subscriptionTier || 'FREE'
               })`
           )
           .join(', '),
@@ -993,14 +993,14 @@ const SwitchUser = () => {
             {mapData.map((item: any) => (
               <div
                 onClick={pick(item)}
-                key={item.id}
+                key={item?.id}
                 className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer whitespace-nowrap truncate"
               >
                 {t('user_1', 'user:')}
-                {item.id.split('-').at(-1)} -{' '}
-                {item.name ? `${item.name} - ` : ''}
-                {item.email}
-                {item.orgs ? ` - ${item.orgs}` : ''}
+                {item?.id?.split('-')?.at(-1)} -{' '}
+                {item?.name ? `${item?.name} - ` : ''}
+                {item?.email}
+                {item?.orgs ? ` - ${item?.orgs}` : ''}
               </div>
             ))}
           </div>
@@ -1061,12 +1061,12 @@ export const Impersonate = () => {
   const mapData = useMemo(() => {
     return data?.map(
       (curr: any) => ({
-        id: curr.id,
-        name: curr.user.name,
-        email: curr.user.email,
-        orgName: curr.organization?.name,
-        role: curr.role,
-        tier: curr.organization?.subscription?.subscriptionTier || 'FREE',
+        id: curr?.id,
+        name: curr?.user?.name,
+        email: curr?.user?.email,
+        orgName: curr?.organization?.name,
+        role: curr?.role,
+        tier: curr?.organization?.subscription?.subscriptionTier || 'FREE',
       }),
       []
     );
@@ -1128,13 +1128,13 @@ export const Impersonate = () => {
               <div className="absolute top-[100%] w-max min-w-full max-w-[90vw] start-0 bg-sixth border border-customColor6 text-textColor z-[999]">
                 {mapData?.map((user: any) => (
                   <div
-                    onClick={setUser(user.id)}
-                    key={user.id}
+                    onClick={setUser(user?.id)}
+                    key={user?.id}
                     className="p-[10px] border-b border-customColor6 hover:bg-tableBorder cursor-pointer whitespace-nowrap truncate"
                   >
                     {t('user_1', 'user:')}
-                    {user.id.split('-').at(-1)} - {user.name} - {user.email} -{' '}
-                    {user.orgName} ({user.role} / {user.tier})
+                    {user?.id?.split('-')?.at(-1)} - {user?.name} - {user?.email}{' '}
+                    - {user?.orgName} ({user?.role} / {user?.tier})
                   </div>
                 ))}
               </div>

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -64,14 +64,14 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                 />
               </svg>
               {!!current?.name && (
-                <div className="max-w-[120px] truncate">{current.name}</div>
+                <div className="max-w-[240px] truncate">{current.name}</div>
               )}
             </div>
           )}
           {data?.length > 1 && (
             <div
               className={clsx(
-                'hidden py-[12px] px-[12px] group-hover:flex absolute top-[100%] end-0 bg-third border-tableBorder border gap-[12px] cursor-pointer flex-col',
+                'hidden py-[12px] px-[12px] group-hover:flex absolute top-[100%] end-0 w-max max-w-[400px] bg-third border-tableBorder border gap-[12px] cursor-pointer flex-col',
                 asOpenSelect ? '!flex !relative max-w-[500px] mx-auto mb-[10px]' : '',
               )}
             >
@@ -81,7 +81,11 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                   id: string;
                   users: { role: 'SUPERADMIN' | 'ADMIN' | 'USER' }[];
                 }) => (
-                  <div key={org.id} onClick={changeOrg(org)}>
+                  <div
+                    key={org.id}
+                    onClick={changeOrg(org)}
+                    className="whitespace-nowrap truncate"
+                  >
                     {org.name}
                     {!!org.users?.[0]?.role && (
                       <span className="text-customColor18">

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -75,11 +75,29 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                 asOpenSelect ? '!flex !relative max-w-[500px] mx-auto mb-[10px]' : '',
               )}
             >
-              {withoutCurrent?.map((org: { name: string; id: string }) => (
-                <div key={org.id} onClick={changeOrg(org)}>
-                  {org.name}
-                </div>
-              ))}
+              {withoutCurrent?.map(
+                (org: {
+                  name: string;
+                  id: string;
+                  users: { role: 'SUPERADMIN' | 'ADMIN' | 'USER' }[];
+                }) => (
+                  <div key={org.id} onClick={changeOrg(org)}>
+                    {org.name}
+                    {!!org.users?.[0]?.role && (
+                      <span className="text-customColor18">
+                        {' '}
+                        (
+                        {org.users[0].role === 'SUPERADMIN'
+                          ? 'Super-Admin'
+                          : org.users[0].role === 'ADMIN'
+                          ? 'Admin'
+                          : 'User'}
+                        )
+                      </span>
+                    )}
+                  </div>
+                )
+              )}
             </div>
           )}
         </div>

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -64,7 +64,7 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                 />
               </svg>
               {!!current?.name && (
-                <div className="max-w-[240px] truncate">{current.name}</div>
+                <div className="max-w-[240px] truncate">{current?.name}</div>
               )}
             </div>
           )}
@@ -82,18 +82,18 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                   users: { role: 'SUPERADMIN' | 'ADMIN' | 'USER' }[];
                 }) => (
                   <div
-                    key={org.id}
+                    key={org?.id}
                     onClick={changeOrg(org)}
                     className="whitespace-nowrap truncate"
                   >
-                    {org.name}
-                    {!!org.users?.[0]?.role && (
+                    {org?.name}
+                    {!!org?.users?.[0]?.role && (
                       <span className="text-customColor18">
                         {' '}
                         (
-                        {org.users[0].role === 'SUPERADMIN'
+                        {org?.users?.[0]?.role === 'SUPERADMIN'
                           ? 'Super-Admin'
-                          : org.users[0].role === 'ADMIN'
+                          : org?.users?.[0]?.role === 'ADMIN'
                           ? 'Admin'
                           : 'User'}
                         )

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -49,7 +49,7 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
             <div className="bg-btnPrimary !flex !relative max-w-[500px] mx-auto py-[12px] px-[12px]">Select Organization</div>
           )}
           {!asOpenSelect && (
-            <div className="flex items-center">
+            <div className="flex items-center gap-[6px]">
               <svg
                 className={user?.tier.current === 'FREE' ? 'animate-bounce drop-shadow-glow': ''}
                 width="24"
@@ -63,6 +63,9 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                   fill="currentColor"
                 />
               </svg>
+              {!!current?.name && (
+                <div className="max-w-[120px] truncate">{current.name}</div>
+              )}
             </div>
           )}
           {data?.length > 1 && (
@@ -72,7 +75,7 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                 asOpenSelect ? '!flex !relative max-w-[500px] mx-auto mb-[10px]' : '',
               )}
             >
-              {data?.map((org: { name: string; id: string }) => (
+              {withoutCurrent?.map((org: { name: string; id: string }) => (
                 <div key={org.id} onClick={changeOrg(org)}>
                   {org.name}
                 </div>

--- a/apps/frontend/src/components/public-api/public.component.tsx
+++ b/apps/frontend/src/components/public-api/public.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { useSWRConfig } from 'swr';
+import { useState, useCallback, useMemo } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
 import { useUser } from '../layout/user.context';
 import copy from 'copy-to-clipboard';
 import { useToaster } from '@gitroom/react/toaster/toaster';
@@ -709,10 +709,29 @@ const PublicApiContent = () => {
 
 export const PublicComponent = () => {
   const t = useT();
+  const fetch = useFetch();
+  const user = useUser();
   const [subTab, setSubTab] = useState<'api' | 'developer'>('api');
+  const loadOrganizations = useCallback(async () => {
+    return await (await fetch('/user/organizations')).json();
+  }, []);
+  const { data: organizations } = useSWR('organizations', loadOrganizations, {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    refreshWhenOffline: false,
+    refreshWhenHidden: false,
+    revalidateOnReconnect: false,
+  });
+  const currentOrg = useMemo(() => {
+    return organizations?.find((org: any) => org.id === user?.orgId);
+  }, [organizations, user?.orgId]);
 
   return (
     <div className="flex flex-col gap-[20px]">
+      <h3 className="text-[20px]">
+        {t('developers', 'Developers')}
+        {currentOrg?.name ? ` - ${currentOrg.name}` : ''}
+      </h3>
       <div className="flex gap-[6px]">
         {(['api', 'developer'] as const).map((tab) => (
           <button

--- a/apps/frontend/src/components/public-api/public.component.tsx
+++ b/apps/frontend/src/components/public-api/public.component.tsx
@@ -723,7 +723,7 @@ export const PublicComponent = () => {
     revalidateOnReconnect: false,
   });
   const currentOrg = useMemo(() => {
-    return organizations?.find((org: any) => org.id === user?.orgId);
+    return organizations?.find((org: any) => org?.id === user?.orgId);
   }, [organizations, user?.orgId]);
 
   return (

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -139,9 +139,16 @@ export class OrganizationRepository {
       },
       select: {
         id: true,
+        role: true,
         organization: {
           select: {
             id: true,
+            name: true,
+            subscription: {
+              select: {
+                subscriptionTier: true,
+              },
+            },
           },
         },
         user: {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (UX clarity).

# Why was this change needed?

A support case showed how easily users with two same-email accounts (different auth providers) get lost: the customer was viewing the paying org from his invited USER-role account and couldn't see Settings -> Developers, without realizing which account/org he was on. Nothing in the UI answered "which org am I viewing and what am I in it":

- The org switcher was a bare icon with no indication of the active org, and its dropdown repeated the current org among the options.
- Same-named orgs (common when one person owns several accounts) were indistinguishable in the dropdown.
- The admin Impersonation / Switch User dropdowns showed only user id + email, so identical rows (same email, two accounts) couldn't be told apart, nor which org/role/plan each row belongs to.
- The Developers screen was the only settings screen without a title, so it never said which org's API key it shows.

Changes:

- Org switcher shows the active org name next to the icon (truncated at 240px) and lists only the other orgs in the dropdown, each with the member's role (Super-Admin / Admin / User); the menu sizes to its content up to 400px instead of wrapping inside the narrow anchor.
- Developers settings screen gets a "Developers - <org name>" title like the other settings screens.
- Admin Impersonation and Switch User dropdowns show org name, role and plan per row (the impersonation search API now also returns org name, role and subscription tier), and the menus grow to fit their rows.

# Other information:

No new translation keys. The asOpenSelect variant of the selector is only used by the currently-unreferenced BillingAfter component.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)