### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/build-extension.yaml
+++ b/.github/workflows/build-extension.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22,24,26`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22,24,26` (using `26` where a concrete pin is needed).

- `.github/workflows/build-extension.yaml`
  - `node-version: 20` → `node-version: 22`
- `.github/workflows/publish-extension.yml`
  - `node-version: 20` → `node-version: 22`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22,24,26`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
