### PR TITLE
fix: require explicit opt-in to republish a published post

### DIFF
--- a/apps/backend/src/api/routes/posts.controller.ts
+++ b/apps/backend/src/api/routes/posts.controller.ts
@@ -273,9 +273,12 @@ export class PostsController {
     @GetOrgFromRequest() org: Organization,
     @Param('id') id: string,
     @Body('date') date: string,
-    @Body('action') action: 'schedule' | 'update' = 'schedule'
+    // 'update' is the safe default: clients that don't send an action must
+    // never requeue (and thereby republish) a post by accident
+    @Body('action') action: 'schedule' | 'update' = 'update',
+    @Body('republish') republish = false
   ) {
-    return this._postsService.changeDate(org.id, id, date, action);
+    return this._postsService.changeDate(org.id, id, date, action, republish);
   }
 
   @Post('/separate-posts')

--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -679,8 +679,18 @@ export const CalendarColumn: FC<{
                 <div className="flex flex-col">
                   <div className="text-[20px] mb-[20px]">
                     {t(
-                      'post_already_published_drag',
-                      'This post was already published, what do you want to do?'
+                      'post_already_published_republish_warning',
+                      'This post was already published. Republishing will publish it again to'
+                    )}{' '}
+                    {post.integration?.name}{' '}
+                    {t('republish_at', 'at')} {getDate.format('DD/MM/YYYY HH:mm')}.
+                    {(!!item.interval || !!post.intervalInDays) && (
+                      <div className="mt-[10px]">
+                        {t(
+                          'republish_recurring_note',
+                          'This is a recurring post: your changes apply to all future recurrences starting now.'
+                        )}
+                      </div>
                     )}
                   </div>
                   <div className="flex w-full gap-[10px]">
@@ -730,6 +740,9 @@ export const CalendarColumn: FC<{
         body: JSON.stringify({
           date: getDate.utc().format('YYYY-MM-DDTHH:mm:ss'),
           action,
+          // published posts always confirm via the modal before reaching here;
+          // for QUEUE posts the flag is a no-op on the server
+          ...(action === 'schedule' ? { republish: true } : {}),
         }),
       });
       if (status !== 500) {

--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -192,19 +192,39 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
 
   const schedule = useCallback(
     (type: 'draft' | 'now' | 'schedule' | 'update') => async () => {
+      let republish = false;
       if (
         (type === 'now' || type === 'schedule') &&
         (existingData?.posts?.[0]?.state === 'PUBLISHED' ||
           (existingData?.posts?.[0]?.state === 'QUEUE' &&
             dayjs().isAfter(date.utc())))
       ) {
+        const channels = selectedIntegrations
+          .map((p) => p.integration.name)
+          .join(', ');
+        const isRecurring =
+          !!repeater || !!existingData?.posts?.[0]?.intervalInDays;
+
         const whatToDo = await new Promise((resolve) => {
           modal.openModal({
-            title: 'What do you want to do?',
+            title: t('what_do_you_want_to_do', 'What do you want to do?'),
             children: (
               <div className="flex flex-col">
                 <div className="text-[20px] mb-[20px]">
-                  This post was already published, what do you want to do?
+                  {t(
+                    'post_already_published_republish_warning',
+                    'This post was already published. Republishing will publish it again to'
+                  )}{' '}
+                  {channels} {t('republish_at', 'at')}{' '}
+                  {date.format('DD/MM/YYYY HH:mm')}.
+                  {isRecurring && (
+                    <div className="mt-[10px]">
+                      {t(
+                        'republish_recurring_note',
+                        'This is a recurring post: your changes apply to all future recurrences starting now.'
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div className="flex w-full gap-[10px]">
                   <div className="flex-1 flex">
@@ -213,7 +233,10 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
                       className="flex-1"
                       onClick={() => resolve('update')}
                     >
-                      Just update the post details
+                      {t(
+                        'just_update_post_details',
+                        'Just update the post details'
+                      )}
                     </Button>
                   </div>
                   <div className="flex-1 flex">
@@ -222,7 +245,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
                       className="flex-1"
                       onClick={() => resolve('republish')}
                     >
-                      Republish the post
+                      {t('republish_the_post', 'Republish the post')}
                     </Button>
                   </div>
                 </div>
@@ -233,6 +256,10 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
 
         if (whatToDo === 'update') {
           type = 'update';
+        }
+
+        if (whatToDo === 'republish') {
+          republish = true;
         }
       }
 
@@ -385,6 +412,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
 
       const data = {
         type,
+        ...(republish ? { republish } : {}),
         ...(repeater ? { inter: repeater } : {}),
         tags,
         shortLink,

--- a/i18n.lock
+++ b/i18n.lock
@@ -735,3 +735,10 @@ checksums:
     cancel_coupon_title: 6a02a23e494728ddb694f591be65900d
     cancel_coupon_failed: 7bbb5c2646ba919b7df0879225eba918
     cancel_coupon_success: ded654a3b6c5fdfe7bdd23e9b5ad711c
+    what_do_you_want_to_do: c2c352197ed13cee73ed85f9706b35de
+    just_update_post_details: fb0d9cba2fe76d06571fc30dc8db0f13
+    reschedule_post: 103d1943e23d4f71b22439a3b03885dd
+    republish_the_post: 6c16f02f8d70ced4cc6ccc1112968704
+    post_already_published_republish_warning: b552a207c31d6381fb831da005dac9ed
+    republish_at: 282cf74a2c63ff46388104f9853bfaf8
+    republish_recurring_note: e0eafbc730f5e8d5f9f5cb5aab48fe2d

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -873,6 +873,29 @@ export class PostsService {
     return '';
   }
 
+  // A schedule-type save targeting an already-PUBLISHED post republishes it to
+  // the platform: require the explicit `republish` opt-in instead. The message
+  // doubles as the confirmation dialog for API/MCP automation.
+  private guardAgainstRepublish(
+    post: { state: State; publishDate: Date; integration?: { providerIdentifier: string } } | null,
+    source: 'createPost' | 'changeDate'
+  ) {
+    if (post?.state !== 'PUBLISHED') {
+      return;
+    }
+
+    const howToUpdate =
+      source === 'createPost' ? `use type 'update'` : `use action 'update'`;
+
+    throw new BadRequestException(
+      `This post was already published on ${dayjs
+        .utc(post.publishDate)
+        .format('YYYY-MM-DD HH:mm')} UTC. Saving it this way would publish it again to ${
+        post.integration?.providerIdentifier || 'the channel'
+      }. To edit without republishing, ${howToUpdate}. To intentionally publish again, pass republish: true.`
+    );
+  }
+
   async createPost(
     orgId: string,
     body: CreatePostDto,
@@ -880,6 +903,16 @@ export class PostsService {
   ): Promise<any[]> {
     const postList = [];
     for (const post of body.posts) {
+      if (
+        (body.type === 'schedule' || body.type === 'now') &&
+        !body.republish &&
+        post.value?.[0]?.id
+      ) {
+        this.guardAgainstRepublish(
+          await this._postRepository.getPostById(post.value[0].id, orgId),
+          'createPost'
+        );
+      }
       const provider = this._integrationManager.getSocialIntegration(
         (post.settings as any)?.__type
       );
@@ -970,9 +1003,14 @@ export class PostsService {
     orgId: string,
     id: string,
     date: string,
-    action: 'schedule' | 'update' = 'schedule'
+    action: 'schedule' | 'update' = 'schedule',
+    republish = false
   ) {
     const getPostById = await this._postRepository.getPostById(id, orgId);
+
+    if (action === 'schedule' && !republish) {
+      this.guardAgainstRepublish(getPostById, 'changeDate');
+    }
 
     // schedule: Set status to QUEUE and change date (reschedule the post)
     // update: Just change the date without changing the status

--- a/libraries/nestjs-libraries/src/dtos/posts/create.post.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/create.post.dto.ts
@@ -107,6 +107,12 @@ export class CreatePostDto {
   @IsNumber()
   inter?: number;
 
+  // explicit opt-in to publish an already-PUBLISHED post again; without it a
+  // schedule/now save targeting a published post is rejected
+  @IsOptional()
+  @IsBoolean()
+  republish?: boolean;
+
   @IsDefined()
   @IsDateString()
   date: string;

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "نعم، إلغاء القسيمة",
   "cancel_coupon_title": "إلغاء القسيمة؟",
   "cancel_coupon_failed": "تعذّر إلغاء القسيمة",
-  "cancel_coupon_success": "تم إلغاء القسيمة"
+  "cancel_coupon_success": "تم إلغاء القسيمة",
+  "what_do_you_want_to_do": "ماذا تريد أن تفعل؟",
+  "just_update_post_details": "فقط قم بتحديث تفاصيل المنشور",
+  "reschedule_post": "إعادة جدولة المنشور",
+  "republish_the_post": "إعادة نشر المنشور",
+  "post_already_published_republish_warning": "تم نشر هذا المنشور بالفعل. إعادة النشر ستقوم بنشره مرة أخرى على",
+  "republish_at": "في",
+  "republish_recurring_note": "هذا منشور متكرر: ستنطبق تغييراتك على جميع التكرارات المستقبلية بدءًا من الآن."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "হ্যাঁ, কুপন বাতিল করুন",
   "cancel_coupon_title": "কুপন বাতিল করবেন?",
   "cancel_coupon_failed": "কুপন বাতিল করা যায়নি",
-  "cancel_coupon_success": "কুপন বাতিল হয়েছে"
+  "cancel_coupon_success": "কুপন বাতিল হয়েছে",
+  "what_do_you_want_to_do": "আপনি কী করতে চান?",
+  "just_update_post_details": "শুধুমাত্র পোস্টের বিবরণ আপডেট করুন",
+  "reschedule_post": "পোস্ট পুনঃনির্ধারণ করুন",
+  "republish_the_post": "পোস্টটি পুনঃপ্রকাশ করুন",
+  "post_already_published_republish_warning": "এই পোস্টটি ইতিমধ্যে প্রকাশিত হয়েছে। পুনঃপ্রকাশ করলে এটি আবার প্রকাশিত হবে",
+  "republish_at": "সময়",
+  "republish_recurring_note": "এটি একটি পুনরাবৃত্তিমূলক পোস্ট: আপনার পরিবর্তনসমূহ এখন থেকে শুরু করে সকল ভবিষ্যৎ পুনরাবৃত্তিতে প্রয়োগ হবে।"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Ja, Gutschein stornieren",
   "cancel_coupon_title": "Gutschein stornieren?",
   "cancel_coupon_failed": "Der Gutschein konnte nicht storniert werden",
-  "cancel_coupon_success": "Gutschein storniert"
+  "cancel_coupon_success": "Gutschein storniert",
+  "what_do_you_want_to_do": "Was möchten Sie tun?",
+  "just_update_post_details": "Nur die Post-Details aktualisieren",
+  "reschedule_post": "Beitrag neu terminieren",
+  "republish_the_post": "Beitrag erneut veröffentlichen",
+  "post_already_published_republish_warning": "Dieser Beitrag wurde bereits veröffentlicht. Durch erneutes Veröffentlichen wird er erneut veröffentlicht auf",
+  "republish_at": "um",
+  "republish_recurring_note": "Dies ist ein wiederkehrender Beitrag: Ihre Änderungen gelten ab jetzt für alle zukünftigen Wiederholungen."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -732,5 +732,12 @@
   "yes_cancel_coupon": "Yes, cancel coupon",
   "cancel_coupon_title": "Cancel Coupon?",
   "cancel_coupon_failed": "Could not cancel the coupon",
-  "cancel_coupon_success": "Coupon cancelled"
+  "cancel_coupon_success": "Coupon cancelled",
+  "what_do_you_want_to_do": "What do you want to do?",
+  "just_update_post_details": "Just update the post details",
+  "reschedule_post": "Reschedule the post",
+  "republish_the_post": "Republish the post",
+  "post_already_published_republish_warning": "This post was already published. Republishing will publish it again to",
+  "republish_at": "at",
+  "republish_recurring_note": "This is a recurring post: your changes apply to all future recurrences starting now."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Sí, cancelar cupón",
   "cancel_coupon_title": "¿Cancelar cupón?",
   "cancel_coupon_failed": "No se pudo cancelar el cupón",
-  "cancel_coupon_success": "Cupón cancelado"
+  "cancel_coupon_success": "Cupón cancelado",
+  "what_do_you_want_to_do": "¿Qué quieres hacer?",
+  "just_update_post_details": "Solo actualizar los detalles de la publicación",
+  "reschedule_post": "Reprogramar la publicación",
+  "republish_the_post": "Volver a publicar la publicación",
+  "post_already_published_republish_warning": "Esta publicación ya fue publicada. Volver a publicarla la publicará nuevamente en",
+  "republish_at": "a las",
+  "republish_recurring_note": "Esta es una publicación recurrente: tus cambios se aplican a todas las recurrencias futuras a partir de ahora."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Oui, annuler le coupon",
   "cancel_coupon_title": "Annuler le coupon ?",
   "cancel_coupon_failed": "Impossible d'annuler le coupon",
-  "cancel_coupon_success": "Coupon annulé"
+  "cancel_coupon_success": "Coupon annulé",
+  "what_do_you_want_to_do": "Que voulez-vous faire ?",
+  "just_update_post_details": "Mettre à jour uniquement les détails de la publication",
+  "reschedule_post": "Reprogrammer la publication",
+  "republish_the_post": "Republier la publication",
+  "post_already_published_republish_warning": "Cette publication a déjà été publiée. La republier la publiera à nouveau sur",
+  "republish_at": "à",
+  "republish_recurring_note": "Il s'agit d'une publication récurrente : vos modifications s'appliquent à toutes les récurrences futures à partir de maintenant."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "כן, בטל קופון",
   "cancel_coupon_title": "לבטל קופון?",
   "cancel_coupon_failed": "לא ניתן היה לבטל את הקופון",
-  "cancel_coupon_success": "הקופון בוטל"
+  "cancel_coupon_success": "הקופון בוטל",
+  "what_do_you_want_to_do": "מה ברצונך לעשות?",
+  "just_update_post_details": "רק לעדכן את פרטי הפוסט",
+  "reschedule_post": "לתזמן מחדש את הפוסט",
+  "republish_the_post": "לפרסם מחדש את הפוסט",
+  "post_already_published_republish_warning": "הפוסט הזה כבר פורסם. פרסום מחדש יפרסם אותו שוב ב",
+  "republish_at": "בשעה",
+  "republish_recurring_note": "זהו פוסט חוזר: השינויים שלך יחולו על כל ההופעות העתידיות החל מעכשיו."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Sì, annulla il coupon",
   "cancel_coupon_title": "Annulla coupon?",
   "cancel_coupon_failed": "Impossibile annullare il coupon",
-  "cancel_coupon_success": "Coupon annullato"
+  "cancel_coupon_success": "Coupon annullato",
+  "what_do_you_want_to_do": "Cosa vuoi fare?",
+  "just_update_post_details": "Aggiorna solo i dettagli del post",
+  "reschedule_post": "Ripianifica il post",
+  "republish_the_post": "Ripubblica il post",
+  "post_already_published_republish_warning": "Questo post è già stato pubblicato. Ripubblicandolo verrà pubblicato nuovamente su",
+  "republish_at": "a",
+  "republish_recurring_note": "Questo è un post ricorrente: le tue modifiche verranno applicate a tutte le future ricorrenze a partire da ora."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "はい、クーポンをキャンセルします",
   "cancel_coupon_title": "クーポンをキャンセルしますか？",
   "cancel_coupon_failed": "クーポンをキャンセルできませんでした",
-  "cancel_coupon_success": "クーポンがキャンセルされました"
+  "cancel_coupon_success": "クーポンがキャンセルされました",
+  "what_do_you_want_to_do": "何をしたいですか？",
+  "just_update_post_details": "投稿の詳細だけを更新する",
+  "reschedule_post": "投稿の日時を変更する",
+  "republish_the_post": "投稿を再公開する",
+  "post_already_published_republish_warning": "この投稿は既に公開されています。再公開すると、もう一度投稿されます：",
+  "republish_at": "公開日時：",
+  "republish_recurring_note": "これは定期投稿です：今後すべての繰り返しに対して変更が適用されます。"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "네, 쿠폰을 취소합니다.",
   "cancel_coupon_title": "쿠폰을 취소하시겠습니까?",
   "cancel_coupon_failed": "쿠폰을 취소할 수 없습니다.",
-  "cancel_coupon_success": "쿠폰이 취소되었습니다."
+  "cancel_coupon_success": "쿠폰이 취소되었습니다.",
+  "what_do_you_want_to_do": "무엇을 하시겠습니까?",
+  "just_update_post_details": "게시물 세부정보만 업데이트하기",
+  "reschedule_post": "게시물 일정 다시 잡기",
+  "republish_the_post": "게시물 다시 게시하기",
+  "post_already_published_republish_warning": "이 게시물은 이미 게시되었습니다. 다시 게시하면 다음에 다시 게시됩니다:",
+  "republish_at": "다음 시간에",
+  "republish_recurring_note": "이 게시물은 반복 게시물입니다. 변경사항은 지금부터 시작하는 모든 향후 반복에 적용됩니다."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Sim, cancelar cupom",
   "cancel_coupon_title": "Cancelar cupom?",
   "cancel_coupon_failed": "Não foi possível cancelar o cupom",
-  "cancel_coupon_success": "Cupom cancelado"
+  "cancel_coupon_success": "Cupom cancelado",
+  "what_do_you_want_to_do": "O que você deseja fazer?",
+  "just_update_post_details": "Apenas atualizar os detalhes da publicação",
+  "reschedule_post": "Reagendar a publicação",
+  "republish_the_post": "Republicar a publicação",
+  "post_already_published_republish_warning": "Esta publicação já foi publicada. Republicar irá publicá-la novamente em",
+  "republish_at": "em",
+  "republish_recurring_note": "Esta é uma publicação recorrente: suas alterações se aplicam a todas as futuras recorrências a partir de agora."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Да, отменить купон",
   "cancel_coupon_title": "Отменить купон?",
   "cancel_coupon_failed": "Не удалось отменить купон",
-  "cancel_coupon_success": "Купон отменён"
+  "cancel_coupon_success": "Купон отменён",
+  "what_do_you_want_to_do": "Что вы хотите сделать?",
+  "just_update_post_details": "Просто обновить детали поста",
+  "reschedule_post": "Перепланировать пост",
+  "republish_the_post": "Опубликовать пост повторно",
+  "post_already_published_republish_warning": "Этот пост уже был опубликован. Повторная публикация опубликует его снова в",
+  "republish_at": "в",
+  "republish_recurring_note": "Это повторяющийся пост: ваши изменения будут применяться ко всем будущим публикациям, начиная с этого момента."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Evet, kuponu iptal et",
   "cancel_coupon_title": "Kupon İptal Edilsin mi?",
   "cancel_coupon_failed": "Kupon iptal edilemedi",
-  "cancel_coupon_success": "Kupon iptal edildi"
+  "cancel_coupon_success": "Kupon iptal edildi",
+  "what_do_you_want_to_do": "Ne yapmak istiyorsunuz?",
+  "just_update_post_details": "Sadece gönderi detaylarını güncelle",
+  "reschedule_post": "Gönderiyi yeniden zamanla",
+  "republish_the_post": "Gönderiyi tekrar yayımla",
+  "post_already_published_republish_warning": "Bu gönderi zaten yayımlanmış. Tekrar yayımlamak, gönderiyi yeniden yayımlar",
+  "republish_at": "tarihinde/saatinde",
+  "republish_recurring_note": "Bu tekrar eden bir gönderi: yaptığınız değişiklikler bundan sonraki tüm tekrarlar için geçerli olacaktır."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "Đúng, hủy mã giảm giá",
   "cancel_coupon_title": "Hủy mã giảm giá?",
   "cancel_coupon_failed": "Không thể hủy mã giảm giá",
-  "cancel_coupon_success": "Đã hủy mã giảm giá"
+  "cancel_coupon_success": "Đã hủy mã giảm giá",
+  "what_do_you_want_to_do": "Bạn muốn làm gì?",
+  "just_update_post_details": "Chỉ cập nhật chi tiết bài viết",
+  "reschedule_post": "Đặt lại lịch đăng bài",
+  "republish_the_post": "Đăng lại bài viết",
+  "post_already_published_republish_warning": "Bài viết này đã được đăng. Đăng lại sẽ xuất bản bài viết một lần nữa đến",
+  "republish_at": "lúc",
+  "republish_recurring_note": "Đây là bài viết định kỳ: các thay đổi của bạn sẽ áp dụng cho tất cả các lần lặp lại trong tương lai bắt đầu từ bây giờ."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -730,5 +730,12 @@
   "yes_cancel_coupon": "是的，取消优惠券",
   "cancel_coupon_title": "取消优惠券？",
   "cancel_coupon_failed": "无法取消该优惠券",
-  "cancel_coupon_success": "优惠券已取消"
+  "cancel_coupon_success": "优惠券已取消",
+  "what_do_you_want_to_do": "你想做什么？",
+  "just_update_post_details": "仅更新帖子详情",
+  "reschedule_post": "重新安排帖子发布时间",
+  "republish_the_post": "重新发布帖子",
+  "post_already_published_republish_warning": "此帖子已发布。重新发布将再次将其发布到",
+  "republish_at": "于",
+  "republish_recurring_note": "这是一个重复的帖子：你的更改将从现在开始应用于所有未来的重复内容。"
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (server-side guard) + dashboard modal wording.

# Why was this change needed?

A schedule-type save targeting a PUBLISHED post silently requeues it (state back to QUEUE, releaseURL/releaseId nulled, workflow restarted), and because the workflow's initial sleep is max(0, publishDate - now), a save carrying a past date publishes again within seconds. When a user edits an existing published post, the date picker holds the old (past) date - so confirming a reschedule without touching the date is an accidental instant republish. This bit a real customer during the recent recurring-posts incidents: his date edits interacted with exactly this requeue behavior, and the existing protection (2813ed01) is frontend-only - the public API and MCP agents bypass it entirely, and even the dashboard modal never states that republishing can mean publishing right now.

Changes:
- changeDate defaults action to 'update': clients that omit the action can no longer requeue a post by accident (intentional behavior change for external callers of PUT /posts/:id/date that relied on the old default).
- schedule/now saves and action 'schedule' targeting a PUBLISHED post return a 400 that explains what happened and how to proceed, unless the new optional republish flag is sent. Agents surface error bodies to their users, so the message doubles as the confirmation dialog for automation.
- The dashboard modals send republish: true on explicit confirmation and now state the consequence: channel, date, and for recurring posts that changes apply to all future recurrences starting now.

No behavior change for DRAFT/QUEUE posts. New strings translated via lingo.dev.

# Other information:

Verified with 16 service-layer assertions (guard message, rejection before any write, flag passthrough, date-only update, QUEUE unaffected) plus a live dashboard run: modal confirm -> republish: true -> requeue -> real publish to an Instagram channel. Independent of the recurring-recycle PR (#1840); either merge order works.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the Contributor License Agreement (CLA) (maintainer)
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)