### PR TITLE
feat: admin stats - unique publishing/scheduled channels per platform

### DIFF
--- a/apps/frontend/src/app/(app)/(site)/admin/stats/page.tsx
+++ b/apps/frontend/src/app/(app)/(site)/admin/stats/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default async function Page() {
   return (
-    <div className="bg-newBgColorInner flex-1 flex-col flex p-[20px] gap-[12px]">
+    <div className="bg-newBgColorInner flex-1 min-w-0 flex-col flex p-[20px] gap-[12px]">
       <AdminStatsComponent />
     </div>
   );

--- a/apps/frontend/src/components/admin/admin-stats.component.tsx
+++ b/apps/frontend/src/components/admin/admin-stats.component.tsx
@@ -25,6 +25,8 @@ interface StatsResponse {
   connected: StatsBlock;
   publishingAccounts?: StatsBlock;
   scheduledAccounts?: StatsBlock;
+  publishingChannels?: StatsBlock;
+  scheduledChannels?: StatsBlock;
 }
 
 const isoDaysAgo = (days: number) => {
@@ -226,60 +228,117 @@ export const AdminStatsComponent: FC = () => {
       ) : error || !data ? (
         <div className="text-red-400">Failed to load stats.</div>
       ) : (
-        <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-[12px]">
-            <SummaryCard label="Total posts published" value={data.posts.total} />
-            <SummaryCard
-              label="Total connected accounts"
-              value={data.connected.total}
-            />
-            <SummaryCard
-              label={unknownOnly ? 'Total unknown errors' : 'Total errors'}
-              value={data.errors.total}
-            />
-            {data.publishingAccounts && (
+        <div className="overflow-x-auto pb-[8px] scrollbar scrollbar-thumb-fifth scrollbar-track-newBgColor flex flex-col gap-[16px]">
+          <div className="flex gap-[12px]">
+            <div className="flex-1 min-w-[220px] shrink-0">
               <SummaryCard
-                label="Unique users - published (all platforms combined)"
-                value={data.publishingAccounts.total}
+                label="Total posts published"
+                value={data.posts.total}
               />
+            </div>
+            <div className="flex-1 min-w-[220px] shrink-0">
+              <SummaryCard
+                label="Total connected accounts"
+                value={data.connected.total}
+              />
+            </div>
+            <div className="flex-1 min-w-[220px] shrink-0">
+              <SummaryCard
+                label={unknownOnly ? 'Total unknown errors' : 'Total errors'}
+                value={data.errors.total}
+              />
+            </div>
+            {data.publishingChannels && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <SummaryCard
+                  label="Unique channels - published (all platforms combined)"
+                  value={data.publishingChannels.total}
+                />
+              </div>
+            )}
+            {data.scheduledChannels && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <SummaryCard
+                  label="Unique channels - scheduled (all platforms combined)"
+                  value={data.scheduledChannels.total}
+                />
+              </div>
+            )}
+            {data.publishingAccounts && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <SummaryCard
+                  label="Unique users - published (all platforms combined)"
+                  value={data.publishingAccounts.total}
+                />
+              </div>
             )}
             {data.scheduledAccounts && (
-              <SummaryCard
-                label="Unique users - scheduled (all platforms combined)"
-                value={data.scheduledAccounts.total}
-              />
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <SummaryCard
+                  label="Unique users - scheduled (all platforms combined)"
+                  value={data.scheduledAccounts.total}
+                />
+              </div>
             )}
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-[12px]">
-            <PerSocialTable
-              title="Posts published per social"
-              block={data.posts}
-            />
-            <PerSocialTable
-              title="Connected accounts per social"
-              block={data.connected}
-            />
-            <PerSocialTable
-              title={
-                unknownOnly ? 'Unknown errors per social' : 'Errors per social'
-              }
-              block={data.errors}
-            />
-            {data.publishingAccounts && (
+          <div className="flex gap-[12px] items-start">
+            <div className="flex-1 min-w-[220px] shrink-0">
               <PerSocialTable
-                title="Unique users - published"
-                block={data.publishingAccounts}
+                title="Posts published per social"
+                block={data.posts}
               />
+            </div>
+            <div className="flex-1 min-w-[220px] shrink-0">
+              <PerSocialTable
+                title="Connected accounts per social"
+                block={data.connected}
+              />
+            </div>
+            <div className="flex-1 min-w-[220px] shrink-0">
+              <PerSocialTable
+                title={
+                  unknownOnly
+                    ? 'Unknown errors per social'
+                    : 'Errors per social'
+                }
+                block={data.errors}
+              />
+            </div>
+            {data.publishingChannels && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <PerSocialTable
+                  title="Unique channels - published"
+                  block={data.publishingChannels}
+                />
+              </div>
+            )}
+            {data.scheduledChannels && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <PerSocialTable
+                  title="Unique channels - scheduled"
+                  block={data.scheduledChannels}
+                />
+              </div>
+            )}
+            {data.publishingAccounts && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <PerSocialTable
+                  title="Unique users - published"
+                  block={data.publishingAccounts}
+                />
+              </div>
             )}
             {data.scheduledAccounts && (
-              <PerSocialTable
-                title="Unique users - scheduled"
-                block={data.scheduledAccounts}
-              />
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <PerSocialTable
+                  title="Unique users - scheduled"
+                  block={data.scheduledAccounts}
+                />
+              </div>
             )}
           </div>
-        </>
+        </div>
       )}
     </div>
   );

