### PR TITLE
fix(x-provider): avoid forcing gif buffer format on non-gif media uploads

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -559,14 +559,7 @@ export class XProvider extends SocialAbstract implements SocialProvider {
                   hasExtension(m.path, 'mp4')
                     ? this.uploadVideoChunked(client, m.path)
                     : client.v2.uploadMedia(
-                        await sharp(await readOrFetch(m.path), {
-                          animated: lookup(m.path) === 'image/gif',
-                        })
-                          .resize({
-                            width: 1000,
-                          })
-                          .gif()
-                          .toBuffer(),
+                        Buffer.from(await readOrFetch(m.path)),
                         {
                           media_type: (lookup(m.path) || '') as any,
                         }


### PR DESCRIPTION
### Problem
When uploading non-GIF images (JPEG, PNG, WebP) to X (Twitter), `XProvider.uploadMedia` was executing `sharp(buffer).resize({ width: 1000 }).gif().toBuffer()`, which forced GIF formatting on the binary buffer while passing `media_type: image/jpeg` or `image/png` to Twitter API. This caused Twitter to reject the upload with a 400 Bad Request error (`ApplicationFailure: Unknown Error`).

### Fix
Replaced `.gif().toBuffer()` conversion with clean raw buffer streaming (`Buffer.from(await readOrFetch(m.path))`), allowing JPEG, PNG, and GIF images to be uploaded to Twitter API v2 correctly with their matching MIME headers.