### PR TITLE
feat: mark recurrence projections as projected

### DIFF
--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -52,6 +52,7 @@ import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import i18next from 'i18next';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
 import { CreationMethodBadge } from '@gitroom/frontend/components/launches/creation.method.badge';
+import { RepeatIcon } from '@gitroom/frontend/components/ui/icons';
 import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import copy from 'copy-to-clipboard';
@@ -986,6 +987,7 @@ const CalendarItem: FC<{
   showTime?: boolean;
   post: Post & {
     integration: Integration;
+    projected?: boolean;
     tags: {
       tag: Tags;
     }[];
@@ -1057,6 +1059,18 @@ const CalendarItem: FC<{
             creationMethod={post.creationMethod}
             ringColor="var(--new-bgColor)"
           />
+        </div>
+      )}
+      {post.projected && (
+        <div
+          className="absolute -top-[6px] -right-[6px] z-20 w-[18px] h-[18px] rounded-full bg-btnPrimary flex items-center justify-center text-white"
+          data-tooltip-id="tooltip"
+          data-tooltip-content={t(
+            'recurrence_projection',
+            'Recurrence: a future occurrence of this recurring post'
+          )}
+        >
+          <RepeatIcon size={11} className="text-white" />
         </div>
       )}
       <div

--- a/i18n.lock
+++ b/i18n.lock
@@ -735,3 +735,4 @@ checksums:
     cancel_coupon_title: 6a02a23e494728ddb694f591be65900d
     cancel_coupon_failed: 7bbb5c2646ba919b7df0879225eba918
     cancel_coupon_success: ded654a3b6c5fdfe7bdd23e9b5ad711c
+    recurrence_projection: defdc104f3424ff6087e13d96f837e6f

--- a/libraries/helpers/src/utils/posts.list.minify.ts
+++ b/libraries/helpers/src/utils/posts.list.minify.ts
@@ -26,6 +26,7 @@ const POST_ITEM_KEYS: Record<string, string> = {
   intervalInDays: 'iv',
   actualDate: 'ad',
   creationMethod: 'cm',
+  projected: 'pj',
 };
 
 const INTEGRATION_KEYS: Record<string, string> = {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -206,10 +206,14 @@ export class PostsRepository {
       let startingDate = dayjs.utc(post.publishDate);
       while (dayjs.utc(endDate).isSameOrAfter(startingDate)) {
         if (dayjs(startingDate).isSameOrAfter(dayjs.utc(post.publishDate))) {
+          // every occurrence except the row's real date is a synthesized
+          // projection of the recurrence, not a real post
+          const projected = !startingDate.isSame(dayjs.utc(post.publishDate));
           addMorePosts.push({
             ...post,
             publishDate: startingDate.toDate(),
             actualDate: post.publishDate,
+            ...(projected ? { projected } : {}),
           });
         }
 

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "نعم، إلغاء القسيمة",
   "cancel_coupon_title": "إلغاء القسيمة؟",
   "cancel_coupon_failed": "تعذّر إلغاء القسيمة",
-  "cancel_coupon_success": "تم إلغاء القسيمة"
+  "cancel_coupon_success": "تم إلغاء القسيمة",
+  "recurrence_projection": "التكرار: حدوث مستقبلي لهذا المنشور المتكرر"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "হ্যাঁ, কুপন বাতিল করুন",
   "cancel_coupon_title": "কুপন বাতিল করবেন?",
   "cancel_coupon_failed": "কুপন বাতিল করা যায়নি",
-  "cancel_coupon_success": "কুপন বাতিল হয়েছে"
+  "cancel_coupon_success": "কুপন বাতিল হয়েছে",
+  "recurrence_projection": "পুনরাবৃত্তি: এই পুনরাবৃত্ত পোস্টের একটি ভবিষ্যৎ ঘটনা"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Ja, Gutschein stornieren",
   "cancel_coupon_title": "Gutschein stornieren?",
   "cancel_coupon_failed": "Der Gutschein konnte nicht storniert werden",
-  "cancel_coupon_success": "Gutschein storniert"
+  "cancel_coupon_success": "Gutschein storniert",
+  "recurrence_projection": "Wiederholung: ein zukünftiges Auftreten dieses wiederkehrenden Beitrags"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -732,5 +732,6 @@
   "yes_cancel_coupon": "Yes, cancel coupon",
   "cancel_coupon_title": "Cancel Coupon?",
   "cancel_coupon_failed": "Could not cancel the coupon",
-  "cancel_coupon_success": "Coupon cancelled"
+  "cancel_coupon_success": "Coupon cancelled",
+  "recurrence_projection": "Recurrence: a future occurrence of this recurring post"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Sí, cancelar cupón",
   "cancel_coupon_title": "¿Cancelar cupón?",
   "cancel_coupon_failed": "No se pudo cancelar el cupón",
-  "cancel_coupon_success": "Cupón cancelado"
+  "cancel_coupon_success": "Cupón cancelado",
+  "recurrence_projection": "Recurrencia: una ocurrencia futura de esta publicación recurrente"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Oui, annuler le coupon",
   "cancel_coupon_title": "Annuler le coupon ?",
   "cancel_coupon_failed": "Impossible d'annuler le coupon",
-  "cancel_coupon_success": "Coupon annulé"
+  "cancel_coupon_success": "Coupon annulé",
+  "recurrence_projection": "Récurrence : une occurrence future de cette publication récurrente"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "כן, בטל קופון",
   "cancel_coupon_title": "לבטל קופון?",
   "cancel_coupon_failed": "לא ניתן היה לבטל את הקופון",
-  "cancel_coupon_success": "הקופון בוטל"
+  "cancel_coupon_success": "הקופון בוטל",
+  "recurrence_projection": "התרחשות חוזרת: הופעה עתידית של הפוסט החוזר הזה"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Sì, annulla il coupon",
   "cancel_coupon_title": "Annulla coupon?",
   "cancel_coupon_failed": "Impossibile annullare il coupon",
-  "cancel_coupon_success": "Coupon annullato"
+  "cancel_coupon_success": "Coupon annullato",
+  "recurrence_projection": "Ricorrenza: una futura occorrenza di questo post ricorrente"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "はい、クーポンをキャンセルします",
   "cancel_coupon_title": "クーポンをキャンセルしますか？",
   "cancel_coupon_failed": "クーポンをキャンセルできませんでした",
-  "cancel_coupon_success": "クーポンがキャンセルされました"
+  "cancel_coupon_success": "クーポンがキャンセルされました",
+  "recurrence_projection": "繰り返し: この定期的な投稿の今後の発生"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "네, 쿠폰을 취소합니다.",
   "cancel_coupon_title": "쿠폰을 취소하시겠습니까?",
   "cancel_coupon_failed": "쿠폰을 취소할 수 없습니다.",
-  "cancel_coupon_success": "쿠폰이 취소되었습니다."
+  "cancel_coupon_success": "쿠폰이 취소되었습니다.",
+  "recurrence_projection": "반복: 이 반복 게시글의 미래 발생"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Sim, cancelar cupom",
   "cancel_coupon_title": "Cancelar cupom?",
   "cancel_coupon_failed": "Não foi possível cancelar o cupom",
-  "cancel_coupon_success": "Cupom cancelado"
+  "cancel_coupon_success": "Cupom cancelado",
+  "recurrence_projection": "Recorrência: uma ocorrência futura desta postagem recorrente"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Да, отменить купон",
   "cancel_coupon_title": "Отменить купон?",
   "cancel_coupon_failed": "Не удалось отменить купон",
-  "cancel_coupon_success": "Купон отменён"
+  "cancel_coupon_success": "Купон отменён",
+  "recurrence_projection": "Повтор: будущий случай этой повторяющейся публикации"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Evet, kuponu iptal et",
   "cancel_coupon_title": "Kupon İptal Edilsin mi?",
   "cancel_coupon_failed": "Kupon iptal edilemedi",
-  "cancel_coupon_success": "Kupon iptal edildi"
+  "cancel_coupon_success": "Kupon iptal edildi",
+  "recurrence_projection": "Yinelenme: Bu yinelenen gönderinin gelecekteki bir oluşumu"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Đúng, hủy mã giảm giá",
   "cancel_coupon_title": "Hủy mã giảm giá?",
   "cancel_coupon_failed": "Không thể hủy mã giảm giá",
-  "cancel_coupon_success": "Đã hủy mã giảm giá"
+  "cancel_coupon_success": "Đã hủy mã giảm giá",
+  "recurrence_projection": "Lặp lại: một lần xuất hiện trong tương lai của bài đăng định kỳ này"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "是的，取消优惠券",
   "cancel_coupon_title": "取消优惠券？",
   "cancel_coupon_failed": "无法取消该优惠券",
-  "cancel_coupon_success": "优惠券已取消"
+  "cancel_coupon_success": "优惠券已取消",
+  "recurrence_projection": "重复：该周期性帖子的未来一次发布"
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (API field + calendar badge).

# Why was this change needed?

The calendar and the public GET /posts expand every recurring (interval) post into future virtual occurrences that are indistinguishable from real scheduled posts - same id, no marker. During the recent recurring-posts incidents, a customer edited these projections believing they were standalone scheduled posts, which is part of how his schedule and the armed workflows drifted apart.

- The synthesized occurrences (every emitted date other than the row's real publishDate) now carry projected: true; the entry at the real date and non-recurring posts are unchanged.
- The calendar wire format maps the field (projected -> pj) like the other minified keys; the public API uses the repository payload directly, so the field flows through as-is.
- The calendar renders a small repeat badge with a tooltip on projected entries (new string translated via lingo.dev).

# Other information:

Verified with 10 assertions over the repository expansion and the minify/expand round-trip, plus visual verification in the dashboard (badge + tooltip on projections, no badge on the real occurrence). Backward-compatible: the field is additive and absent for non-projected entries.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the Contributor License Agreement (CLA) (maintainer)
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)