### PR TITLE
fix: surface Reddit submit errors instead of crashing on websocket_url

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -9,6 +9,7 @@ import { RedditSettingsDto } from '@gitroom/nestjs-libraries/dtos/posts/provider
 import { timer } from '@gitroom/helpers/utils/timer';
 import { groupBy } from 'lodash';
 import {
+  BadBody,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -263,6 +264,24 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
         })
       ).json();
 
+      if (all?.json?.errors?.length || !all?.json?.data) {
+        const errors: string[][] = all?.json?.errors || [];
+        const message =
+          errors.map((e) => e.join(': ')).join(', ') ||
+          'Reddit did not return post data';
+
+        if (errors.some((e) => e?.[0] === 'RATELIMIT')) {
+          throw new Error(message);
+        }
+
+        throw new BadBody(
+          'reddit',
+          JSON.stringify(all),
+          new URLSearchParams(postData) as any,
+          message
+        );
+      }
+
       const {
         id: redditId,
         name,
@@ -274,6 +293,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
       }>((res) => {
         if (all?.json?.data?.id) {
           res(all.json.data);
+          return;
         }
 
         const ws = new WebSocket(all.json.data.websocket_url);


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix

# Why was this change needed?

A production postSocial Temporal workflow failed with "TypeError: Cannot read properties of undefined (reading 'websocket_url')" in the Reddit provider.

When Reddit's /api/submit rejects a post (rate limit, banned/private subreddit, validation error), it responds with HTTP 200, a json.errors array, and no json.data. The provider ignored the errors array and unconditionally read all.json.data.websocket_url, so the workflow crashed with a TypeError that hid Reddit's real rejection reason.

This PR:
- Checks json.errors / missing json.data after submit. RATELIMIT errors throw a plain Error so Temporal retries the activity (the post can succeed once the rate-limit window passes); any other error throws a non-retryable BadBody carrying Reddit's actual error messages (e.g. "SUBREDDIT_NOTALLOWED: ...").
- Adds the missing return after resolving with a direct post id, so responses that include the id (self/link posts) no longer fall through and open a websocket anyway.

The retryable path uses a plain Error because the handleErrors 'retry' mechanism only runs in fetch() for non-200 statuses, and Reddit returns these errors with HTTP 200.

# Other information:

Not e2e-verified — reproducing requires a real Reddit rejection (rate limit or a subreddit that rejects the post).

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)