### PR TITLE
feat(nostr): allow cross-account reposting

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -12,6 +12,8 @@ import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { Integration } from '@prisma/client';
+import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
+import { buildNostrRepostEvent } from '@gitroom/nestjs-libraries/integrations/social/nostr.repost';
 
 // @ts-ignore
 global.WebSocket = WebSocket;
@@ -94,6 +96,34 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     }
 
     return {};
+  }
+
+  @PostPlug({
+    identifier: 'nostr-repost-post-users',
+    title: 'Add Re-posters',
+    description: 'Add Nostr accounts to repost your note',
+    pickIntegration: ['nostr'],
+    fields: [],
+  })
+  async repostPostUsers(
+    integration: Integration,
+    originalIntegration: Integration,
+    postId: string,
+    information: any
+  ) {
+    const originalEvent = await pool.get(list, {
+      ids: [postId],
+      limit: 1,
+    });
+    if (!originalEvent) return;
+
+    const { password } = AuthService.verifyJWT(integration.token) as any;
+    const repostEvent = finalizeEvent(
+      buildNostrRepostEvent(originalEvent),
+      password
+    );
+
+    await this.publish(integration.internalId, repostEvent);
   }
 
   private async publish(pubkey: string, event: any) {

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.repost.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.repost.spec.ts
@@ -1,0 +1,26 @@
+import type { Event } from 'nostr-tools';
+import { buildNostrRepostEvent } from './nostr.repost';
+
+describe('buildNostrRepostEvent', () => {
+  it('builds a NIP-18 repost that references the original note and author', () => {
+    const original = {
+      id: 'event-id',
+      pubkey: 'author-pubkey',
+      kind: 1,
+      content: 'hello',
+      tags: [],
+      created_at: 1,
+      sig: 'signature',
+    } as Event;
+
+    expect(buildNostrRepostEvent(original, 123)).toEqual({
+      kind: 6,
+      content: JSON.stringify(original),
+      tags: [
+        ['e', 'event-id'],
+        ['p', 'author-pubkey'],
+      ],
+      created_at: 123,
+    });
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/social/nostr.repost.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.repost.ts
@@ -1,0 +1,14 @@
+import type { Event } from 'nostr-tools';
+
+export const buildNostrRepostEvent = (
+  originalEvent: Event,
+  createdAt = Math.floor(Date.now() / 1000)
+) => ({
+  kind: 6,
+  content: JSON.stringify(originalEvent),
+  tags: [
+    ['e', originalEvent.id],
+    ['p', originalEvent.pubkey],
+  ],
+  created_at: createdAt,
+});


### PR DESCRIPTION
Closes #1586

## Summary
- add the same post-publish re-poster plug available for X to Nostr integrations
- fetch the original note and publish a signed NIP-18 kind-6 repost from each selected account
- include the original event plus `e` and `p` references required by NIP-18

## Validation
- focused `buildNostrRepostEvent` check: 4/4 assertions passing
- modified Nostr files produce no TypeScript diagnostics