### PR TITLE
Fix mobile viewport metadata

### DIFF
--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -1,6 +1,11 @@
 import { SentryComponent } from '@gitroom/frontend/components/layout/sentry.component';
+import type { Viewport } from 'next';
 
 export const dynamic = 'force-dynamic';
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 import '../global.scss';
 import 'react-tooltip/dist/react-tooltip.css';
 import '@copilotkit/react-ui/styles.css';

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -1,4 +1,10 @@
+import type { Viewport } from 'next';
+
 export const dynamic = 'force-dynamic';
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 import '../global.scss';
 import 'react-tooltip/dist/react-tooltip.css';
 import '@copilotkit/react-ui/styles.css';

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -1,6 +1,11 @@
 import { MantineWrapper } from '@gitroom/react/helpers/mantine.wrapper';
+import type { Viewport } from 'next';
 
 export const dynamic = 'force-dynamic';
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 import '../global.scss';
 import 'react-tooltip/dist/react-tooltip.css';
 import '@copilotkit/react-ui/styles.css';


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Fixes #1845.

The frontend route layouts define their own document shell with `<html>`, `<head>`, and `<body>`, but did not provide an explicit Next.js viewport declaration. This can cause mobile browsers to render pages at desktop width and scale them down.

This adds a standard App Router `viewport` export with `width: 'device-width'` and `initialScale: 1` to the frontend app, extension, and provider root layouts.

# Other information:

Validation performed:

- `pnpm install --frozen-lockfile`
- `pnpm --filter ./apps/frontend run build`

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
