### PR TITLE
fix: stream provider media uploads instead of buffering files in memory

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -180,9 +180,12 @@ export abstract class SocialAbstract {
   protected async mediaSize(path: string, identifier = ''): Promise<number> {
     if (path.indexOf('http') === 0) {
       // the media path is user-influenced, keep the SSRF-safe dispatcher that
-      // this.fetch applies to every other outbound request
+      // this.fetch applies to every other outbound request. identity encoding
+      // so content-length matches the bytes a later GET actually streams
+      // (fetch transparently decompresses encoded bodies).
       const head = await fetch(path, {
         method: 'HEAD',
+        headers: { 'accept-encoding': 'identity' },
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
       const length = Number(head.headers.get('content-length'));
@@ -213,7 +216,10 @@ export abstract class SocialAbstract {
   ): Promise<Buffer> {
     if (path.indexOf('http') === 0) {
       const response = await fetch(path, {
-        headers: { Range: `bytes=${start}-${end}` },
+        headers: {
+          Range: `bytes=${start}-${end}`,
+          'accept-encoding': 'identity',
+        },
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
       // Anything but 206 means the server ignored the Range header: buffering
@@ -250,7 +256,10 @@ export abstract class SocialAbstract {
       return createReadStream(path);
     }
 
+    // identity encoding so the streamed byte count matches the size mediaSize
+    // reported - a decompressed body would overflow any declared length.
     const response = await fetch(path, {
+      headers: { 'accept-encoding': 'identity' },
       dispatcher: getSsrfSafeDispatcher(),
     } as any);
 
@@ -287,7 +296,10 @@ export abstract class SocialAbstract {
 
       const status = err.response.status || 500;
       const data = err.response.data;
-      const json = typeof data === 'string' ? data : safeStringify(data || {});
+      // '|| {}' / "|| '{}'" match this.fetch, which never hands handleErrors
+      // an empty string.
+      const json =
+        (typeof data === 'string' ? data : safeStringify(data || {})) || '{}';
       const handleError = this.handleErrors(json, status);
 
       if (

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -5,6 +5,7 @@ import { ApplicationFailure } from '@temporalio/activity';
 import { readOrFetch } from '@gitroom/helpers/utils/read.or.fetch';
 import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import sharp from 'sharp';
+import { createReadStream, statSync } from 'fs';
 
 export type ValidityMedia = {
   path: string;
@@ -171,6 +172,122 @@ export abstract class SocialAbstract {
       await readOrFetch(url)
     ).metadata();
     return { width, height };
+  }
+
+  // Resolves the total byte size of the media without loading it into memory:
+  // a HEAD request for remote URLs, statSync for local files.
+  protected async mediaSize(path: string, identifier = ''): Promise<number> {
+    if (path.indexOf('http') === 0) {
+      // the media path is user-influenced, keep the SSRF-safe dispatcher that
+      // this.fetch applies to every other outbound request
+      const head = await fetch(path, {
+        method: 'HEAD',
+        dispatcher: getSsrfSafeDispatcher(),
+      } as any);
+      const length = head.headers.get('content-length');
+      // A failed HEAD can still carry a content-length (of the error body),
+      // which would register the media with a garbage size downstream.
+      if (!head.ok || !length) {
+        throw new BadBody(
+          identifier,
+          '{}',
+          Buffer.from('{}'),
+          'Could not determine the media size for upload'
+        );
+      }
+      return Number(length);
+    }
+
+    return statSync(path).size;
+  }
+
+  // Reads a single [start, end] byte range into memory. Used by providers whose
+  // chunked-upload APIs require a Buffer per segment: only one small chunk is
+  // resident at a time, never the whole file.
+  protected async mediaChunk(
+    path: string,
+    start: number,
+    end: number
+  ): Promise<Buffer> {
+    if (path.indexOf('http') === 0) {
+      const response = await fetch(path, {
+        headers: { Range: `bytes=${start}-${end}` },
+        dispatcher: getSsrfSafeDispatcher(),
+      } as any);
+      // Anything but 206 means the server ignored the Range header: buffering
+      // response.body here would silently load the whole file into memory and
+      // upload corrupted chunks.
+      if (response.status !== 206) {
+        throw new BadBody(
+          '',
+          '{}',
+          Buffer.from('{}'),
+          `Media server did not honor the range request (status ${response.status})`
+        );
+      }
+      return Buffer.from(await response.arrayBuffer());
+    }
+
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      createReadStream(path, { start, end })
+        .on('data', (chunk) => chunks.push(chunk as Buffer))
+        .on('end', () => resolve(Buffer.concat(chunks)))
+        .on('error', reject);
+    });
+  }
+
+  // Streamed request bodies can't be replayed by this.fetch's retry, so
+  // providers wrap streamed uploads in a factory that rebuilds the request
+  // (re-opening its source streams) on every attempt. Errors carrying a
+  // `response` (axios errors, or a thrown { response: { status, data } })
+  // go through the same retry and handleErrors classification rules as
+  // this.fetch; anything else is rethrown untouched so Temporal keeps its
+  // usual retry behavior.
+  protected async runStreamedUpload<T>(
+    func: () => Promise<T>,
+    identifier = '',
+    totalRetries = 0
+  ): Promise<T> {
+    try {
+      return await func();
+    } catch (err: any) {
+      if (!err?.response) {
+        throw err;
+      }
+
+      const status = err.response.status || 500;
+      const data = err.response.data;
+      const json = typeof data === 'string' ? data : safeStringify(data || {});
+      const handleError = this.handleErrors(json, status);
+
+      if (
+        totalRetries <= 2 &&
+        (status === 429 ||
+          (status === 500 && !handleError) ||
+          handleError?.type === 'retry' ||
+          json.includes('rate_limit_exceeded') ||
+          json.includes('Rate limit'))
+      ) {
+        await timer(5000);
+        return this.runStreamedUpload(func, identifier, totalRetries + 1);
+      }
+
+      if (
+        (status === 401 &&
+          (handleError?.type === 'refresh-token' || !handleError)) ||
+        handleError?.type === 'refresh-token'
+      ) {
+        throw new RefreshToken(identifier, json, '{}', handleError?.value);
+      }
+
+      throw new BadBody(
+        identifier,
+        json,
+        '{}',
+        handleError?.value || 'Unknown Error'
+      );
+    }
   }
 
   public async mention(

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -6,6 +6,7 @@ import { readOrFetch } from '@gitroom/helpers/utils/read.or.fetch';
 import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import sharp from 'sharp';
 import { createReadStream, statSync } from 'fs';
+import { Readable } from 'stream';
 
 export type ValidityMedia = {
   path: string;
@@ -207,7 +208,8 @@ export abstract class SocialAbstract {
   protected async mediaChunk(
     path: string,
     start: number,
-    end: number
+    end: number,
+    identifier = ''
   ): Promise<Buffer> {
     if (path.indexOf('http') === 0) {
       const response = await fetch(path, {
@@ -219,7 +221,7 @@ export abstract class SocialAbstract {
       // upload corrupted chunks.
       if (response.status !== 206) {
         throw new BadBody(
-          '',
+          identifier,
           '{}',
           Buffer.from('{}'),
           `Media server did not honor the range request (status ${response.status})`
@@ -235,6 +237,33 @@ export abstract class SocialAbstract {
         .on('end', () => resolve(Buffer.concat(chunks)))
         .on('error', reject);
     });
+  }
+
+  // Opens the media as a Node stream. The media path is user-influenced, so
+  // remote URLs go through the same SSRF-safe dispatcher as every other
+  // outbound request - never fetch these with plain axios/fetch.
+  protected async mediaStream(
+    path: string,
+    identifier = ''
+  ): Promise<Readable> {
+    if (path.indexOf('http') !== 0) {
+      return createReadStream(path);
+    }
+
+    const response = await fetch(path, {
+      dispatcher: getSsrfSafeDispatcher(),
+    } as any);
+
+    if (!response.ok || !response.body) {
+      throw new BadBody(
+        identifier,
+        '{}',
+        Buffer.from('{}'),
+        'Could not read the media for upload'
+      );
+    }
+
+    return Readable.fromWeb(response.body as any);
   }
 
   // Streamed request bodies can't be replayed by this.fetch's retry, so

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -185,10 +185,10 @@ export abstract class SocialAbstract {
         method: 'HEAD',
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
-      const length = head.headers.get('content-length');
+      const length = Number(head.headers.get('content-length'));
       // A failed HEAD can still carry a content-length (of the error body),
-      // which would register the media with a garbage size downstream.
-      if (!head.ok || !length) {
+      // and a zero/NaN size would poison chunk-count math downstream.
+      if (!head.ok || !Number.isFinite(length) || length <= 0) {
         throw new BadBody(
           identifier,
           '{}',
@@ -196,7 +196,7 @@ export abstract class SocialAbstract {
           'Could not determine the media size for upload'
         );
       }
-      return Number(length);
+      return length;
     }
 
     return statSync(path).size;

--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -79,6 +79,8 @@ async function uploadVideo(
   // and the bytes are streamed straight from the source into the upload.
   const headResponse = await fetch(videoPath, {
     method: 'HEAD',
+    // identity encoding so content-length matches the bytes the GET streams
+    headers: { 'accept-encoding': 'identity' },
     // @ts-ignore - undici-only option; blocks SSRF to internal IPs
     dispatcher: getSsrfSafeDispatcher(),
   });
@@ -93,6 +95,7 @@ async function uploadVideo(
   }
 
   const videoResponse = await fetch(videoPath, {
+    headers: { 'accept-encoding': 'identity' },
     // @ts-ignore - undici-only option; blocks SSRF to internal IPs
     dispatcher: getSsrfSafeDispatcher(),
   });

--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -23,6 +23,7 @@ import dayjs from 'dayjs';
 import { Integration } from '@prisma/client';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { isSafePublicHttpsUrl } from '@gitroom/nestjs-libraries/dtos/webhooks/webhook.url.validator';
+import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import sharp from 'sharp';
 import { Plug } from '@gitroom/helpers/decorators/plug.decorator';
 import { timer } from '@gitroom/helpers/utils/timer';
@@ -74,22 +75,32 @@ async function uploadVideo(
     exp: Date.now() / 1000 + 60 * 30, // 30 minutes
   });
 
-  async function downloadVideo(
-    url: string
-  ): Promise<{ video: Buffer; size: number }> {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch video: ${response.statusText}`);
-    }
-    const arrayBuffer = await response.arrayBuffer();
-    const video = Buffer.from(arrayBuffer);
-    const size = video.length;
-    return { video, size };
+  // The video is never buffered in memory: the size comes from a HEAD request
+  // and the bytes are streamed straight from the source into the upload.
+  const headResponse = await fetch(videoPath, {
+    method: 'HEAD',
+    // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+    dispatcher: getSsrfSafeDispatcher(),
+  });
+  const videoSize = Number(headResponse.headers.get('content-length') || 0);
+  if (!headResponse.ok || !videoSize) {
+    throw new BadBody(
+      'bluesky',
+      '{}',
+      {} as any,
+      'Could not determine the video size for Bluesky upload'
+    );
   }
 
-  const video = await downloadVideo(videoPath);
+  const videoResponse = await fetch(videoPath, {
+    // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+    dispatcher: getSsrfSafeDispatcher(),
+  });
+  if (!videoResponse.ok) {
+    throw new Error(`Failed to fetch video: ${videoResponse.statusText}`);
+  }
 
-  console.log('Downloaded video', videoPath, video.size);
+  console.log('Uploading video', videoPath, videoSize);
 
   const uploadUrl = new URL(
     'https://video.bsky.app/xrpc/app.bsky.video.uploadVideo'
@@ -102,10 +113,12 @@ async function uploadVideo(
     headers: {
       Authorization: `Bearer ${serviceAuth.token}`,
       'Content-Type': 'video/mp4',
-      'Content-Length': video.size.toString(),
+      'Content-Length': videoSize.toString(),
     },
-    body: video.video,
-  });
+    body: videoResponse.body,
+    // Required by undici when streaming a request body.
+    duplex: 'half',
+  } as any);
 
   const jobStatus = (await uploadResponse.json()) as AppBskyVideoDefs.JobStatus;
   console.log('JobId:', jobStatus.jobId);

--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -96,7 +96,7 @@ async function uploadVideo(
     // @ts-ignore - undici-only option; blocks SSRF to internal IPs
     dispatcher: getSsrfSafeDispatcher(),
   });
-  if (!videoResponse.ok) {
+  if (!videoResponse.ok || !videoResponse.body) {
     throw new Error(`Failed to fetch video: ${videoResponse.statusText}`);
   }
 

--- a/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
@@ -9,6 +9,8 @@ import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.ab
 import { Integration } from '@prisma/client';
 import { DiscordDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/discord.dto';
 import { Tool } from '@gitroom/nestjs-libraries/integrations/tool.decorator';
+import axios from 'axios';
+import FormDataUpload from 'form-data';
 
 export class DiscordProvider extends SocialAbstract implements SocialProvider {
   override maxConcurrentJob = 5; // Discord has generous rate limits for webhook posting
@@ -135,6 +137,59 @@ export class DiscordProvider extends SocialAbstract implements SocialProvider {
       }));
   }
 
+  // Builds the multipart message and streams each attachment straight from its
+  // source (size from a HEAD request) so files are never buffered in memory.
+  // runStreamedUpload rebuilds the whole form per attempt (a consumed stream
+  // can't be replayed) and keeps handleErrors classification.
+  private async sendMessageWithMedia(
+    channel: string,
+    message: string,
+    media: PostDetails['media']
+  ) {
+    return this.runStreamedUpload(async () => {
+      const form = new FormDataUpload();
+      form.append(
+        'payload_json',
+        JSON.stringify({
+          content: message.replace(/\[\[\[(@.*?)]]]/g, (match, p1) => {
+            return `<${p1}>`;
+          }),
+          attachments: media?.map((p, index) => ({
+            id: index,
+            description: `Picture ${index}`,
+            filename: p.path.split('/').pop(),
+          })),
+        })
+      );
+
+      let index = 0;
+      for (const item of media || []) {
+        const fileSize = await this.mediaSize(item.path, this.identifier);
+        const { data: stream } = await axios.get(item.path, {
+          responseType: 'stream',
+        });
+        form.append(`files[${index}]`, stream, {
+          filename: item.path.split('/').pop(),
+          knownLength: fileSize,
+        });
+        index++;
+      }
+
+      const { data } = await axios.post(
+        `https://discord.com/api/channels/${channel}/messages`,
+        form,
+        {
+          headers: {
+            ...form.getHeaders(),
+            Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN_ID}`,
+          },
+        }
+      );
+
+      return data;
+    }, this.identifier);
+  }
+
   async post(
     id: string,
     accessToken: string,
@@ -143,42 +198,11 @@ export class DiscordProvider extends SocialAbstract implements SocialProvider {
     const [firstPost] = postDetails;
     const channel = firstPost.settings.channel;
 
-    const form = new FormData();
-    form.append(
-      'payload_json',
-      JSON.stringify({
-        content: firstPost.message.replace(/\[\[\[(@.*?)]]]/g, (match, p1) => {
-          return `<${p1}>`;
-        }),
-        attachments: firstPost.media?.map((p, index) => ({
-          id: index,
-          description: `Picture ${index}`,
-          filename: p.path.split('/').pop(),
-        })),
-      })
+    const data = await this.sendMessageWithMedia(
+      channel,
+      firstPost.message,
+      firstPost.media
     );
-
-    let index = 0;
-    for (const media of firstPost.media || []) {
-      const loadMedia = await fetch(media.path);
-
-      form.append(
-        `files[${index}]`,
-        await loadMedia.blob(),
-        media.path.split('/').pop()
-      );
-      index++;
-    }
-
-    const data = await (
-      await this.fetch(`https://discord.com/api/channels/${channel}/messages`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN_ID}`,
-        },
-        body: form,
-      })
-    ).json();
 
     return [
       {
@@ -226,45 +250,11 @@ export class DiscordProvider extends SocialAbstract implements SocialProvider {
       threadChannel = threadId;
     }
 
-    const form = new FormData();
-    form.append(
-      'payload_json',
-      JSON.stringify({
-        content: commentPost.message.replace(/\[\[\[(@.*?)]]]/g, (match, p1) => {
-            return `<${p1}>`;
-        }),
-        attachments: commentPost.media?.map((p, index) => ({
-          id: index,
-          description: `Picture ${index}`,
-          filename: p.path.split('/').pop(),
-        })),
-      })
+    const data = await this.sendMessageWithMedia(
+      threadChannel,
+      commentPost.message,
+      commentPost.media
     );
-
-    let index = 0;
-    for (const media of commentPost.media || []) {
-      const loadMedia = await fetch(media.path);
-
-      form.append(
-        `files[${index}]`,
-        await loadMedia.blob(),
-        media.path.split('/').pop()
-      );
-      index++;
-    }
-
-    const data = await (
-      await this.fetch(
-        `https://discord.com/api/channels/${threadChannel}/messages`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN_ID}`,
-          },
-          body: form,
-        }
-      )
-    ).json();
 
     return [
       {

--- a/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/discord.provider.ts
@@ -165,9 +165,7 @@ export class DiscordProvider extends SocialAbstract implements SocialProvider {
       let index = 0;
       for (const item of media || []) {
         const fileSize = await this.mediaSize(item.path, this.identifier);
-        const { data: stream } = await axios.get(item.path, {
-          responseType: 'stream',
-        });
+        const stream = await this.mediaStream(item.path, this.identifier);
         form.append(`files[${index}]`, stream, {
           filename: item.path.split('/').pop(),
           knownLength: fileSize,

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -19,7 +19,6 @@ import { Integration } from '@prisma/client';
 import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
 import { LinkedinDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/linkedin.dto';
 import imageToPDF from 'image-to-pdf';
-import { createReadStream, statSync } from 'fs';
 import { Readable } from 'stream';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
@@ -263,12 +262,19 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     fileName: string,
     accessToken: string,
     personId: string,
-    picture: any,
+    // Either the media bytes (images / converted PDFs) or a `{ path }`
+    // descriptor for videos, which are streamed chunk-by-chunk from the source
+    // instead of being held in memory.
+    picture: Buffer | { path: string },
     type = 'personal' as 'company' | 'personal'
   ) {
     // Determine the appropriate endpoint based on file type
     const isVideo = hasExtension(fileName, 'mp4');
     const isPdf = hasExtension(fileName, 'pdf');
+
+    const fileSizeBytes = Buffer.isBuffer(picture)
+      ? picture.length
+      : await this.mediaSize(picture.path, this.identifier);
 
     let endpoint: string;
     if (isVideo) {
@@ -278,11 +284,6 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     } else {
       endpoint = 'images';
     }
-
-    // Videos arrive as a path/URL (not a Buffer) so the file is never held in
-    // memory whole: the size comes from a HEAD request / stat, and each 2MB
-    // part is fetched with a ranged GET right before its PUT.
-    const videoSize = isVideo ? await this.videoSize(picture) : 0;
 
     const {
       value: { uploadUrl, image, video, document, uploadInstructions, ...all },
@@ -305,7 +306,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
                   : `urn:li:organization:${personId}`,
               ...(isVideo
                 ? {
-                    fileSizeBytes: videoSize,
+                    fileSizeBytes,
                     uploadCaptions: false,
                     uploadThumbnail: false,
                   }
@@ -323,8 +324,18 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     if (isVideo) {
       // Only the Videos API uses multipart chunked uploads. Each 2MB part is
       // PUT separately and the returned etags are passed to finalizeUpload.
-      for (let i = 0; i < videoSize; i += 1024 * 1024 * 2) {
-        const end = Math.min(i + 1024 * 1024 * 2, videoSize) - 1;
+      // Each part is read on demand (mediaChunk) so only one 2MB chunk is ever
+      // resident in memory instead of the whole video.
+      const chunkSize = 1024 * 1024 * 2;
+      for (let i = 0; i < fileSizeBytes; i += chunkSize) {
+        const body = Buffer.isBuffer(picture)
+          ? picture.slice(i, i + chunkSize)
+          : await this.mediaChunk(
+              picture.path,
+              i,
+              Math.min(i + chunkSize, fileSizeBytes) - 1
+            );
+
         const upload = await this.fetch(
           sendUrlRequest,
           {
@@ -335,7 +346,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
               Authorization: `Bearer ${accessToken}`,
               'Content-Type': 'application/octet-stream',
             },
-            body: await this.videoChunk(picture, i, end),
+            body,
           },
           'linkedin',
           0,
@@ -359,7 +370,9 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
             Authorization: `Bearer ${accessToken}`,
             ...(isPdf ? { 'Content-Type': 'application/pdf' } : {}),
           },
-          body: picture,
+          // Only videos arrive as a { path } descriptor; images and documents
+          // are always a Buffer.
+          body: picture as Buffer,
         },
         'linkedin',
         0,
@@ -583,109 +596,56 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     personId: string,
     type: 'company' | 'personal'
   ): Promise<Record<string, string[]>> {
-    const mediaUploads = await Promise.all(
-      postDetails.flatMap(
-        (post) =>
-          post.media?.map(async (media) => {
-            // Videos are passed through as their path/URL: uploadPicture
-            // downloads them in 2MB ranges instead of buffering the whole file.
-            let mediaBuffer: Buffer | string;
+    // Media is uploaded sequentially on purpose: uploading everything with
+    // Promise.all holds every file in memory at the same time.
+    const mediaUploads: Record<string, string[]> = {};
+    for (const post of postDetails) {
+      for (const media of post.media || []) {
+        let mediaBuffer: Buffer | { path: string };
 
-            // Check if media has a buffer (from PDF conversion)
-            if (
-              media &&
-              typeof media === 'object' &&
-              'buffer' in media &&
-              Buffer.isBuffer(media.buffer)
-            ) {
-              mediaBuffer = (media as any).buffer;
-            } else if (hasExtension(media.path, 'mp4')) {
-              mediaBuffer = media.path;
-            } else {
-              mediaBuffer = await this.prepareMediaBuffer(media.path);
-            }
+        // Check if media has a buffer (from PDF conversion)
+        if (
+          media &&
+          typeof media === 'object' &&
+          'buffer' in media &&
+          Buffer.isBuffer(media.buffer)
+        ) {
+          mediaBuffer = (media as any).buffer;
+        } else if (hasExtension(media.path, 'mp4')) {
+          // Videos are never buffered: uploadPicture streams them from the
+          // source chunk-by-chunk.
+          mediaBuffer = { path: media.path };
+        } else {
+          mediaBuffer = await this.prepareMediaBuffer(media.path);
+        }
 
-            const uploadedMediaId = await this.uploadPicture(
-              media.path,
-              accessToken,
-              personId,
-              mediaBuffer,
-              type
-            );
-
-            return {
-              id: uploadedMediaId,
-              postId: post.id,
-            };
-          }) || []
-      )
-    );
-
-    return mediaUploads.reduce((acc, upload) => {
-      if (!upload?.id) return acc;
-
-      acc[upload.postId] = acc[upload.postId] || [];
-      acc[upload.postId].push(upload.id);
-      return acc;
-    }, {} as Record<string, string[]>);
-  }
-
-  // Resolves the total byte size of the video without loading it into memory:
-  // a HEAD request for remote URLs, statSync for local files.
-  private async videoSize(path: string): Promise<number> {
-    if (path.indexOf('http') === 0) {
-      const head = await fetch(path, { method: 'HEAD' });
-      const length = head.headers.get('content-length');
-      if (!length) {
-        throw new BadBody(
-          'linkedin-error-upload',
-          '{}',
-          Buffer.from('{}'),
-          'Could not determine the video size for LinkedIn upload'
+        const uploadedMediaId = await this.uploadPicture(
+          media.path,
+          accessToken,
+          personId,
+          mediaBuffer,
+          type
         );
+
+        if (!uploadedMediaId) {
+          continue;
+        }
+
+        mediaUploads[post.id] = mediaUploads[post.id] || [];
+        mediaUploads[post.id].push(uploadedMediaId);
       }
-      return Number(length);
     }
 
-    return statSync(path).size;
-  }
-
-  // Returns only the [start, end] byte window of the video as a Buffer (a
-  // ranged GET for remote URLs, a ranged read for local files), so memory is
-  // bounded by the part size. A Buffer (not a stream) because this.fetch may
-  // retry the PUT, which would fail with a consumed one-shot stream body.
-  private async videoChunk(
-    path: string,
-    start: number,
-    end: number
-  ): Promise<Buffer> {
-    if (path.indexOf('http') === 0) {
-      const response = await fetch(path, {
-        headers: { Range: `bytes=${start}-${end}` },
-      });
-      // A 200 means the origin ignored the Range header and is sending the
-      // whole file: uploading it as this part would silently corrupt the
-      // video, so fail loudly instead.
-      if (response.status !== 206) {
-        throw new BadBody(
-          'linkedin-error-upload',
-          '{}',
-          Buffer.from('{}'),
-          `Media server ignored the ranged request (status ${response.status}); it must support HTTP Range requests for chunked LinkedIn uploads`
-        );
-      }
-      return Buffer.from(await response.arrayBuffer());
-    }
-
-    return this.streamToBuffer(createReadStream(path, { start, end }));
+    return mediaUploads;
   }
 
   private async prepareMediaBuffer(mediaUrl: string): Promise<Buffer> {
     const isGif = lookup(mediaUrl) === 'image/gif';
 
-    // GIFs pass through untouched (sharp would break animation).
+    // GIFs pass through untouched (sharp would break animation). Videos never
+    // reach this function - they are streamed by uploadPicture instead.
     if (isGif) {
-      return Buffer.from(await readOrFetch(mediaUrl));
+      return readOrFetch(mediaUrl);
     }
 
     const mime = lookup(mediaUrl);

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -333,7 +333,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
           : await this.mediaChunk(
               picture.path,
               i,
-              Math.min(i + chunkSize, fileSizeBytes) - 1
+              Math.min(i + chunkSize, fileSizeBytes) - 1,
+              this.identifier
             );
 
         const upload = await this.fetch(

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -646,7 +646,9 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     // GIFs pass through untouched (sharp would break animation). Videos never
     // reach this function - they are streamed by uploadPicture instead.
     if (isGif) {
-      return readOrFetch(mediaUrl);
+      // Buffer.from keeps the return type a real Buffer regardless of what
+      // readOrFetch yields - uploadPicture branches on Buffer.isBuffer.
+      return Buffer.from(await readOrFetch(mediaUrl));
     }
 
     const mime = lookup(mediaUrl);

--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -146,6 +146,8 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
     // a consumed stream can't be replayed.
     const media = await this.runStreamedUpload<{ id: string }>(async () => {
       const fileResponse = await fetch(fileUrl, {
+        // identity encoding so content-length matches the streamed bytes
+        headers: { 'accept-encoding': 'identity' },
         // @ts-ignore - undici-only option; blocks SSRF to internal IPs
         dispatcher: getSsrfSafeDispatcher(),
       });

--- a/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/mastodon.provider.ts
@@ -10,6 +10,8 @@ import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/s
 import dayjs from 'dayjs';
 import { Integration } from '@prisma/client';
 import { number, string } from 'yup';
+import FormDataUpload from 'form-data';
+import { PassThrough, Readable } from 'stream';
 
 export class MastodonProvider extends SocialAbstract implements SocialProvider {
   override maxConcurrentJob = 5; // Mastodon instances typically have generous limits
@@ -137,26 +139,68 @@ export class MastodonProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     alt?: string
   ) {
-    const form = new FormData();
-    form.append(
-      'file',
-      await fetch(fileUrl, {
+    // The file is streamed straight from storage into the Mastodon upload
+    // request instead of being buffered in memory. Both requests keep the
+    // SSRF-safe dispatcher because the URLs are not fully under our control,
+    // and the whole request is rebuilt per attempt by runStreamedUpload since
+    // a consumed stream can't be replayed.
+    const media = await this.runStreamedUpload<{ id: string }>(async () => {
+      const fileResponse = await fetch(fileUrl, {
         // @ts-ignore - undici-only option; blocks SSRF to internal IPs
         dispatcher: getSsrfSafeDispatcher(),
-      }).then((r) => r.blob())
-    );
-    if (alt) {
-      form.append('description', alt);
-    }
-    const media = await (
-      await this.fetch(`${instanceUrl}/api/v1/media`, {
+      });
+      if (!fileResponse.ok || !fileResponse.body) {
+        throw new Error(`Failed to fetch media: ${fileResponse.statusText}`);
+      }
+      const contentLength = Number(
+        fileResponse.headers.get('content-length') || 0
+      );
+
+      const form = new FormDataUpload();
+      form.append('file', Readable.fromWeb(fileResponse.body as any), {
+        filename: fileUrl.split('/').pop()?.split('?')[0] || 'file',
+        ...(contentLength ? { knownLength: contentLength } : {}),
+      });
+      if (alt) {
+        form.append('description', alt);
+      }
+
+      const mediaResponse = await fetch(`${instanceUrl}/api/v1/media`, {
         method: 'POST',
         headers: {
+          ...form.getHeaders(),
+          // Some Mastodon front-ends reject chunked multipart, so send an
+          // exact Content-Length whenever the source size is known.
+          ...(contentLength
+            ? { 'Content-Length': String(form.getLengthSync()) }
+            : {}),
           Authorization: `Bearer ${accessToken}`,
         },
-        body: form,
-      })
-    ).json();
+        // form-data is an old-style stream undici can't consume directly;
+        // piping through a PassThrough turns it into a proper Readable.
+        body: form.pipe(new PassThrough()),
+        // Required by undici when streaming a request body.
+        duplex: 'half',
+        // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+        dispatcher: getSsrfSafeDispatcher(),
+      } as any);
+
+      if (
+        mediaResponse.status !== 200 &&
+        mediaResponse.status !== 201 &&
+        mediaResponse.status !== 202
+      ) {
+        throw {
+          response: {
+            status: mediaResponse.status,
+            data: await mediaResponse.text().catch(() => '{}'),
+          },
+        };
+      }
+
+      return (await mediaResponse.json()) as { id: string };
+    }, this.identifier);
+
     return media.id;
   }
 

--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -9,6 +9,7 @@ import { RedditSettingsDto } from '@gitroom/nestjs-libraries/dtos/posts/provider
 import { timer } from '@gitroom/helpers/utils/timer';
 import { groupBy } from 'lodash';
 import {
+  BadBody,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -201,9 +202,22 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
       headers: upload.getHeaders(),
     });
 
-    return [
-      ...(d.data as string).matchAll(/<Location>(.*?)<\/Location>/g),
-    ][0][1];
+    // S3 only echoes a <Location> body when the POST succeeds with 201; guard
+    // the parse so an empty/unexpected body fails with a clear error instead
+    // of a TypeError.
+    const location = [
+      ...String(d.data || '').matchAll(/<Location>(.*?)<\/Location>/g),
+    ][0]?.[1];
+    if (!location) {
+      throw new BadBody(
+        this.identifier,
+        String(d.data || '{}'),
+        Buffer.from('{}'),
+        'Reddit media upload did not return a location'
+      );
+    }
+
+    return location;
   }
 
   async post(

--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -181,9 +181,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
     // Stream the file into Reddit's S3 form instead of buffering it in memory.
     // S3 requires the exact part length, which comes from a HEAD request.
     const fileSize = await this.mediaSize(path, this.identifier);
-    const { data } = await axios.get(path, {
-      responseType: 'stream',
-    });
+    const stream = await this.mediaStream(path, this.identifier);
 
     const upload = (fields as { name: string; value: string }[]).reduce(
       (acc, value) => {
@@ -193,7 +191,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
       new FormDataUpload()
     );
 
-    upload.append('file', data, {
+    upload.append('file', stream, {
       filename: path.split('/').pop(),
       contentType: (mimeType as string) || 'application/octet-stream',
       knownLength: fileSize,

--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -14,6 +14,7 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { lookup } from 'mime-types';
 import axios from 'axios';
+import FormDataUpload from 'form-data';
 import WebSocket from 'ws';
 import { Tool } from '@gitroom/nestjs-libraries/integrations/tool.decorator';
 import { Integration } from '@prisma/client';
@@ -177,8 +178,11 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
       )
     ).json();
 
+    // Stream the file into Reddit's S3 form instead of buffering it in memory.
+    // S3 requires the exact part length, which comes from a HEAD request.
+    const fileSize = await this.mediaSize(path, this.identifier);
     const { data } = await axios.get(path, {
-      responseType: 'arraybuffer',
+      responseType: 'stream',
     });
 
     const upload = (fields as { name: string; value: string }[]).reduce(
@@ -186,20 +190,22 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
         acc.append(value.name, value.value);
         return acc;
       },
-      new FormData()
+      new FormDataUpload()
     );
 
-    upload.append(
-      'file',
-      new Blob([Buffer.from(data)], { type: mimeType as string })
-    );
-
-    const d = await fetch('https:' + action, {
-      method: 'POST',
-      body: upload,
+    upload.append('file', data, {
+      filename: path.split('/').pop(),
+      contentType: (mimeType as string) || 'application/octet-stream',
+      knownLength: fileSize,
     });
 
-    return [...(await d.text()).matchAll(/<Location>(.*?)<\/Location>/g)][0][1];
+    const d = await axios.post('https:' + action, upload, {
+      headers: upload.getHeaders(),
+    });
+
+    return [
+      ...(d.data as string).matchAll(/<Location>(.*?)<\/Location>/g),
+    ][0][1];
   }
 
   async post(

--- a/libraries/nestjs-libraries/src/integrations/social/skool.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/skool.provider.ts
@@ -1,5 +1,6 @@
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
-import { SocialAbstract } from '../social.abstract';
+import { BadBody, SocialAbstract } from '../social.abstract';
+import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import {
   AuthTokenDetails,
   MediaContent,
@@ -206,10 +207,27 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
     const fileIds: string[] = [];
 
     for (const item of media) {
-      const fileResponse = await fetch(item.path);
-      const fileBuffer = await fileResponse.arrayBuffer();
+      // Size and type come from a HEAD request; the PUT below streams the
+      // bytes so the file is never buffered in memory.
+      const headResponse = await fetch(item.path, {
+        method: 'HEAD',
+        // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+        dispatcher: getSsrfSafeDispatcher(),
+      });
       const contentType =
-        fileResponse.headers.get('content-type') || 'application/octet-stream';
+        headResponse.headers.get('content-type') || 'application/octet-stream';
+      const contentLength = Number(
+        headResponse.headers.get('content-length') || 0
+      );
+      if (!headResponse.ok || !contentLength) {
+        // A permanent condition - fail fast instead of letting Temporal retry
+        throw new BadBody(
+          this.identifier,
+          '{}',
+          '{}',
+          'Could not determine the media size for upload'
+        );
+      }
       const fileName = item.path.split('/').pop() || 'file';
 
       const createFileResponse = await (
@@ -222,7 +240,7 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
           body: JSON.stringify({
             file_name: fileName,
             content_type: contentType,
-            content_length: fileBuffer.byteLength,
+            content_length: contentLength,
             content_disposition: '',
             ref: '',
             owner_id: userId,
@@ -231,14 +249,24 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
         }, 'create file record')
       ).json();
 
+      const fileResponse = await fetch(item.path, {
+        // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+        dispatcher: getSsrfSafeDispatcher(),
+      });
+      if (!fileResponse.ok || !fileResponse.body) {
+        throw new Error(`Failed to fetch media: ${fileResponse.statusText}`);
+      }
       await fetch(createFileResponse.write_url, {
         method: 'PUT',
         headers: {
           'Content-Type': createFileResponse.content_type,
+          'Content-Length': String(contentLength),
           'x-amz-acl': createFileResponse.acl,
         },
-        body: fileBuffer,
-      });
+        body: fileResponse.body,
+        // Required by undici when streaming a request body.
+        duplex: 'half',
+      } as any);
 
       fileIds.push(createFileResponse.file.id);
     }

--- a/libraries/nestjs-libraries/src/integrations/social/skool.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/skool.provider.ts
@@ -256,7 +256,7 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
       if (!fileResponse.ok || !fileResponse.body) {
         throw new Error(`Failed to fetch media: ${fileResponse.statusText}`);
       }
-      await fetch(createFileResponse.write_url, {
+      const uploadResponse = await fetch(createFileResponse.write_url, {
         method: 'PUT',
         headers: {
           'Content-Type': createFileResponse.content_type,
@@ -267,6 +267,16 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
         // Required by undici when streaming a request body.
         duplex: 'half',
       } as any);
+      // A rejected PUT would otherwise publish the post with an empty
+      // attachment - the file id exists but no bytes were stored.
+      if (!uploadResponse.ok) {
+        throw new BadBody(
+          this.identifier,
+          await uploadResponse.text().catch(() => '{}'),
+          '{}',
+          'Failed to upload the media file'
+        );
+      }
 
       fileIds.push(createFileResponse.file.id);
     }

--- a/libraries/nestjs-libraries/src/integrations/social/skool.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/skool.provider.ts
@@ -211,6 +211,8 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
       // bytes so the file is never buffered in memory.
       const headResponse = await fetch(item.path, {
         method: 'HEAD',
+        // identity encoding so content-length matches the bytes the GET streams
+        headers: { 'accept-encoding': 'identity' },
         // @ts-ignore - undici-only option; blocks SSRF to internal IPs
         dispatcher: getSsrfSafeDispatcher(),
       });
@@ -250,6 +252,7 @@ export class SkoolProvider extends SocialAbstract implements SocialProvider {
       ).json();
 
       const fileResponse = await fetch(item.path, {
+        headers: { 'accept-encoding': 'identity' },
         // @ts-ignore - undici-only option; blocks SSRF to internal IPs
         dispatcher: getSsrfSafeDispatcher(),
       });

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -16,7 +16,7 @@ import {
 import { TikTokDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/tiktok.dto';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { hasExtension } from '@gitroom/helpers/utils/has.extension';
-import { createReadStream, statSync } from 'fs';
+import { createReadStream } from 'fs';
 import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import { Integration } from '@prisma/client';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
@@ -683,31 +683,6 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
-  // Resolves the total byte size of the media without loading it into memory:
-  // a HEAD request for remote URLs, statSync for local files.
-  private async tiktokMediaSize(path: string): Promise<number> {
-    if (path.indexOf('http') === 0) {
-      // the media path is user-influenced, keep the SSRF-safe dispatcher that
-      // this.fetch applies to every other outbound request
-      const head = await fetch(path, {
-        method: 'HEAD',
-        dispatcher: getSsrfSafeDispatcher(),
-      } as any);
-      const length = head.headers.get('content-length');
-      if (!length) {
-        throw new BadBody(
-          'tiktok-error-upload',
-          '{}',
-          Buffer.from('{}'),
-          'Could not determine the video size for TikTok upload'
-        );
-      }
-      return Number(length);
-    }
-
-    return statSync(path).size;
-  }
-
   // Returns a streaming body for the [start, end] byte range of the media so we
   // never hold the whole file in memory: a ranged GET for remote URLs, a ranged
   // read stream for local files.
@@ -833,7 +808,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     // loaded into memory.
     const videoSize = isPhoto
       ? undefined
-      : await this.tiktokMediaSize(videoPath);
+      : await this.mediaSize(videoPath, 'tiktok-error-upload');
 
     const {
       data: { publish_id, upload_url },

--- a/libraries/nestjs-libraries/src/integrations/social/tumblr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tumblr.provider.ts
@@ -5,6 +5,7 @@ import {
   SocialProvider,
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import {
+  BadBody,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -543,6 +544,17 @@ export class TumblrProvider extends SocialAbstract implements SocialProvider {
           },
         }
       );
+
+      // axios parses JSON silently: a non-JSON 200 (proxy/WAF page) comes
+      // back as a raw string, which would publish the post with an empty id.
+      if (!response || typeof response !== 'object' || !response.response) {
+        throw new BadBody(
+          this.identifier,
+          String(response || '{}'),
+          '{}',
+          'Tumblr did not return a valid post response'
+        );
+      }
 
       return response as TumblrCreatePostResponse;
     }, this.identifier);

--- a/libraries/nestjs-libraries/src/integrations/social/tumblr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tumblr.provider.ts
@@ -524,10 +524,8 @@ export class TumblrProvider extends SocialAbstract implements SocialProvider {
         const mediaUrl = this.getMediaUrl(item.path);
         const mimeType = this.getMimeType(item.path);
         const fileSize = await this.mediaSize(mediaUrl, this.identifier);
-        const { data } = await axios.get(mediaUrl, {
-          responseType: 'stream',
-        });
-        formData.append(`media-${index}`, data, {
+        const stream = await this.mediaStream(mediaUrl, this.identifier);
+        formData.append(`media-${index}`, stream, {
           filename: item.path.split('/').pop() || `media-${index}`,
           contentType: mimeType,
           knownLength: fileSize,

--- a/libraries/nestjs-libraries/src/integrations/social/tumblr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tumblr.provider.ts
@@ -12,6 +12,7 @@ import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { TumblrDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/tumblr.dto';
 import { Integration } from '@prisma/client';
 import axios from 'axios';
+import FormDataUpload from 'form-data';
 import { lookup } from 'mime-types';
 import { hasExtension } from '@gitroom/helpers/utils/has.extension';
 
@@ -509,37 +510,44 @@ export class TumblrProvider extends SocialAbstract implements SocialProvider {
     payload: { content: TumblrContentBlock[]; [key: string]: any },
     media: NonNullable<PostDetails['media']>
   ) {
-    const formData = new FormData();
-    formData.append(
-      'json',
-      new Blob([JSON.stringify(payload)], { type: 'application/json' })
-    );
-
-    for (const [index, item] of media.entries()) {
-      const mimeType = this.getMimeType(item.path);
-      const { data } = await axios.get(this.getMediaUrl(item.path), {
-        responseType: 'arraybuffer',
+    // Each media part is streamed from its source into the multipart request
+    // (with its size from a HEAD request) so files are never held in memory.
+    // runStreamedUpload rebuilds the whole form per attempt (a consumed
+    // stream can't be replayed) and keeps handleErrors classification.
+    return this.runStreamedUpload<TumblrCreatePostResponse>(async () => {
+      const formData = new FormDataUpload();
+      formData.append('json', JSON.stringify(payload), {
+        contentType: 'application/json',
       });
-      formData.append(
-        `media-${index}`,
-        new Blob([Buffer.from(data)], { type: mimeType }),
-        item.path.split('/').pop() || `media-${index}`
-      );
-    }
 
-    return (await (
-      await this.fetch(
+      for (const [index, item] of media.entries()) {
+        const mediaUrl = this.getMediaUrl(item.path);
+        const mimeType = this.getMimeType(item.path);
+        const fileSize = await this.mediaSize(mediaUrl, this.identifier);
+        const { data } = await axios.get(mediaUrl, {
+          responseType: 'stream',
+        });
+        formData.append(`media-${index}`, data, {
+          filename: item.path.split('/').pop() || `media-${index}`,
+          contentType: mimeType,
+          knownLength: fileSize,
+        });
+      }
+
+      const { data: response } = await axios.post(
         `${TUMBLR_API_URL}/blog/${encodeURIComponent(blogName)}/posts`,
+        formData,
         {
-          method: 'POST',
           headers: {
+            ...formData.getHeaders(),
             Authorization: `Bearer ${accessToken}`,
             'User-Agent': TUMBLR_USER_AGENT,
           },
-          body: formData,
         }
-      )
-    ).json()) as TumblrCreatePostResponse;
+      );
+
+      return response as TumblrCreatePostResponse;
+    }, this.identifier);
   }
 
   private async createContentBlocks(post: PostDetails<TumblrDto>) {

--- a/libraries/nestjs-libraries/src/integrations/social/whop.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/whop.provider.ts
@@ -276,7 +276,7 @@ export class WhopProvider extends SocialAbstract implements SocialProvider {
         if (!fileResponse.ok || !fileResponse.body) {
           throw new Error(`Failed to fetch media: ${fileResponse.statusText}`);
         }
-        await fetch(createFileResponse.upload_url, {
+        const uploadResponse = await fetch(createFileResponse.upload_url, {
           method: 'PUT',
           headers: {
             // Whop's own upload_headers win if they ever include a length.
@@ -287,6 +287,16 @@ export class WhopProvider extends SocialAbstract implements SocialProvider {
           // Required by undici when streaming a request body.
           duplex: 'half',
         } as any);
+        // A rejected PUT leaves the file pending forever - fail fast instead
+        // of burning the ~9 minute status poll below.
+        if (!uploadResponse.ok) {
+          throw new BadBody(
+            this.identifier,
+            await uploadResponse.text().catch(() => '{}'),
+            '{}',
+            'Failed to upload the media file'
+          );
+        }
 
         let uploadStatus = 'pending';
         let attempts = 0;

--- a/libraries/nestjs-libraries/src/integrations/social/whop.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/whop.provider.ts
@@ -234,6 +234,8 @@ export class WhopProvider extends SocialAbstract implements SocialProvider {
       // through the whole ~9 minute status poll).
       const headResponse = await fetch(item.path, {
         method: 'HEAD',
+        // identity encoding so content-length matches the bytes the GET streams
+        headers: { 'accept-encoding': 'identity' },
         // @ts-ignore - undici-only option; blocks SSRF to internal IPs
         dispatcher: getSsrfSafeDispatcher(),
       });
@@ -270,6 +272,7 @@ export class WhopProvider extends SocialAbstract implements SocialProvider {
 
       if (createFileResponse.upload_url) {
         const fileResponse = await fetch(item.path, {
+          headers: { 'accept-encoding': 'identity' },
           // @ts-ignore - undici-only option; blocks SSRF to internal IPs
           dispatcher: getSsrfSafeDispatcher(),
         });

--- a/libraries/nestjs-libraries/src/integrations/social/whop.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/whop.provider.ts
@@ -8,7 +8,11 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { timer } from '@gitroom/helpers/utils/timer';
-import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import {
+  BadBody,
+  SocialAbstract,
+} from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import { WhopDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/whop.dto';
 import { Integration } from '@prisma/client';
 import { Tool } from '@gitroom/nestjs-libraries/integrations/tool.decorator';
@@ -225,8 +229,26 @@ export class WhopProvider extends SocialAbstract implements SocialProvider {
     const attachments: { id: string }[] = [];
 
     for (const item of media) {
-      const fileResponse = await fetch(item.path);
-      const fileBuffer = await fileResponse.arrayBuffer();
+      // The size comes from a HEAD request; the PUT below streams the bytes
+      // so the file is never buffered in memory (it used to stay resident
+      // through the whole ~9 minute status poll).
+      const headResponse = await fetch(item.path, {
+        method: 'HEAD',
+        // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+        dispatcher: getSsrfSafeDispatcher(),
+      });
+      const contentLength = Number(
+        headResponse.headers.get('content-length') || 0
+      );
+      if (!headResponse.ok || !contentLength) {
+        // A permanent condition - fail fast instead of letting Temporal retry
+        throw new BadBody(
+          this.identifier,
+          '{}',
+          '{}',
+          'Could not determine the media size for upload'
+        );
+      }
       const fileName = item.path.split('/').pop() || 'file';
 
       const createFileResponse = await (
@@ -247,11 +269,24 @@ export class WhopProvider extends SocialAbstract implements SocialProvider {
       ).json();
 
       if (createFileResponse.upload_url) {
+        const fileResponse = await fetch(item.path, {
+          // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+          dispatcher: getSsrfSafeDispatcher(),
+        });
+        if (!fileResponse.ok || !fileResponse.body) {
+          throw new Error(`Failed to fetch media: ${fileResponse.statusText}`);
+        }
         await fetch(createFileResponse.upload_url, {
           method: 'PUT',
-          headers: createFileResponse.upload_headers || {},
-          body: fileBuffer,
-        });
+          headers: {
+            // Whop's own upload_headers win if they ever include a length.
+            'Content-Length': String(contentLength),
+            ...(createFileResponse.upload_headers || {}),
+          },
+          body: fileResponse.body,
+          // Required by undici when streaming a request body.
+          duplex: 'half',
+        } as any);
 
         let uploadStatus = 'pending';
         let attempts = 0;

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -450,7 +450,7 @@ export class XProvider extends SocialAbstract implements SocialProvider {
         `media/upload/${mediaId}/append`,
         {
           segment_index: i,
-          media: await this.mediaChunk(path, start, end),
+          media: await this.mediaChunk(path, start, end, this.identifier),
         },
         { forceBodyMode: 'form-data' }
       );

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -10,7 +10,6 @@ import {
 import { lookup } from 'mime-types';
 import sharp from 'sharp';
 import { readOrFetch } from '@gitroom/helpers/utils/read.or.fetch';
-import { createReadStream, statSync } from 'fs';
 import {
   BadBody,
   SocialAbstract,
@@ -421,173 +420,118 @@ export class XProvider extends SocialAbstract implements SocialProvider {
     );
   }
 
-  // Same INIT / APPEND / FINALIZE flow as client.v2.uploadMedia, but the
-  // video is never held in memory whole: total_bytes comes from a HEAD
-  // request (statSync for local files) and each 1MB segment is fetched with
-  // a ranged GET right before its APPEND. client.v2.uploadMedia only accepts
-  // a Buffer, which is why the loop is replicated here.
-  private async uploadVideoChunked(client: TwitterApi, path: string) {
-    const size = await this.videoSize(path);
-    const chunkSize = 1024 * 1024;
+  // X's v2 chunked upload requires a Buffer per APPEND segment, so we read one
+  // ranged chunk at a time (mediaChunk) instead of buffering the whole video.
+  // 1MB is the exact chunk size client.v2.uploadMedia used in production, so
+  // it is proven against X's APPEND limits; larger chunks are documented but
+  // unproven here.
+  private static readonly X_UPLOAD_CHUNK_SIZE = 1024 * 1024;
 
-    const initResponse = await client.v2.post<{ data: { id: string } }>(
+  private async uploadVideoInChunks(client: TwitterApi, path: string) {
+    const totalBytes = await this.mediaSize(path, this.identifier);
+    const mediaType = String(lookup(path) || 'video/mp4');
+
+    const init = await client.v2.post<{ data: { id: string } }>(
       'media/upload/initialize',
       {
-        media_type: lookup(path) || 'video/mp4',
-        total_bytes: size,
+        media_type: mediaType,
+        total_bytes: totalBytes,
         media_category: 'tweet_video',
       }
     );
-    const mediaId = initResponse.data.id;
+    const mediaId = init.data.id;
 
-    for (let i = 0; i < size; i += chunkSize) {
-      const end = Math.min(i + chunkSize, size) - 1;
+    const chunkSize = XProvider.X_UPLOAD_CHUNK_SIZE;
+    const totalChunkCount = Math.ceil(totalBytes / chunkSize);
+    for (let i = 0; i < totalChunkCount; i++) {
+      const start = i * chunkSize;
+      const end = Math.min(start + chunkSize, totalBytes) - 1;
       await client.v2.post(
         `media/upload/${mediaId}/append`,
         {
-          segment_index: i / chunkSize,
-          media: await this.videoChunk(path, i, end),
+          segment_index: i,
+          media: await this.mediaChunk(path, start, end),
         },
         { forceBodyMode: 'form-data' }
       );
     }
 
-    const finalizeResponse = await client.v2.post<{
-      data: { processing_info?: object };
+    const finalize = await client.v2.post<{
+      data: {
+        id: string;
+        processing_info?: { state: string; check_after_secs?: number };
+      };
     }>(`media/upload/${mediaId}/finalize`);
-    if (finalizeResponse.data.processing_info) {
-      await this.waitForMediaProcessing(client, mediaId);
+
+    let processing = finalize.data.processing_info;
+    let attempts = 0;
+    const maxAttempts = 100; // X drives the pace via check_after_secs (~1-5s each)
+    while (processing && processing.state !== 'succeeded') {
+      if (processing.state === 'failed' || attempts >= maxAttempts) {
+        throw new BadBody(
+          this.identifier,
+          JSON.stringify(processing),
+          Buffer.from('{}'),
+          `X failed to process the uploaded video${
+            (processing as any)?.error?.message
+              ? `: ${(processing as any).error.message}`
+              : ''
+          }`
+        );
+      }
+
+      await timer((processing.check_after_secs || 1) * 1000);
+      const status = await client.v2.get<{
+        data: {
+          processing_info?: { state: string; check_after_secs?: number };
+        };
+      }>('media/upload', { command: 'STATUS', media_id: mediaId });
+      processing = status.data.processing_info;
+      attempts++;
     }
 
     return mediaId;
-  }
-
-  // Mirrors the private client.v2.waitForMediaProcessing.
-  private async waitForMediaProcessing(client: TwitterApi, mediaId: string) {
-    const response = await client.v2.get<{
-      data: {
-        processing_info?: {
-          state: string;
-          check_after_secs?: number;
-          error?: { message?: string };
-        };
-      };
-    }>('media/upload', { command: 'STATUS', media_id: mediaId });
-
-    const info = response.data.processing_info;
-    if (!info || info.state === 'succeeded') {
-      return;
-    }
-    if (info.state === 'failed') {
-      throw new BadBody(
-        'x-error-upload',
-        JSON.stringify(response.data),
-        Buffer.from('{}'),
-        `X media processing failed: ${info.error?.message || 'unknown error'}`
-      );
-    }
-    await timer((info.check_after_secs || 1) * 1000);
-    await this.waitForMediaProcessing(client, mediaId);
-  }
-
-  // Resolves the total byte size of the video without loading it into memory:
-  // a HEAD request for remote URLs, statSync for local files.
-  private async videoSize(path: string): Promise<number> {
-    if (path.indexOf('http') === 0) {
-      const head = await fetch(path, { method: 'HEAD' });
-      const length = head.headers.get('content-length');
-      if (!length) {
-        throw new BadBody(
-          'x-error-upload',
-          '{}',
-          Buffer.from('{}'),
-          'Could not determine the video size for X upload'
-        );
-      }
-      return Number(length);
-    }
-
-    return statSync(path).size;
-  }
-
-  // Returns only the [start, end] byte window of the video as a Buffer (a
-  // ranged GET for remote URLs, a ranged read for local files), so memory is
-  // bounded by the segment size.
-  private async videoChunk(
-    path: string,
-    start: number,
-    end: number
-  ): Promise<Buffer> {
-    if (path.indexOf('http') === 0) {
-      const response = await fetch(path, {
-        headers: { Range: `bytes=${start}-${end}` },
-      });
-      // A 200 means the origin ignored the Range header and is sending the
-      // whole file: uploading it as this segment would silently corrupt the
-      // video, so fail loudly instead.
-      if (response.status !== 206) {
-        throw new BadBody(
-          'x-error-upload',
-          '{}',
-          Buffer.from('{}'),
-          `Media server ignored the ranged request (status ${response.status}); it must support HTTP Range requests for chunked X uploads`
-        );
-      }
-      return Buffer.from(await response.arrayBuffer());
-    }
-
-    return new Promise((resolve, reject) => {
-      const chunks: Buffer[] = [];
-      createReadStream(path, { start, end })
-        .on('data', (chunk) => chunks.push(chunk as Buffer))
-        .on('end', () => resolve(Buffer.concat(chunks)))
-        .on('error', reject);
-    });
   }
 
   private async uploadMedia(
     client: TwitterApi,
     postDetails: PostDetails<any>[]
   ) {
-    return (
-      await Promise.all(
-        postDetails.flatMap((p) =>
-          p?.media?.flatMap(async (m) => {
-            return {
-              id: await this.runInConcurrent(
-                async () =>
-                  hasExtension(m.path, 'mp4')
-                    ? this.uploadVideoChunked(client, m.path)
-                    : client.v2.uploadMedia(
-                        await sharp(await readOrFetch(m.path), {
-                          animated: lookup(m.path) === 'image/gif',
-                        })
-                          .resize({
-                            width: 1000,
-                          })
-                          .gif()
-                          .toBuffer(),
-                        {
-                          media_type: (lookup(m.path) || '') as any,
-                        }
-                      ),
-                true
-              ),
-              postId: p.id,
-            };
-          })
-        )
-      )
-    ).reduce((acc, val) => {
-      if (!val?.id) {
-        return acc;
+    // Media is uploaded sequentially on purpose: uploading everything with
+    // Promise.all holds every file in memory at the same time.
+    const media = {} as Record<string, string[]>;
+    for (const p of postDetails) {
+      for (const m of p?.media || []) {
+        const id = await this.runInConcurrent(
+          async () =>
+            hasExtension(m.path, 'mp4')
+              ? this.uploadVideoInChunks(client, m.path)
+              : client.v2.uploadMedia(
+                  await sharp(await readOrFetch(m.path), {
+                    animated: lookup(m.path) === 'image/gif',
+                  })
+                    .resize({
+                      width: 1000,
+                    })
+                    .gif()
+                    .toBuffer(),
+                  {
+                    media_type: (lookup(m.path) || '') as any,
+                  }
+                ),
+          true
+        );
+
+        if (!id) {
+          continue;
+        }
+
+        media[p.id] = media[p.id] || [];
+        media[p.id].push(id);
       }
+    }
 
-      acc[val.postId] = acc[val.postId] || [];
-      acc[val.postId].push(val.id);
-
-      return acc;
-    }, {} as Record<string, string[]>);
+    return media;
   }
 
   async post(

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -464,10 +464,13 @@ export class XProvider extends SocialAbstract implements SocialProvider {
     }>(`media/upload/${mediaId}/finalize`);
 
     let processing = finalize.data.processing_info;
-    let attempts = 0;
-    const maxAttempts = 100; // X drives the pace via check_after_secs (~1-5s each)
+    // X drives the pace via check_after_secs; cap on accumulated wait time
+    // (long videos can legitimately process for many minutes) instead of an
+    // attempt count, but never poll forever.
+    let waitedMs = 0;
+    const maxWaitMs = 30 * 60 * 1000;
     while (processing && processing.state !== 'succeeded') {
-      if (processing.state === 'failed' || attempts >= maxAttempts) {
+      if (processing.state === 'failed' || waitedMs >= maxWaitMs) {
         throw new BadBody(
           this.identifier,
           JSON.stringify(processing),
@@ -480,14 +483,15 @@ export class XProvider extends SocialAbstract implements SocialProvider {
         );
       }
 
-      await timer((processing.check_after_secs || 1) * 1000);
+      const waitMs = (processing.check_after_secs || 1) * 1000;
+      await timer(waitMs);
+      waitedMs += waitMs;
       const status = await client.v2.get<{
         data: {
           processing_info?: { state: string; check_after_secs?: number };
         };
       }>('media/upload', { command: 'STATUS', media_id: mediaId });
       processing = status.data.processing_info;
-      attempts++;
     }
 
     return mediaId;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix — memory-leak / OOM fix in the workers.

# Why was this change needed?

Workers were running out of memory because most social providers downloaded entire media files into memory (`arrayBuffer()` / `Blob`) before uploading them. With several concurrent jobs uploading large videos, the buffers stacked up and OOM-killed the worker (in Whop's case the buffer even stayed resident through the whole ~9-minute status poll).

This PR makes every provider upload media without holding the whole file in memory:

- **social.abstract.ts** — shared helpers: `mediaSize` (HEAD request / `statSync`), `mediaChunk` (ranged reads for chunked-upload APIs), and `runStreamedUpload` (retry + `handleErrors` classification for streamed bodies that can't be replayed — the whole request is rebuilt per attempt).
- **LinkedIn / X** — chunked video uploads now read one 1–2MB ranged part at a time instead of buffering the video; LinkedIn media uploads run sequentially instead of `Promise.all` (parallel uploads held every file in memory at once).
- **Bluesky / Skool / Whop** — size from a HEAD request, body streamed straight from the source with `duplex: 'half'`.
- **Discord / Mastodon / Reddit / Tumblr** — multipart forms stream attachments with known lengths via `form-data`, rebuilt on every retry attempt.
- **TikTok** — moved its media-size helper to the shared abstract implementation.

All user-influenced media fetches keep the SSRF-safe dispatcher, and error classification (retry / refresh-token / bad-body) matches the existing `this.fetch` behavior so Temporal retry semantics are unchanged. No workflow or activity signatures were touched.

# Other information:

Follow-up to the August 2026 worker OOM audit; the Temporal worker configuration findings from that audit are not part of this PR.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Social media attachments now stream directly during upload, reducing memory usage and improving reliability for large files.
  * Media uploads use more consistent size detection, sequential processing where applicable, and bounded video transfers.
  * Uploads retry safely and provide clearer errors for unavailable media, invalid metadata, timeouts, and failed responses.
  * Remote media retrieval includes enhanced security protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->