### PR TITLE
feat: tag extension-origin errors in Sentry beforeSend

### DIFF
--- a/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
+++ b/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
@@ -52,6 +52,28 @@ export const initializeSentryBasic = (environment: string, dsn: string, extensio
             }
           }
 
+          const frames = event.exception.values.flatMap(
+            (exception) => exception.stacktrace?.frames || []
+          );
+          const extensionOrigin =
+            frames.length > 0 &&
+            frames.every(
+              (frame) =>
+                !frame.filename ||
+                frame.filename.includes('/scripts/inpage.js') ||
+                frame.filename.startsWith('chrome-extension://') ||
+                frame.filename.startsWith('moz-extension://') ||
+                frame.filename.startsWith('safari-extension://')
+            );
+          if (extensionOrigin) {
+            event.tags = { ...event.tags, extension_origin: 'true' };
+            event.extra = {
+              ...event.extra,
+              hasWindowEthereum:
+                typeof window !== 'undefined' && !!(window as any).ethereum,
+            };
+          }
+
           // If there's an exception and an event id, present the user report dialog.
           if (event.event_id) {
             // Only attempt to show the dialog in a browser environment.

--- a/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
+++ b/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
@@ -55,15 +55,16 @@ export const initializeSentryBasic = (environment: string, dsn: string, extensio
           const frames = event.exception.values.flatMap(
             (exception) => exception.stacktrace?.frames || []
           );
+          const isExtensionFrame = (frame: { filename?: string }) =>
+            !!frame.filename &&
+            (frame.filename.includes('/scripts/inpage.js') ||
+              frame.filename.startsWith('chrome-extension://') ||
+              frame.filename.startsWith('moz-extension://') ||
+              frame.filename.startsWith('safari-extension://'));
           const extensionOrigin =
-            frames.length > 0 &&
+            frames.some(isExtensionFrame) &&
             frames.every(
-              (frame) =>
-                !frame.filename ||
-                frame.filename.includes('/scripts/inpage.js') ||
-                frame.filename.startsWith('chrome-extension://') ||
-                frame.filename.startsWith('moz-extension://') ||
-                frame.filename.startsWith('safari-extension://')
+              (frame) => !frame.filename || isExtensionFrame(frame)
             );
           if (extensionOrigin) {
             event.tags = { ...event.tags, extension_origin: 'true' };

--- a/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
+++ b/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
@@ -57,7 +57,7 @@ export const initializeSentryBasic = (environment: string, dsn: string, extensio
           );
           const isExtensionFrame = (frame: { filename?: string }) =>
             !!frame.filename &&
-            (frame.filename.includes('/scripts/inpage.js') ||
+            (frame.filename.endsWith('/scripts/inpage.js') ||
               frame.filename.startsWith('chrome-extension://') ||
               frame.filename.startsWith('moz-extension://') ||
               frame.filename.startsWith('safari-extension://'));


### PR DESCRIPTION
# What kind of change does this PR introduce?

Observability improvement (frontend Sentry).

# Why was this change needed?

Investigated Sentry user feedback CLOUD-1PD ("I got this issues message 2x") which links to issue CLOUD-C "Failed to connect to MetaMask" (~1K events, 149 users in 90d, 6 user reports, escalating). The event's entire stack is a single frame from MetaMask's injected script (app:///scripts/inpage.js in Object.connect) — no Postiz frames, and we have no MetaMask/window.ethereum code on /launches where it fires. Our beforeSend shows the user report dialog for every captured exception, so an extension's own error pops our "report an issue" dialog — that's the message the user got twice.

Before suppressing anything, this PR only adds annotation: events whose stack frames are all extension-origin (chrome-extension://, moz-extension://, safari-extension://, or wallet-injected inpage.js) get tagged extension_origin=true plus a hasWindowEthereum extra. Once deployed, filtering CLOUD-C by this tag confirms (or refutes) the extension origin with real data; then we can decide whether to stop showing the dialog / reporting for such errors. A single frame from our own bundles disqualifies the tag, so genuine Postiz errors can't be mis-tagged. No events are dropped and dialog behavior is unchanged.

# Other information:

Follow-up candidate: skip the report dialog (or the event entirely) for extension_origin errors once confirmed.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)