### PR TITLE
feat: invoice history icon in top bar, visible under the billing paywall

### DIFF
--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -153,6 +153,11 @@ export class BillingController {
     return this._stripeService.prorate(org.id, body);
   }
 
+  @Get('/invoices')
+  async getInvoices(@GetOrgFromRequest() org: Organization) {
+    return this._stripeService.getCharges(org.id);
+  }
+
   @Get('/charges')
   async getCharges(
     @GetUserFromRequest() user: User,

--- a/apps/frontend/src/components/billing/first.billing.component.tsx
+++ b/apps/frontend/src/components/billing/first.billing.component.tsx
@@ -28,6 +28,7 @@ import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 import useCookie from 'react-use-cookie';
 import { LogoutComponent } from '@gitroom/frontend/components/layout/logout.component';
 import { DeveloperIconComponent } from '@gitroom/frontend/components/developer/developer.icon.component';
+import { InvoicesComponent } from '@gitroom/frontend/components/layout/invoices.component';
 
 const ModeComponent = dynamic(
   () => import('@gitroom/frontend/components/layout/mode.component'),
@@ -183,6 +184,7 @@ export const FirstBillingComponent = () => {
         <div className="flex items-center">
           <div className="flex gap-[20px] text-textItemBlur">
             <OrganizationSelector />
+            <InvoicesComponent />
             <div className="hover:text-newTextColor">
               <ModeComponent />
             </div>

--- a/apps/frontend/src/components/layout/invoices.component.tsx
+++ b/apps/frontend/src/components/layout/invoices.component.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { FC, useCallback } from 'react';
+import useSWR from 'swr';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import { useVariables } from '@gitroom/react/helpers/variable.context';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+
+interface Charge {
+  id: string;
+  amount: number;
+  currency: string;
+  created: number;
+  status: string;
+  refunded: boolean;
+  amount_refunded: number;
+  description: string | null;
+  receipt_url: string | null;
+  invoice_pdf: string | null;
+}
+
+const useInvoices = () => {
+  const fetch = useFetch();
+  return useSWR<Charge[]>('/billing/invoices', async () => {
+    return (await fetch('/billing/invoices')).json();
+  }, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+  });
+};
+
+const InvoicesModal: FC<{ close: () => void }> = ({ close }) => {
+  const t = useT();
+  const { data: charges } = useInvoices();
+
+  return (
+    <div className="flex flex-col gap-[16px] min-w-[500px]">
+      <div className="max-h-[400px] overflow-y-auto">
+        {!charges?.length ? (
+          <div className="text-center py-[20px] text-newTextColor/60">
+            {t('no_charges', 'No charges found')}
+          </div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="text-left border-b border-newTableBorder">
+                <th className="p-[8px]">{t('date', 'Date')}</th>
+                <th className="p-[8px]">{t('amount', 'Amount')}</th>
+                <th className="p-[8px]">{t('status', 'Status')}</th>
+                <th className="p-[8px] w-[50px]" />
+              </tr>
+            </thead>
+            <tbody>
+              {charges.map((charge) => (
+                <tr
+                  key={charge.id}
+                  className="border-b border-newTableBorder hover:bg-tableBorder"
+                >
+                  <td className="p-[8px]">
+                    {new Date(charge.created * 1000).toLocaleDateString()}
+                  </td>
+                  <td className="p-[8px]">
+                    ${(charge.amount / 100).toFixed(2)}{' '}
+                    {charge.currency.toUpperCase()}
+                  </td>
+                  <td className="p-[8px]">
+                    {charge.refunded ? (
+                      <span className="text-red-400">
+                        {t('refunded', 'Refunded')}
+                      </span>
+                    ) : (
+                      <span className="text-green-400">
+                        {t('paid', 'Paid')}
+                      </span>
+                    )}
+                  </td>
+                  <td className="p-[8px]">
+                    {(charge.invoice_pdf || charge.receipt_url) && (
+                      <a
+                        href={charge.invoice_pdf || charge.receipt_url!}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center w-[28px] h-[28px] rounded-[4px] hover:bg-tableBorder transition-colors"
+                        title={charge.invoice_pdf ? t('download_invoice', 'Download Invoice') : t('view_receipt', 'View Receipt')}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          width="16"
+                          height="16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                          <polyline points="7 10 12 15 17 10" />
+                          <line x1="12" y1="15" x2="12" y2="3" />
+                        </svg>
+                      </a>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const InvoicesComponent: FC = () => {
+  const { billingEnabled, isGeneral } = useVariables();
+  const { openModal } = useModals();
+  const t = useT();
+
+  const handleClick = useCallback(() => {
+    openModal({
+      title: t('invoices', 'Invoices'),
+      children: (close) => <InvoicesModal close={close} />,
+    });
+  }, []);
+
+  if (!billingEnabled || !isGeneral) {
+    return null;
+  }
+
+  return (
+    <div
+      className="hover:text-newTextColor cursor-pointer"
+      data-tooltip-id="tooltip"
+      data-tooltip-content={t('invoices', 'Invoices')}
+      onClick={handleClick}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="8" y1="13" x2="16" y2="13" />
+        <line x1="8" y1="17" x2="16" y2="17" />
+      </svg>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/new-layout/layout.component.tsx
+++ b/apps/frontend/src/components/new-layout/layout.component.tsx
@@ -37,6 +37,7 @@ import { LanguageComponent } from '@gitroom/frontend/components/layout/language.
 import { ChromeExtensionComponent } from '@gitroom/frontend/components/layout/chrome.extension.component';
 import NotificationComponent from '@gitroom/frontend/components/notifications/notification.component';
 import { OrganizationSelector } from '@gitroom/frontend/components/layout/organization.selector';
+import { InvoicesComponent } from '@gitroom/frontend/components/layout/invoices.component';
 import { StreakComponent } from '@gitroom/frontend/components/layout/streak.component';
 import { PreConditionComponent } from '@gitroom/frontend/components/layout/pre-condition.component';
 import { AttachToFeedbackIcon } from '@gitroom/frontend/components/new-layout/sentry.feedback.component';
@@ -132,6 +133,7 @@ export const LayoutComponent = ({ children }: { children: ReactNode }) => {
                           <StreakComponent />
                           <div className="w-[1px] h-[20px] bg-blockSeparator" />
                           <OrganizationSelector />
+                          <InvoicesComponent />
                           <div className="hover:text-newTextColor">
                             <ModeComponent />
                           </div>

--- a/i18n.lock
+++ b/i18n.lock
@@ -735,3 +735,4 @@ checksums:
     cancel_coupon_title: 6a02a23e494728ddb694f591be65900d
     cancel_coupon_failed: 7bbb5c2646ba919b7df0879225eba918
     cancel_coupon_success: ded654a3b6c5fdfe7bdd23e9b5ad711c
+    invoices: 2a9cab536b243f033848ec5dfd92b0a7

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "نعم، إلغاء القسيمة",
   "cancel_coupon_title": "إلغاء القسيمة؟",
   "cancel_coupon_failed": "تعذّر إلغاء القسيمة",
-  "cancel_coupon_success": "تم إلغاء القسيمة"
+  "cancel_coupon_success": "تم إلغاء القسيمة",
+  "invoices": "فواتير"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "হ্যাঁ, কুপন বাতিল করুন",
   "cancel_coupon_title": "কুপন বাতিল করবেন?",
   "cancel_coupon_failed": "কুপন বাতিল করা যায়নি",
-  "cancel_coupon_success": "কুপন বাতিল হয়েছে"
+  "cancel_coupon_success": "কুপন বাতিল হয়েছে",
+  "invoices": "চালানসমূহ"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Ja, Gutschein stornieren",
   "cancel_coupon_title": "Gutschein stornieren?",
   "cancel_coupon_failed": "Der Gutschein konnte nicht storniert werden",
-  "cancel_coupon_success": "Gutschein storniert"
+  "cancel_coupon_success": "Gutschein storniert",
+  "invoices": "Rechnungen"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -732,5 +732,6 @@
   "yes_cancel_coupon": "Yes, cancel coupon",
   "cancel_coupon_title": "Cancel Coupon?",
   "cancel_coupon_failed": "Could not cancel the coupon",
-  "cancel_coupon_success": "Coupon cancelled"
+  "cancel_coupon_success": "Coupon cancelled",
+  "invoices": "Invoices"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Sí, cancelar cupón",
   "cancel_coupon_title": "¿Cancelar cupón?",
   "cancel_coupon_failed": "No se pudo cancelar el cupón",
-  "cancel_coupon_success": "Cupón cancelado"
+  "cancel_coupon_success": "Cupón cancelado",
+  "invoices": "Facturas"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Oui, annuler le coupon",
   "cancel_coupon_title": "Annuler le coupon ?",
   "cancel_coupon_failed": "Impossible d'annuler le coupon",
-  "cancel_coupon_success": "Coupon annulé"
+  "cancel_coupon_success": "Coupon annulé",
+  "invoices": "Factures"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "כן, בטל קופון",
   "cancel_coupon_title": "לבטל קופון?",
   "cancel_coupon_failed": "לא ניתן היה לבטל את הקופון",
-  "cancel_coupon_success": "הקופון בוטל"
+  "cancel_coupon_success": "הקופון בוטל",
+  "invoices": "חשבוניות"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Sì, annulla il coupon",
   "cancel_coupon_title": "Annulla coupon?",
   "cancel_coupon_failed": "Impossibile annullare il coupon",
-  "cancel_coupon_success": "Coupon annullato"
+  "cancel_coupon_success": "Coupon annullato",
+  "invoices": "Fatture"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "はい、クーポンをキャンセルします",
   "cancel_coupon_title": "クーポンをキャンセルしますか？",
   "cancel_coupon_failed": "クーポンをキャンセルできませんでした",
-  "cancel_coupon_success": "クーポンがキャンセルされました"
+  "cancel_coupon_success": "クーポンがキャンセルされました",
+  "invoices": "請求書"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "네, 쿠폰을 취소합니다.",
   "cancel_coupon_title": "쿠폰을 취소하시겠습니까?",
   "cancel_coupon_failed": "쿠폰을 취소할 수 없습니다.",
-  "cancel_coupon_success": "쿠폰이 취소되었습니다."
+  "cancel_coupon_success": "쿠폰이 취소되었습니다.",
+  "invoices": "송장"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Sim, cancelar cupom",
   "cancel_coupon_title": "Cancelar cupom?",
   "cancel_coupon_failed": "Não foi possível cancelar o cupom",
-  "cancel_coupon_success": "Cupom cancelado"
+  "cancel_coupon_success": "Cupom cancelado",
+  "invoices": "Faturas"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Да, отменить купон",
   "cancel_coupon_title": "Отменить купон?",
   "cancel_coupon_failed": "Не удалось отменить купон",
-  "cancel_coupon_success": "Купон отменён"
+  "cancel_coupon_success": "Купон отменён",
+  "invoices": "Счета-фактуры"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Evet, kuponu iptal et",
   "cancel_coupon_title": "Kupon İptal Edilsin mi?",
   "cancel_coupon_failed": "Kupon iptal edilemedi",
-  "cancel_coupon_success": "Kupon iptal edildi"
+  "cancel_coupon_success": "Kupon iptal edildi",
+  "invoices": "Faturalar"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "Đúng, hủy mã giảm giá",
   "cancel_coupon_title": "Hủy mã giảm giá?",
   "cancel_coupon_failed": "Không thể hủy mã giảm giá",
-  "cancel_coupon_success": "Đã hủy mã giảm giá"
+  "cancel_coupon_success": "Đã hủy mã giảm giá",
+  "invoices": "Hóa đơn"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -730,5 +730,6 @@
   "yes_cancel_coupon": "是的，取消优惠券",
   "cancel_coupon_title": "取消优惠券？",
   "cancel_coupon_failed": "无法取消该优惠券",
-  "cancel_coupon_success": "优惠券已取消"
+  "cancel_coupon_success": "优惠券已取消",
+  "invoices": "发票"
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature.

# Why was this change needed?

Customers who cancel their subscription drop to the FREE tier and hit the billing paywall, which blocks the settings/billing page - so they can no longer see or download their past invoices, and several unsubscribed customers asked for exactly that.

This adds a small invoice icon in the top-right header (between the organization switcher and the light/dark toggle) that opens a read-only Invoices modal: Date / Amount / Status per charge, with a download link to the Stripe invoice PDF (or receipt). It is a read-only version of the admin Manage Billing modal - no checkboxes, no refund/coupon/cancel buttons. The icon renders in both the normal layout header and the paywall screen's separate header (the whole point - cancelled users live on that screen), and only when billingEnabled && isGeneral, so self-hosted instances never see it.

Backend: one new endpoint, GET /billing/invoices, returning the caller's own org charges via the existing StripeService.getCharges. Charges are fetched lazily - only when the modal opens, never on layout mount. The superAdmin-only GET /billing/charges admin endpoint is untouched.

Includes lingo.dev translations for the new `invoices` key.

# Other information:

Tested locally against real Stripe test data: populated modal (3 charges, correct amounts/status), empty state ("No charges found") for orgs without charges, paywall header via an impersonated FREE-tier org, and the download link click-through to the Stripe-hosted receipt/invoice page. Frontend and backend production builds pass.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)