### PR TITLE
fix(tags): attach tags on post creation after creating a tag in the modal

### DIFF
--- a/apps/frontend/src/components/launches/tags.component.tsx
+++ b/apps/frontend/src/components/launches/tags.component.tsx
@@ -98,12 +98,15 @@ export const TagsComponentInner: FC<{
       setTagValue(modify);
       onChange({
         target: {
-          value: modify,
+          value: modify.map((p: any) => ({
+            label: p.name,
+            value: p.name,
+          })),
           name,
         },
       });
     }
-  }, []);
+  }, [tagValue, name, onChange, mutate, modals, t]);
 
   const deleteTag = useCallback(
     async (tag: any, e: React.MouseEvent) => {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, post editor tag dropdown). `addTag` in `TagsComponentInner` (`apps/frontend/src/components/launches/tags.component.tsx`) now emits `{label, value}` objects through `onChange`, matching what the select and delete handlers in the same component already emit, and its `useCallback` dependency array lists `tagValue` instead of being empty so the closure no longer captures a stale selection. Previously a tag created from the "Add New Tag" modal was emitted as a raw tag object the post form does not understand, and it replaced rather than extended the existing selection. The tags API, tag colours and the dropdown rendering are unchanged.

# Why was this change needed?

Found while validating the tag deletion fixes: tags are silently dropped when a post is created right after creating a tag in the creation modal — the post saves fine but with zero tag assignments, no error anywhere.

Root cause is in the tags dropdown's addTag handler: it emitted the raw tag objects from the SWR mutate result instead of the {label, value} name mapping the save endpoint matches tags by, so the payload had no labels and the backend's by-name lookup matched nothing. It also had an empty useCallback dependency array, so a stale tagValue additionally dropped previously selected tags from the emitted list.

The fix makes addTag emit the same {label, value} mapping the row-toggle and deleteTag handlers already use, with the same dependency list.

# Other information:

Tested end to end on a local run with DB verification: reproduced both variants on main (modal-created tag saved zero TagsPosts rows; a pre-selected tag plus a newly created one both dropped), then verified on this branch that both flows attach correctly on the initial save and that edit-and-resave keeps assignments unchanged.

# QA

1. [ ] Open the calendar, create a new post and pick a channel
2. [ ] Open the tag dropdown and select an existing tag
3. [ ] Click "Add New Tag", create a tag called `qa-tag` and confirm
4. [ ] The dropdown shows both tags selected (first tag chip plus "+1")
5. [ ] Save the post, then reopen it - both the pre-existing tag and `qa-tag` are still attached
6. [ ] On the calendar the post renders with both tag colours

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
