### PR TITLE
fix(threads): use threads.com for the OAuth authorize URL

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -103,7 +103,7 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
     const state = makeId(6);
     return {
       url:
-        'https://www.threads.net/oauth/authorize' +
+        'https://www.threads.com/oauth/authorize' +
         `?client_id=${process.env.THREADS_APP_ID}` +
         `&redirect_uri=${encodeURIComponent(
           `${


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Threads provider auth). `ThreadsProvider.generateAuthUrl` points the authorize URL at `https://www.threads.com/oauth/authorize` instead of `https://www.threads.net/oauth/authorize`. Meta moved the Threads domain and the old host now redirects in a way that breaks the OAuth handshake for some users. Only the authorize host changes - the requested scopes, the `redirect_uri`, the state generation and the token-exchange endpoint in `authenticate` are all unchanged.

# Why was this change needed?

A self-hoster reported that clicking "Add Threads" landed on the Threads homepage instead of the authorization screen. Threads migrated its website from threads.net to threads.com, and `threads.net/oauth/authorize` now returns a **301 Moved Permanently** to threads.com (verified with curl and in the production network tab) — so every connect flow today goes through a cross-domain redirect on the legacy domain before reaching the real authorize endpoint. For some users that redirect drops the OAuth query parameters, so they land on the homepage and the consent screen never appears. The reporting user confirmed that replaying the exact same `/oauth/authorize` path on threads.com shows the consent screen and completes the connection.

Note the redirect preserves parameters for most users (the flow works in production today), which is why this wasn't caught earlier — but it is demonstrably lossy for some users, and linking directly to threads.com removes the dependency on that redirect entirely. Verified locally: with this change the browser's first request goes straight to `www.threads.com/oauth/authorize` with all parameters intact and the flow completes.

This changes only the browser-facing authorize URL. The server-to-server `graph.threads.net` endpoints are unchanged — Meta's API changelog (June 6, 2025) states the API is accessible on both `graph.threads.com` and `graph.threads.net`.

# Other information:

None

# QA

1. [ ] Set `THREADS_APP_ID` and `THREADS_APP_SECRET` and start the app
2. [ ] Go to Channels -> Add Channel -> Threads
3. [ ] The popup opens on `threads.com` and shows the Meta consent screen directly, with no interstitial redirect
4. [ ] Approve the consent screen - you land back in Postiz and the Threads channel appears connected with the correct name and avatar
5. [ ] Schedule a short text post to that channel and confirm it publishes to Threads
6. [ ] Disconnect and reconnect the channel once to confirm the flow is repeatable

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla)
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
