### PR TITLE
fix(gmb): fail post when Google returns REJECTED or unconfirmed localPost

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/gmb.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/gmb.provider.ts
@@ -484,7 +484,7 @@ export class GmbProvider extends SocialAbstract implements SocialProvider {
       'create local post'
     );
 
-    const postData = await response.json();
+    const postData = await response.json().catch(() => ({}));
 
     if (postData?.state === 'REJECTED') {
       throw new BadBody(

--- a/libraries/nestjs-libraries/src/integrations/social/gmb.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/gmb.provider.ts
@@ -9,6 +9,7 @@ import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library/build/src/auth/oauth2client';
 import {
+  BadBody,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -485,8 +486,26 @@ export class GmbProvider extends SocialAbstract implements SocialProvider {
 
     const postData = await response.json();
 
+    if (postData?.state === 'REJECTED') {
+      throw new BadBody(
+        this.identifier,
+        JSON.stringify(postData),
+        JSON.stringify(postBody),
+        'Google rejected this post for a content policy violation. Please review the post content and try again.'
+      );
+    }
+
+    if (!postData?.name) {
+      throw new BadBody(
+        this.identifier,
+        JSON.stringify(postData),
+        JSON.stringify(postBody),
+        'Google did not confirm the post creation. Please try again.'
+      );
+    }
+
     // Extract the post ID and construct the URL
-    const postId = postData.name || '';
+    const postId = postData.name;
     const locationId = id.split('/').pop();
 
     // GMB posts don't have direct URLs, but we can link to the business profile


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A customer reported (2026-07-31, support case) that their Google Business Profile posts were shown as published by Postiz but never appeared on their Business Profile. Root cause: Google's v4 `localPosts.create` can return HTTP 200 with the created LocalPost in `state: REJECTED` — Google moderates post content at creation time (content policy: prohibited content, phone numbers in text, low-quality media, etc.), and a rejected post is accepted by the API but never goes live. The GMB provider ignored the response body and returned `status: 'success'` on any 2xx, so rejected posts silently showed as published.

This PR makes `GmbProvider.post()` read the create response:
- `state === 'REJECTED'` → throws `BadBody` with "Google rejected this post for a content policy violation. Please review the post content and try again." — the post is marked failed and the error shows in the calendar, same as other providers' non-retryable body errors.
- Missing `name` (malformed/unconfirmed 200) → throws `BadBody` with "Google did not confirm the post creation. Please try again."
- `PROCESSING` (accepted, under Google review) intentionally still reports success.

# Other information:

Verified e2e locally through the full pipeline (public API → Temporal → orchestrator → provider) by stubbing only the Google response: REJECTED → post fails instantly (non-retryable) with the policy message in the calendar; empty body → fails with the "did not confirm" message; LIVE → publishes with the unchanged `PostResponse` shape and release URL.

Docs check: v4 localPosts is current; the only localPosts change since this provider was written is the 2026-04 RecurrenceInfo addition — nothing changed about `state` semantics. Possible future follow-up (out of scope here): use the response's `searchUrl` as the release URL.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)