### PR TITLE
fix(refresh): only disconnect channels on recognized auth errors, log refresh failures

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -7,6 +7,7 @@ import {
   SocialProvider,
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { TemporalService } from 'nestjs-temporal-core';
+import { safeStringify } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 
 @Injectable()
 export class RefreshIntegrationService {
@@ -73,11 +74,33 @@ export class RefreshIntegrationService {
     socialProvider: SocialProvider,
     cause = ''
   ): Promise<AuthTokenDetails | false> {
+    let refreshError: any = null;
     const refresh: false | AuthTokenDetails = await socialProvider
       .refreshToken(integration.refreshToken)
-      .catch((err) => false);
+      .catch((err) => {
+        refreshError = err;
+        return false as const;
+      });
 
     if (!refresh || !refresh.accessToken) {
+      console.error(
+        `Refresh failed for ${integration.providerIdentifier} (${integration.id}):`,
+        refreshError || 'no access token returned'
+      );
+
+      if (refreshError) {
+        const handle = socialProvider.handleErrors?.(
+          `${refreshError?.message || ''} ${safeStringify(refreshError)}`,
+          refreshError?.status || refreshError?.response?.status || 0
+        );
+
+        // transient / unrecognized errors should not disconnect the channel,
+        // only errors the provider recognizes as an invalid refresh token
+        if (handle?.type !== 'refresh-token') {
+          return false;
+        }
+      }
+
       await this._integrationService.refreshNeeded(
         integration.organizationId,
         integration.id

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -66,7 +66,7 @@ export class NotEnoughScopes {
   ) {}
 }
 
-function safeStringify(obj: any) {
+export function safeStringify(obj: any) {
   const seen = new WeakSet();
 
   return JSON.stringify(obj, (key, value) => {

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -140,6 +140,12 @@ export interface SocialProvider
     ISocialMediaIntegration {
   identifier: string;
   refreshWait?: boolean;
+  handleErrors?(
+    body: string,
+    status: number
+  ):
+    | { type: 'refresh-token' | 'bad-body' | 'retry'; value: string }
+    | undefined;
   convertToJPEG?: boolean;
   stripLinks?: () => boolean;
   refreshCron?: boolean;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A production customer's GMB channel was repeatedly flagged "manual refresh needed" (~50 minutes after every reconnect, with no post in between) and they were emailed to reconnect each time. Root cause: `refreshProcess` swallowed every refresh error with `.catch(() => false)`, so a transient failure (network blip, provider 5xx, rate limit) was handled exactly like a dead refresh token — flag `refreshNeeded`, disconnect the channel, email the user — and the actual error was discarded, leaving nothing in the logs to diagnose.

This PR:
- Logs the real refresh error (provider, integration id, full error).
- Classifies it with the provider's own `handleErrors` (the same pattern `runInConcurrent` already uses for thrown exceptions). Only errors the provider recognizes as an invalid refresh token (e.g. Google's `invalid_grant`) keep the existing disconnect flow; anything else returns `false` without disconnecting so the next refresh retries cleanly.

Behavior note: providers without a `handleErrors` override are no longer disconnected from the refresh path. A genuinely dead token there still gets flagged on the next real API call, when `SocialAbstract.fetch` throws `RefreshToken` on 401 and the post workflow marks the channel.

# Other information:

Reproduced and validated e2e against a local DB by driving `RefreshIntegrationService.refresh` directly (Nest application context), with a dead `HTTPS_PROXY` to force a genuine network error and a reversed refresh token to force a genuine `invalid_grant`:

| Scenario | Old code | This PR |
|---|---|---|
| Transient `ECONNREFUSED`, valid token (youtube) | disconnected + reconnect email, nothing logged | stays connected, error logged |
| Real `invalid_grant` from Google (youtube) | disconnected + reconnect notification | same (unchanged) |
| Dead token on provider without `handleErrors` (reddit) | disconnected | logged, flagged at next post instead |

Healthy refresh re-verified after each scenario (token rotated, expiration updated).

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)