### PR TITLE
feat: admin stats - unique publishing/scheduled users per platform

### DIFF
--- a/apps/frontend/src/components/admin/admin-stats.component.tsx
+++ b/apps/frontend/src/components/admin/admin-stats.component.tsx
@@ -23,6 +23,8 @@ interface StatsResponse {
   errors: StatsBlock;
   posts: StatsBlock;
   connected: StatsBlock;
+  publishingAccounts?: StatsBlock;
+  scheduledAccounts?: StatsBlock;
 }
 
 const isoDaysAgo = (days: number) => {
@@ -225,7 +227,7 @@ export const AdminStatsComponent: FC = () => {
         <div className="text-red-400">Failed to load stats.</div>
       ) : (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-[12px]">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-[12px]">
             <SummaryCard label="Total posts published" value={data.posts.total} />
             <SummaryCard
               label="Total connected accounts"
@@ -235,9 +237,21 @@ export const AdminStatsComponent: FC = () => {
               label={unknownOnly ? 'Total unknown errors' : 'Total errors'}
               value={data.errors.total}
             />
+            {data.publishingAccounts && (
+              <SummaryCard
+                label="Unique users - published (all platforms combined)"
+                value={data.publishingAccounts.total}
+              />
+            )}
+            {data.scheduledAccounts && (
+              <SummaryCard
+                label="Unique users - scheduled (all platforms combined)"
+                value={data.scheduledAccounts.total}
+              />
+            )}
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-[12px]">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-[12px]">
             <PerSocialTable
               title="Posts published per social"
               block={data.posts}
@@ -252,6 +266,18 @@ export const AdminStatsComponent: FC = () => {
               }
               block={data.errors}
             />
+            {data.publishingAccounts && (
+              <PerSocialTable
+                title="Unique users - published"
+                block={data.publishingAccounts}
+              />
+            )}
+            {data.scheduledAccounts && (
+              <PerSocialTable
+                title="Unique users - scheduled"
+                block={data.scheduledAccounts}
+              />
+            )}
           </div>
         </>
       )}

--- a/libraries/nestjs-libraries/src/database/prisma/admin-stats/admin-stats.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/admin-stats/admin-stats.repository.ts
@@ -23,6 +23,8 @@ export interface StatsResponse {
   errors: { total: number; perSocial: PerSocial[] };
   posts: { total: number; perSocial: PerSocial[] };
   connected: { total: number; perSocial: PerSocial[] };
+  publishingAccounts: { total: number; perSocial: PerSocial[] };
+  scheduledAccounts: { total: number; perSocial: PerSocial[] };
 }
 
 const sortDesc = (list: PerSocial[]) =>
@@ -113,6 +115,73 @@ export class AdminStatsRepository {
     };
   }
 
+  // Distinct organizations with at least one top-level post in the range,
+  // per provider and overall: "publishing" = already PUBLISHED, "scheduled" =
+  // QUEUE or PUBLISHED (a published post was scheduled for that day too).
+  // The totals are distinct across all providers combined, not a summation.
+  private async accountStats(params: StatsParams) {
+    const whereBase: Prisma.PostWhereInput = {
+      parentPostId: null,
+      deletedAt: null,
+      publishDate: { gte: params.from, lte: params.to },
+    };
+
+    const [publishedGroups, scheduledGroups] = await Promise.all([
+      this._post.model.post.groupBy({
+        by: ['organizationId', 'integrationId'],
+        where: { ...whereBase, state: 'PUBLISHED' },
+      }),
+      this._post.model.post.groupBy({
+        by: ['organizationId', 'integrationId'],
+        where: { ...whereBase, state: { in: ['QUEUE', 'PUBLISHED'] } },
+      }),
+    ]);
+
+    const integrationIds = [
+      ...new Set(
+        [...publishedGroups, ...scheduledGroups].map((g) => g.integrationId)
+      ),
+    ];
+    const integrations = integrationIds.length
+      ? await this._integration.model.integration.findMany({
+          where: { id: { in: integrationIds } },
+          select: { id: true, providerIdentifier: true },
+        })
+      : [];
+    const providerById = new Map(
+      integrations.map((i) => [i.id, i.providerIdentifier])
+    );
+
+    const distinctOrgs = (
+      groups: { organizationId: string; integrationId: string }[]
+    ) => {
+      const allOrgs = new Set<string>();
+      const orgsByProvider = new Map<string, Set<string>>();
+      for (const g of groups) {
+        const provider = providerById.get(g.integrationId) || 'unknown';
+        if (!orgsByProvider.has(provider)) {
+          orgsByProvider.set(provider, new Set());
+        }
+        orgsByProvider.get(provider)!.add(g.organizationId);
+        allOrgs.add(g.organizationId);
+      }
+      return {
+        total: allOrgs.size,
+        perSocial: sortDesc(
+          [...orgsByProvider.entries()].map(([provider, orgs]) => ({
+            provider,
+            count: orgs.size,
+          }))
+        ),
+      };
+    };
+
+    return {
+      publishingAccounts: distinctOrgs(publishedGroups),
+      scheduledAccounts: distinctOrgs(scheduledGroups),
+    };
+  }
+
   private async connectedStats(params: StatsParams) {
     const where: Prisma.IntegrationWhereInput = {
       deletedAt: null,
@@ -140,9 +209,10 @@ export class AdminStatsRepository {
   }
 
   async getStats(params: StatsParams): Promise<StatsResponse> {
-    const [errors, posts, connected] = await Promise.all([
+    const [errors, posts, accounts, connected] = await Promise.all([
       this.errorStats(params),
       this.postStats(params),
+      this.accountStats(params),
       this.connectedStats(params),
     ]);
 
@@ -152,6 +222,8 @@ export class AdminStatsRepository {
       errors,
       posts,
       connected,
+      publishingAccounts: accounts.publishingAccounts,
+      scheduledAccounts: accounts.scheduledAccounts,
     };
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature - two new metrics on the super-admin stats page.

# Why was this change needed?

We need to know, per platform, how many unique customer accounts (organizations) are publishing or have posts scheduled each day, so we can tell how close we are to each platform's daily unique-users limit - especially TikTok, where we hit that wall several times in the last few days.

The /admin/stats response gains two additive blocks, `publishingAccounts` and `scheduledAccounts`: distinct organizations per platform plus an all-platforms-combined total (distinct across platforms, not a summation - an org posting on two platforms counts once in the total). Scheduled counts QUEUE + PUBLISHED top-level posts, so it always includes the published set; DRAFT and ERROR are excluded (drafts aren't scheduled, errored posts failed) - if that needs adjusting it's a one-line where-clause change. Same filters as the existing post stats (top-level posts only, not deleted, publishDate in range), same Prisma groupBy pattern, added to the existing Promise.all fan-out. Existing response fields and tables are unchanged, so the change is backward compatible.

Verified end-to-end locally: seeded scenarios confirm dup channels dedup (org with 2 LinkedIn channels counts once), combined totals are distinct not summed, scheduled >= published, queued-only platforms still get a row, and the real Instagram/TikTok posts in the local DB show correctly per date range.

# Other information:

Super-admin only page; strings untranslated like the rest of the page, so no lingo.dev run needed.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)