### PR TITLE
fix(tags): clean up post assignments on tag deletion and stop matching soft-deleted tags

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -182,6 +182,11 @@ export class PostsRepository {
         group: true,
         creationMethod: true,
         tags: {
+          where: {
+            tag: {
+              deletedAt: null,
+            },
+          },
           select: {
             tag: true,
           },
@@ -294,6 +299,11 @@ export class PostsRepository {
           group: true,
           creationMethod: true,
           tags: {
+            where: {
+              tag: {
+                deletedAt: null,
+              },
+            },
             select: {
               tag: true,
             },
@@ -353,6 +363,11 @@ export class PostsRepository {
       include: {
         integration: true,
         tags: {
+          where: {
+            tag: {
+              deletedAt: null,
+            },
+          },
           select: {
             tag: true,
           },
@@ -378,6 +393,11 @@ export class PostsRepository {
           ? {
               integration: true,
               tags: {
+                where: {
+                  tag: {
+                    deletedAt: null,
+                  },
+                },
                 select: {
                   tag: true,
                 },
@@ -598,6 +618,7 @@ export class PostsRepository {
           const tagsList = await this._tags.model.tags.findMany({
             where: {
               orgId: orgId,
+              deletedAt: null,
               name: {
                 in: tags.map((tag) => tag.label).filter((f) => f),
               },
@@ -838,8 +859,8 @@ export class PostsRepository {
     });
   }
 
-  deleteTag(id: string, orgId: string) {
-    return this._tags.model.tags.update({
+  async deleteTag(id: string, orgId: string) {
+    const tag = await this._tags.model.tags.update({
       where: {
         id,
         orgId,
@@ -848,6 +869,14 @@ export class PostsRepository {
         deletedAt: new Date(),
       },
     });
+
+    await this._tagsPosts.model.tagsPosts.deleteMany({
+      where: {
+        tagId: tag.id,
+      },
+    });
+
+    return tag;
   }
 
   createComment(


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Customer report: deleting a tag leaves it stuck on the posts it was assigned to, and recreating a tag with the same name shows the label twice on the calendar.

Tag deletion is a soft delete on the Tags row but never touched the TagsPosts join rows, so assignments survived and the calendar kept rendering the dead tag. Worse, the save-path tag matching looks tags up by name with no deletedAt filter, so after recreating a same-name tag a save attached both the dead and the live tag (the doubled label).

The fix keeps the soft delete but hard-deletes the tag's TagsPosts rows (after the org-scoped update succeeds, so it can't be used cross-org), adds the deletedAt filter to the save-path name matching, and filters soft-deleted tags out of the post read queries. Existing orgs already have orphaned rows from past deletions, so the read filter hides them immediately and the save-path rewrite drops them the next time an affected post is saved — no data migration needed.

# Other information:

Tested end to end on a local run: reproduced the stuck remnant and the doubled label on main, then verified on this branch (via the calendar UI and direct DB checks) that orphans stop rendering immediately, re-saving drops the orphaned row, deleting a live tag cleans its assignments, and a recreated same-name tag attaches exactly once.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
