### PR TITLE
fix(tags): readable calendar tag labels on any tag color

### DIFF
--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -1069,7 +1069,7 @@ const CalendarItem: FC<{
       >
         <div
           className={clsx(
-            post?.tags?.[0]?.tag?.color ? 'mix-blend-difference' : '',
+            post?.tags?.[0]?.tag?.color ? 'text-shadow-tags' : '',
             'group-hover:hidden cursor-pointer'
           )}
         >
@@ -1079,7 +1079,7 @@ const CalendarItem: FC<{
           <div
             className={clsx(
               'hidden group-hover:block hover:underline cursor-pointer',
-              post?.tags?.[0]?.tag?.color && 'mix-blend-difference'
+              post?.tags?.[0]?.tag?.color && 'text-shadow-tags'
             )}
             onClick={copyDebugJson}
           >
@@ -1089,7 +1089,7 @@ const CalendarItem: FC<{
         <div
           className={clsx(
             'hidden group-hover:block hover:underline cursor-pointer',
-            post?.tags?.[0]?.tag?.color && 'mix-blend-difference'
+            post?.tags?.[0]?.tag?.color && 'text-shadow-tags'
           )}
           onClick={duplicatePost}
         >
@@ -1098,7 +1098,7 @@ const CalendarItem: FC<{
         <div
           className={clsx(
             'hidden group-hover:block hover:underline cursor-pointer',
-            post?.tags?.[0]?.tag?.color && 'mix-blend-difference'
+            post?.tags?.[0]?.tag?.color && 'text-shadow-tags'
           )}
           onClick={preview}
         >
@@ -1110,7 +1110,7 @@ const CalendarItem: FC<{
           <div
             className={clsx(
               'hidden group-hover:block hover:underline cursor-pointer',
-              post?.tags?.[0]?.tag?.color && 'mix-blend-difference'
+              post?.tags?.[0]?.tag?.color && 'text-shadow-tags'
             )}
             onClick={missingRelease}
           >
@@ -1120,7 +1120,7 @@ const CalendarItem: FC<{
           <div
             className={clsx(
               'hidden group-hover:block hover:underline cursor-pointer',
-              post?.tags?.[0]?.tag?.color && 'mix-blend-difference'
+              post?.tags?.[0]?.tag?.color && 'text-shadow-tags'
             )}
             onClick={statistics}
           >
@@ -1132,7 +1132,7 @@ const CalendarItem: FC<{
         <div
           className={clsx(
             'hidden group-hover:block hover:underline cursor-pointer',
-            post?.tags?.[0]?.tag?.color && 'mix-blend-difference'
+            post?.tags?.[0]?.tag?.color && 'text-shadow-tags'
           )}
           onClick={deletePost}
         >


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (UI).

# Why was this change needed?

Customer report: the tag label on calendar posts is unreadable for many tag colors.

The calendar tag bar renders the label and the hover action icons with mix-blend-difference over the raw tag color. That works for saturated colors but fails exactly on mid-tones and muted colors — on a mid-gray tag, white blended by difference lands on nearly the same gray, making the label and icons close to invisible.

This replaces the blend with the white-text + text-shadow-tags outline pattern already used for the same tag pills in the tags dropdown, so the bar is readable regardless of tag color. Posts without a tag color keep the existing bg-btnPrimary fallback unchanged.

# Other information:

Tested end to end on a local run with before/after screenshots of the same post and colors: on main the label and hover icons are near-invisible on mid-gray; on this branch both are crisply readable on mid-gray, pastel, saturated red, and purple.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
