### PR TITLE
feat(nostr): add account mention autocomplete

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.mention.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.mention.ts
@@ -1,0 +1,9 @@
+import { nip19 } from 'nostr-tools';
+
+export const formatNostrMention = (pubkey: string, name: string) => {
+  try {
+    return `nostr:${nip19.npubEncode(pubkey)}`;
+  } catch {
+    return `@${name.replace(/^@/, '')}`;
+  }
+};

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.spec.ts
@@ -1,0 +1,16 @@
+import { nip19 } from 'nostr-tools';
+import { formatNostrMention } from './nostr.mention';
+
+describe('formatNostrMention', () => {
+  it('formats a hex public key as a NIP-21 nostr URI', () => {
+    const pubkey = 'f'.repeat(64);
+
+    expect(formatNostrMention(pubkey, 'alice')).toBe(
+      `nostr:${nip19.npubEncode(pubkey)}`
+    );
+  });
+
+  it('falls back to a readable mention for an invalid public key', () => {
+    expect(formatNostrMention('invalid', '@alice')).toBe('@alice');
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -7,11 +7,18 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
 import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
-import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
+import {
+  getPublicKey,
+  Relay,
+  finalizeEvent,
+  nip19,
+  SimplePool,
+} from 'nostr-tools';
 
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { Integration } from '@prisma/client';
+import { formatNostrMention } from '@gitroom/nestjs-libraries/integrations/social/nostr.mention';
 
 // @ts-ignore
 global.WebSocket = WebSocket;
@@ -94,6 +101,82 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     }
 
     return {};
+  }
+
+  override async mention(
+    token: string,
+    data: { query: string },
+    id: string,
+    integration: Integration
+  ) {
+    const query = data.query.trim();
+    if (!query) return [];
+
+    let author: string | undefined;
+    if (/^[0-9a-f]{64}$/i.test(query)) {
+      author = query.toLowerCase();
+    } else if (query.toLowerCase().startsWith('npub1')) {
+      try {
+        const decoded = nip19.decode(query);
+        if (decoded.type === 'npub') author = decoded.data;
+      } catch {
+        // Fall back to a relay text search for malformed/incomplete npubs.
+      }
+    }
+
+    const events = await pool.querySync(
+      list,
+      author
+        ? { kinds: [0], authors: [author], limit: 1 }
+        : { kinds: [0], search: query, limit: 50 }
+    );
+
+    const latestByAuthor = new Map<string, (typeof events)[number]>();
+    for (const event of events) {
+      const previous = latestByAuthor.get(event.pubkey);
+      if (!previous || previous.created_at < event.created_at) {
+        latestByAuthor.set(event.pubkey, event);
+      }
+    }
+
+    const normalizedQuery = query.toLowerCase();
+    return [...latestByAuthor.values()]
+      .map((event) => {
+        try {
+          const profile = JSON.parse(event.content || '{}');
+          const label =
+            profile.display_name ||
+            profile.displayName ||
+            profile.name ||
+            nip19.npubEncode(event.pubkey).slice(0, 16);
+          const searchable = [
+            label,
+            profile.name,
+            profile.nip05,
+            nip19.npubEncode(event.pubkey),
+            event.pubkey,
+          ]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase();
+
+          if (!author && !searchable.includes(normalizedQuery)) return null;
+
+          return {
+            id: event.pubkey,
+            label,
+            image: profile.picture || profile.image || '',
+          };
+        } catch {
+          return null;
+        }
+      })
+      .filter((profile): profile is NonNullable<typeof profile> => !!profile)
+      .slice(0, 10);
+  }
+
+  mentionFormat(idOrHandle: string, name: string) {
+    return formatNostrMention(idOrHandle, name);
   }
 
   private async publish(pubkey: string, event: any) {


### PR DESCRIPTION
Closes #1603

## Summary
- search Nostr kind-0 profiles across the configured relays
- support display name, npub, and hex public-key lookup
- format selected profiles as `nostr:npub...` references
- keep the latest metadata event per pubkey and cap suggestions at 10

## Validation
- focused `formatNostrMention` assertions: 2/2 passing
- modified Nostr files pass TypeScript checking
- the repository-wide check remains blocked by pre-existing unrelated errors