### PR TITLE
feat: add AgentOnboard session-token auth to the public API

### DIFF
--- a/apps/backend/src/services/auth/public.auth.middleware.ts
+++ b/apps/backend/src/services/auth/public.auth.middleware.ts
@@ -2,17 +2,54 @@ import { HttpStatus, Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { OAuthService } from '@gitroom/nestjs-libraries/database/prisma/oauth/oauth.service';
+import { AgentOnboardService } from '@gitroom/nestjs-libraries/agentonboard/agentonboard.service';
 import { HttpForbiddenException } from '@gitroom/nestjs-libraries/services/exception.filter';
 
 @Injectable()
 export class PublicAuthMiddleware implements NestMiddleware {
   constructor(
     private _organizationService: OrganizationService,
-    private _oauthService: OAuthService
+    private _oauthService: OAuthService,
+    private _agentOnboardService: AgentOnboardService
   ) {}
   async use(req: Request, res: Response, next: NextFunction) {
+    const sessionToken = req.headers['x-session-token'] as string;
     const auth = (req.headers.authorization ||
       req.headers.Authorization) as string;
+
+    // AgentOnboard session-token auth: an AI agent acts on behalf of a user
+    // whose AgentOnboard login email matches a Postiz account. Opt-in — it is
+    // only reachable when AGENTONBOARD_PARTNER_KEY is configured, and it never
+    // changes the behavior of the API-key / OAuth token paths below.
+    if (sessionToken) {
+      try {
+        const agent =
+          await this._agentOnboardService.authenticate(sessionToken);
+        if (!agent) {
+          res
+            .status(HttpStatus.UNAUTHORIZED)
+            .json({ msg: 'Invalid session token' });
+          return;
+        }
+
+        if (!!process.env.STRIPE_SECRET_KEY && !agent.organization.subscription) {
+          res
+            .status(HttpStatus.UNAUTHORIZED)
+            .json({ msg: 'No subscription found' });
+          return;
+        }
+
+        // The org carries the user's real role (org.users[0].role), so the
+        // agent gets exactly the permissions of the account it verifies to.
+        // @ts-ignore
+        req.org = agent.organization;
+        next();
+        return;
+      } catch (err) {
+        throw new HttpForbiddenException();
+      }
+    }
+
     if (!auth) {
       res.status(HttpStatus.UNAUTHORIZED).json({ msg: 'No API Key found' });
       return;

--- a/libraries/nestjs-libraries/src/agentonboard/agentonboard.service.ts
+++ b/libraries/nestjs-libraries/src/agentonboard/agentonboard.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
+import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
+
+// AgentOnboard (https://docs.ao.aawej.in/docs/partner-guide) is an identity
+// layer for AI agents. An agent presents a short-lived session token in the
+// `x-session-token` header; we exchange it for the user's AgentOnboard login
+// email via POST /api/verify, then map that email to a Postiz account. The
+// feature is opt-in: without AGENTONBOARD_PARTNER_KEY no verification can
+// succeed, so the existing public API auth is completely untouched.
+@Injectable()
+export class AgentOnboardService {
+  constructor(
+    private _usersService: UsersService,
+    private _organizationService: OrganizationService
+  ) {}
+
+  // Resolves a session token to the Postiz user + organization it acts on, or
+  // null when the token is invalid, the email has no Postiz account, or the
+  // user belongs to no (enabled) organization.
+  async authenticate(sessionToken: string) {
+    const email = await this.getEmailFromSessionToken(sessionToken);
+    if (!email) {
+      return null;
+    }
+
+    const user = await this._usersService.getAgentUserByEmail(email);
+    if (!user) {
+      return null;
+    }
+
+    // Same default-org resolution the human auth path uses (AuthMiddleware):
+    // the first enabled organization the user belongs to. The org carries the
+    // user's real role (org.users[0].role), so an agent gets exactly the
+    // permissions of the account it verifies to.
+    const organization = (
+      await this._organizationService.getOrgsByUserId(user.id)
+    ).find((f) => !f.users[0]?.disabled);
+
+    if (!organization) {
+      return null;
+    }
+
+    return { user, organization };
+  }
+
+  // Exchanges the agent's session token for the AgentOnboard login email.
+  // Follows the documented contract:
+  //   POST {apiUrl}/api/verify
+  //   Authorization: Bearer <partner key>
+  //   { "sessionToken": "<session token>" }
+  private async getEmailFromSessionToken(sessionToken: string) {
+    const partnerKey = process.env.AGENTONBOARD_PARTNER_KEY;
+    if (!partnerKey) {
+      return null;
+    }
+
+    const apiUrl =
+      process.env.AGENTONBOARD_API_URL || 'https://api.ao.aawej.in';
+
+    try {
+      const response = await fetch(`${apiUrl}/api/verify`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${partnerKey}`,
+        },
+        body: JSON.stringify({ sessionToken }),
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const body = (await response.json()) as { email?: string };
+      return body.email || null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/libraries/nestjs-libraries/src/database/prisma/database.module.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/database.module.ts
@@ -44,6 +44,7 @@ import { ErrorsRepository } from '@gitroom/nestjs-libraries/database/prisma/erro
 import { ErrorsService } from '@gitroom/nestjs-libraries/database/prisma/errors/errors.service';
 import { AdminStatsRepository } from '@gitroom/nestjs-libraries/database/prisma/admin-stats/admin-stats.repository';
 import { AdminStatsService } from '@gitroom/nestjs-libraries/database/prisma/admin-stats/admin-stats.service';
+import { AgentOnboardService } from '@gitroom/nestjs-libraries/agentonboard/agentonboard.service';
 
 @Global()
 @Module({
@@ -53,6 +54,7 @@ import { AdminStatsService } from '@gitroom/nestjs-libraries/database/prisma/adm
     PrismaService,
     PrismaRepository,
     PrismaTransaction,
+    AgentOnboardService,
     UsersService,
     UsersRepository,
     OrganizationService,

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
@@ -128,6 +128,37 @@ export class UsersRepository {
     });
   }
 
+  // AgentOnboard session tokens verify to the user's AgentOnboard login email.
+  // Email is the join key to a Postiz account: prefer the LOCAL account (the
+  // canonical email/password identity, same as getUserByEmail) and fall back
+  // to any activated account (covers users who registered via Google/GitHub).
+  async getAgentUserByEmail(email: string) {
+    const local = await this._user.model.user.findFirst({
+      where: {
+        email: {
+          equals: email,
+          mode: 'insensitive',
+        },
+        providerName: Provider.LOCAL,
+        activated: true,
+      },
+    });
+
+    if (local) {
+      return local;
+    }
+
+    return this._user.model.user.findFirst({
+      where: {
+        email: {
+          equals: email,
+          mode: 'insensitive',
+        },
+        activated: true,
+      },
+    });
+  }
+
   getUserWithActiveSubscriptionByEmail(email: string, excludeUserId: string) {
     return this._user.model.user.findFirst({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
@@ -20,6 +20,10 @@ export class UsersService {
     return this._usersRepository.getUserByEmail(email);
   }
 
+  getAgentUserByEmail(email: string) {
+    return this._usersRepository.getAgentUserByEmail(email);
+  }
+
   getUserById(id: string) {
     return this._usersRepository.getUserById(id);
   }


### PR DESCRIPTION
<!-- Remember to first apply via [the contribution form](https://contribute.postiz.com/p/postiz) and sign the [CLA](https://contribute.postiz.com/p/postiz/cla) before submitting a PR. -->

# What kind of change does this PR introduce?

**Feature** — adds **AgentOnboard** (an open identity layer for AI agents, https://docs.ao.aawej.in) as an opt-in third credential type on Postiz's existing public API (`/public/v1/*`).

# Why was this change needed?

Postiz already has a strong agent story: the `postiz` CLI, the `/public/v1` REST API, the `@postiz/node` SDK, and the n8n/Make integrations. But today, an AI agent that wants to drive Postiz must either **hold a Postiz API key** or **run an OAuth device flow** — per-user credentials, per-agent setup, and a long-lived key that lives in conversation context.

AgentOnboard solves exactly this: a human saves one API key with the `aon` CLI, and **any AgentOnboard-equipped agent** (Claude, OpenClaw, Cursor, and others) mints a **5-minute session token** and calls partner APIs with it. The partner verifies the token server-side with a single HTTP call and gets back the user's email.

**What this solves for Postiz users:** no more API keys or OAuth dance for agent workflows. Their existing agents can schedule posts, manage media, and read analytics by simply presenting a session token.

**What Postiz gets:**
- **Distribution** — every AgentOnboard-equipped agent becomes a potential Postiz user, with zero per-agent onboarding. The integration is one verify call; AgentOnboard handles the identity layer.
- **Zero maintenance & zero risk** — fully opt-in. Without `AGENTONBOARD_PARTNER_KEY` the feature is inert: the existing API-key, OAuth-token, CLI, SDK, n8n and Make flows behave byte-for-byte as before. No schema change, no migration, no new dependency.
- **A stronger security posture than the current public API** — the agent is scoped to the exact Postiz account the verified email resolves to, with that user's **real role** in their organization (the existing public API hardcodes `SUPERADMIN` for every token; this path uses the account's actual role). Postiz never sees the user's AgentOnboard API key, and tokens expire in 5 minutes.

# Other information (tech details)

**Auth flow**
```
agent ── x-session-token: <token> ──▶ PublicAuthMiddleware
        ──▶ AgentOnboardService.authenticate(token)
        ──▶ POST https://api.ao.aawej.in/api/verify
            (Authorization: Bearer <partner key>, body { sessionToken })
        ──▶ 200 { email }  →  local user lookup  →  default org  →  req.org
```
- The middleware branch mirrors the existing `pos_` / API-key branches: same `{ msg }` error shape (`Invalid session token`, `No subscription found`) and the same Stripe subscription check.
- **Email is the join key** (the AgentOnboard partner model): `/api/verify` returns the user's AgentOnboard login email. Postiz maps it to the **LOCAL** account when one exists (the canonical email/password identity, consistent with `getUserByEmail`), falling back to the first **activated** account (covers Google/GitHub-only registrations). Unknown email → `401`, no auto-provisioning.
- The resolved org is the user's first enabled organization, carrying their real role (`org.users[0].role`) — the same resolution the human JWT path uses (`AuthMiddleware`).

**Changed files (5, +157/−1)**
- `libraries/nestjs-libraries/src/agentonboard/agentonboard.service.ts` *(new)* — token verify + email→user→org resolution; plain `fetch`, no new dependency.
- `libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts` — `getAgentUserByEmail` (LOCAL-preferring, activated, case-insensitive).
- `libraries/nestjs-libraries/src/database/prisma/users/users.service.ts` — thin passthrough (standard layering).
- `libraries/nestjs-libraries/src/database/prisma/database.module.ts` — service registered in the `@Global` module.
- `apps/backend/src/services/auth/public.auth.middleware.ts` — third credential branch for `x-session-token`.

**Configuration** (server-side only, read via `process.env` like the rest of the codebase)
- `AGENTONBOARD_PARTNER_KEY` — the partner key; **feature is off when absent**.
- `AGENTONBOARD_API_URL` — optional, defaults to `https://api.ao.aawej.in`.

**Explicitly NOT changed:** database schema, migrations, existing auth paths, CLI/SDK packages, frontend, workflows.

**Verification:** typechecked (`tsc --noEmit -p apps/backend/tsconfig.json`, zero errors in changed files) and exercised end-to-end against a running backend: real `aon token get` token → `GET /public/v1/integrations` → `200` (user's workspace); garbage token → `401 { "msg": "Invalid session token" }`; existing `pos_`/API-key paths unchanged.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue
