### PR TITLE
fix(posts): return image in post list responses

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -174,6 +174,7 @@ export class PostsRepository {
       select: {
         id: true,
         content: true,
+        image: true,
         publishDate: true,
         releaseURL: true,
         releaseId: true,
@@ -286,6 +287,7 @@ export class PostsRepository {
         select: {
           id: true,
           content: true,
+          image: true,
           publishDate: true,
           releaseURL: true,
           releaseId: true,


### PR DESCRIPTION
## Why

`getPosts` and `getPostsList` use `select` allowlists that omit `image`, so every list response drops the media attached to a post.

`getPost` and `getPostById` use `include` and already return `image`. So the two read paths disagree about whether a post has media, which reads like an oversight rather than a deliberate omission.

This is most visible through the public API. `GET /public/v1/posts` returns the repository result directly, so its posts come back with no `image` field, and there is no per-post `GET /public/v1/posts/:id` to fall back on. An API consumer building a calendar or an approval/preview view can see a post's text, state and channel, but cannot render the media that post will actually publish. The media is in the database the whole time.

The web app is unaffected, since it does not read through this endpoint. That is probably why this has not come up before.

## What changed

`image: true` added to the `select` in `getPosts` and `getPostsList`.

The field stays a raw JSON string, which is exactly what `getPost` already returns today, so no existing response changes shape and no consumer needs to change. Callers `JSON.parse` it the same way the rest of the codebase does.

## Notes

- Two lines, no behaviour change beyond the added field.
- The public API reference lives in `gitroomhq/postiz-docs`, so the `Post` response schema there will need `image` adding separately. Happy to send that PR too.
- Related: #1778 asks for fuller post CRUD on the public API. This is only the read-projection half, and is independent of it.