--- a/libraries/nestjs-libraries/src/database/prisma/admin-stats/admin-stats.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/admin-stats/admin-stats.repository.ts
@@ -25,6 +25,8 @@ export interface StatsResponse {
   connected: { total: number; perSocial: PerSocial[] };
   publishingAccounts: { total: number; perSocial: PerSocial[] };
   scheduledAccounts: { total: number; perSocial: PerSocial[] };
+  publishingChannels: { total: number; perSocial: PerSocial[] };
+  scheduledChannels: { total: number; perSocial: PerSocial[] };
 }
 
 const sortDesc = (list: PerSocial[]) =>
@@ -176,9 +178,37 @@ export class AdminStatsRepository {
       };
     };
 
+    // Same idea per channel: distinct integrations regardless of which
+    // organization owns them (a user with two TikTok channels counts twice).
+    const distinctChannels = (
+      groups: { organizationId: string; integrationId: string }[]
+    ) => {
+      const allChannels = new Set<string>();
+      const channelsByProvider = new Map<string, Set<string>>();
+      for (const g of groups) {
+        const provider = providerById.get(g.integrationId) || 'unknown';
+        if (!channelsByProvider.has(provider)) {
+          channelsByProvider.set(provider, new Set());
+        }
+        channelsByProvider.get(provider)!.add(g.integrationId);
+        allChannels.add(g.integrationId);
+      }
+      return {
+        total: allChannels.size,
+        perSocial: sortDesc(
+          [...channelsByProvider.entries()].map(([provider, channels]) => ({
+            provider,
+            count: channels.size,
+          }))
+        ),
+      };
+    };
+
     return {
       publishingAccounts: distinctOrgs(publishedGroups),
       scheduledAccounts: distinctOrgs(scheduledGroups),
+      publishingChannels: distinctChannels(publishedGroups),
+      scheduledChannels: distinctChannels(scheduledGroups),
     };
   }
 
@@ -224,6 +254,8 @@ export class AdminStatsRepository {
       connected,
       publishingAccounts: accounts.publishingAccounts,
       scheduledAccounts: accounts.scheduledAccounts,
+      publishingChannels: accounts.publishingChannels,
+      scheduledChannels: accounts.scheduledChannels,
     };
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature - follow-up to #1843.

# Why was this change needed?

#1843 added unique-user (organization) counts, but platforms like TikTok rate-limit per their own account - i.e. a Postiz channel - and know nothing about Postiz users. A user with two TikTok channels consumes two TikTok quotas, so we also need distinct-channel counts.

This adds `publishingChannels` and `scheduledChannels` to the `/admin/stats` response: distinct integrations with at least one published (PUBLISHED) / scheduled (QUEUE + PUBLISHED) top-level post in the range, per platform plus an all-platforms-combined distinct total. Derived from the same groupBy results as the unique-users blocks, so no extra DB queries.

On the Admin Stats page the two new columns appear between the original three and the unique-users pair. The cards and tables rows now share one horizontally scrolling section (themed always-visible scrollbar when overflowing): wide screens show all seven columns, narrow ones scroll right while the header/filters stay fixed. Also adds `min-w-0` on the page wrapper - the layout's flex chain was letting the page grow to content width and clip instead of scroll.

# Other information:

Superadmin-only page; response fields from #1843 are unchanged, the new blocks are additive.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)