### PR TITLE
fix(ai-images): generate images via OpenaiService instead of DallEAPIWrapper

### DIFF
--- a/apps/orchestrator/src/app.module.ts
+++ b/apps/orchestrator/src/app.module.ts
@@ -3,6 +3,7 @@ import { PostActivity } from '@gitroom/orchestrator/activities/post.activity';
 import { getTemporalModule } from '@gitroom/nestjs-libraries/temporal/temporal.module';
 import { DatabaseModule } from '@gitroom/nestjs-libraries/database/prisma/database.module';
 import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
+import { AutopostActivity } from '@gitroom/orchestrator/activities/autopost.activity';
 import { EmailActivity } from '@gitroom/orchestrator/activities/email.activity';
 import { IntegrationsActivity } from '@gitroom/orchestrator/activities/integrations.activity';
 import { HealthController } from '@gitroom/orchestrator/health.controller';
@@ -10,6 +11,7 @@ import { HealthController } from '@gitroom/orchestrator/health.controller';
 const activities = [
   PostActivity,
   AutopostService,
+  AutopostActivity,
   EmailActivity,
   IntegrationsActivity,
 ];

--- a/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
@@ -5,7 +5,7 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import { END, START, StateGraph } from '@langchain/langgraph';
-import { ChatOpenAI, DallEAPIWrapper } from '@langchain/openai';
+import { ChatOpenAI } from '@langchain/openai';
 import { TavilySearch } from '@langchain/tavily';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
@@ -16,6 +16,7 @@ import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/me
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { GeneratorDto } from '@gitroom/nestjs-libraries/dtos/generator/generator.dto';
 import { generationError } from '@gitroom/nestjs-libraries/openai/generation.error';
+import { OpenaiService } from '@gitroom/nestjs-libraries/openai/openai.service';
 
 const tools = !process.env.TAVILY_API_KEY
   ? []
@@ -26,11 +27,6 @@ const model = new ChatOpenAI({
   apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
   model: 'gpt-4.1',
   temperature: 0.7,
-});
-
-const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'chatgpt-image-latest',
 });
 
 interface WorkflowChannelsState {
@@ -107,7 +103,8 @@ export class AgentGraphService {
   private storage = UploadFactory.createStorage();
   constructor(
     private _postsService: PostsService,
-    private _mediaService: MediaService
+    private _mediaService: MediaService,
+    private _openaiService: OpenaiService
   ) {}
   static state = () =>
     new StateGraph<WorkflowChannelsState>({
@@ -322,10 +319,10 @@ export class AgentGraphService {
     try {
       const newContent = await Promise.all(
         (state.content || []).map(async (p) => {
-          const image = await dalle.invoke(p.prompt!);
+          const image = await this._openaiService.generateImage(p.prompt!);
           return {
             ...p,
-            image,
+            image: 'data:image/png;base64,' + image,
           };
         })
       );

--- a/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/autopost/autopost.service.ts
@@ -6,7 +6,7 @@ import { END, START, StateGraph } from '@langchain/langgraph';
 import { AutoPost, Integration } from '@prisma/client';
 import { BaseMessage } from '@langchain/core/messages';
 import striptags from 'striptags';
-import { ChatOpenAI, DallEAPIWrapper } from '@langchain/openai';
+import { ChatOpenAI } from '@langchain/openai';
 import { JSDOM } from 'jsdom';
 import { z } from 'zod';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
@@ -19,6 +19,8 @@ import { TypedSearchAttributes } from '@temporalio/common';
 import {
   organizationId,
 } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
+import { OpenaiService } from '@gitroom/nestjs-libraries/openai/openai.service';
+import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 const parser = new Parser();
 
 interface WorkflowChannelsState {
@@ -41,11 +43,6 @@ const model = new ChatOpenAI({
   temperature: 0.7,
 });
 
-const dalle = new DallEAPIWrapper({
-  apiKey: process.env.OPENAI_API_KEY || 'sk-proj-',
-  model: 'chatgpt-image-latest',
-});
-
 const generateContent = z.object({
   socialMediaPostContent: z
     .string()
@@ -60,11 +57,13 @@ const dallePrompt = z.object({
 
 @Injectable()
 export class AutopostService {
+  private storage = UploadFactory.createStorage();
   constructor(
     private _autopostsRepository: AutopostRepository,
     private _temporalService: TemporalService,
     private _integrationService: IntegrationService,
-    private _postsService: PostsService
+    private _postsService: PostsService,
+    private _openaiService: OpenaiService
   ) {}
 
   async stopAll(org: string) {
@@ -257,7 +256,12 @@ export class AutopostService {
           content: state.load.description || state.description,
         });
 
-    const image = await dalle.invoke(generatedTextToBeSentToDallE);
+    const generatedImage = await this._openaiService.generateImage(
+      generatedTextToBeSentToDallE
+    );
+    const image = await this.storage.uploadSimple(
+      'data:image/png;base64,' + generatedImage
+    );
 
     return { ...state, image };
   }

--- a/libraries/nestjs-libraries/src/openai/openai.service.ts
+++ b/libraries/nestjs-libraries/src/openai/openai.service.ts
@@ -29,6 +29,10 @@ export class OpenaiService {
       })
     ).data[0];
 
+    if (!generate?.b64_json) {
+      throw new Error('Image generation returned no image data');
+    }
+
     return generate.b64_json;
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Two flows still generated images through LangChain's DallEAPIWrapper, which always sends `response_format: 'url'`. gpt-image models (`chatgpt-image-latest`, and `gpt-image-1` before it) reject that parameter, so every image request returned a 400:

- The "Generate Posts" wizard always failed with "AI generation failed, please try again later." whenever images were enabled.
- Autopost with "Generate Picture" has been silently failing since the gpt-image-1 switch — and was additionally broken one layer up: since the temporal refactor, `AutopostActivity` was never registered in the orchestrator's activities list, so every `autoPost` run failed with NotFoundError before reaching the image code.

The rest of the codebase (media library, agent chat image tool) was already migrated to `OpenaiService.generateImage`, which handles gpt-image correctly (base64, no `response_format`). This brings the last two call sites in line: the generator attaches the result as a `data:` URL (existing upload path already supports it), and Autopost uploads it via `uploadSimple` so the post references a permanent hosted path instead of a short-lived OpenAI URL. `AutopostActivity` is now registered.

Per team decision: use the chatgpt-image model, consume no `ai_images` credits on these paths (unchanged pre-existing behavior), and impose no limits.

# Other information:

Discussed with the team before implementing (model choice, no credits, no limits).

Tested locally end-to-end:
- Generator with pictures: posts drafted with a generated image attached and saved to the media library; text-only generation unaffected; safety rejections surface the curated 422 message through `generationError`.
- Autopost against a live Atom feed: drafts created per integration with the generated image uploaded to storage (verified reachable), `lastUrl` advanced.
- No credits consumed: `Credits` row count for `ai_images` verified unchanged before/after a generator run with images.
- Backend and orchestrator production builds pass.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)