### PR TITLE
fix(mcp): return 405 for GET/DELETE on the streamable-HTTP endpoints

### DIFF
--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -121,6 +121,10 @@ export const startMcp = async (app: INestApplication) => {
     // otherwise a GET opens an SSE stream that never emits and never closes,
     // leaving clients (e.g. ChatGPT) waiting forever.
     if (req.method === 'GET' || req.method === 'DELETE') {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', '*');
+      res.setHeader('Access-Control-Allow-Headers', '*');
+      res.setHeader('Access-Control-Expose-Headers', '*');
       res.setHeader('Allow', 'POST, OPTIONS');
       res.sendStatus(405);
       return;

--- a/libraries/nestjs-libraries/src/chat/start.mcp.ts
+++ b/libraries/nestjs-libraries/src/chat/start.mcp.ts
@@ -116,6 +116,16 @@ export const startMcp = async (app: INestApplication) => {
       return;
     }
 
+    // The serverless transport has no notification stream and no sessions, so
+    // per the MCP Streamable HTTP spec answer GET (and DELETE) with 405 -
+    // otherwise a GET opens an SSE stream that never emits and never closes,
+    // leaving clients (e.g. ChatGPT) waiting forever.
+    if (req.method === 'GET' || req.method === 'DELETE') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+      res.sendStatus(405);
+      return;
+    }
+
     const url = new URL('/mcp-oauth', process.env.NEXT_PUBLIC_BACKEND_URL);
 
     const result = await oauthMiddleware(req, res, url);
@@ -161,6 +171,12 @@ export const startMcp = async (app: INestApplication) => {
       return;
     }
 
+    if (req.method === 'GET' || req.method === 'DELETE') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+      res.sendStatus(405);
+      return;
+    }
+
     const token = req.headers.authorization?.replace('Bearer ', '');
     if (!token) {
       res.status(401).send('Missing Authorization header');
@@ -202,6 +218,12 @@ export const startMcp = async (app: INestApplication) => {
 
     if (req.method === 'OPTIONS') {
       res.sendStatus(200);
+      return;
+    }
+
+    if (req.method === 'GET' || req.method === 'DELETE') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+      res.sendStatus(405);
       return;
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix and resource fix in the backend MCP routes (`libraries/nestjs-libraries/src/chat/start.mcp.ts`). GET and DELETE on the streamable-HTTP MCP endpoints (`/mcp`, `/mcp/:id`, and the shared OAuth handler serving `/mcp-oauth`, `/mcp-oauth-chatgpt`, `/mcp-oauth-claude`, `/mcp-oauth-dynamic`) now return 405 with `Allow: POST, OPTIONS`, before any auth work. The legacy `/sse/:id` + `/message/:id` transport, OPTIONS handling, and the POST flow are deliberately unchanged.

# Why

Two independent motivations, one original and one found since:

1. **Stuck clients (original, 2026-08).** After a POST, streamable-HTTP clients may open a GET on the MCP endpoint - the spec's optional SSE notification stream. Our routes forwarded that GET into the serverless MCP handler, which opens an SSE stream that never emits and never closes, so clients (e.g. ChatGPT's custom connector UI) wait forever.
2. **Server resource drain (found 2026-09).** The MCP service was crashing about once a day on V8's heap limit (~3.4 GB, far below the container's memory). The heap climb stopped on 2026-09-16 when Sentry trace sampling was cut from 100% to 20% (PR #2082) with traffic unchanged (~750K MCP requests/day). What made tracing expensive is the GET traffic: ~214K GETs/day are held open ~5 min on average and ~15 min at p95 - roughly 650 concurrently held streams, each keeping alive a transient Mastra server with all tool handlers, a transport, the response, and a DB auth lookup. Clients reconnect whenever the stream is cut, so idle hosts hold one permanently.

The protocol explicitly allows declining these GETs. Spec 2025-06-18, "Listening for Messages", item 3: a server that does not offer an SSE stream MUST answer such a GET with 405 (https://modelcontextprotocol.io/specification/2025-06-18/basic/transports). The draft 2026-07-28 revision removes the GET stream entirely and tells servers to answer legacy GETs with 405 (https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http).

Who sends the GETs (Sentry, production, last 24h, extrapolated from the 20% sample, ~179K total): Claude Code variants ~64%, Go-http-client ~10%, Cursor ~9%, undici ~8%, node ~5%, python-httpx ~1%, plus small tails. The TypeScript SDK client treats a 405 here as "server does not offer an SSE stream" with no retry; the Go SDK and rmcp (Codex) behave the same per source review.

# What changed

- GET and DELETE return 405 with `Allow: POST, OPTIONS` on `/mcp`, `/mcp/:id`, and the shared OAuth handler covering all four `/mcp-oauth*` mounts, before the OAuth middleware and before any auth lookup.
- CORS headers are set on the OAuth 405 so browser-based clients can read the status.
- Deliberately untouched: legacy `/sse/:id` + `/message/:id` (GET is that transport's protocol), OPTIONS still 200/204, other methods already rejected by the SDK transport.

# Production impact

~1.51M GET and ~54K DELETE requests/week reached the handler at the time of the original measurement, each running the auth DB lookup; GET /mcp accounted for ~1,100 of ~8,000 weekly Prisma pool-timeout errors during the 2026-08-29 pool exhaustion. Today's equivalent is ~214K GETs/day held open as described above. All of that traffic is now answered in milliseconds before touching the DB.

# Validation

2026-09-18, against current main (GET guard; one 405 per connection, no retry loops, POST flow unaffected):
- curl route matrix: GET 405 with and without a token, OPTIONS 200, POST initialize / tools/list / tools/call on `/mcp` and `/mcp/:id`, legacy `/sse` still emits its endpoint event.
- MCP Inspector CLI (TypeScript SDK) on both routes.
- Claude Code: `claude mcp add`, connected, headless tool call.
- Official Python SDK (3.12): sends no GET at all since we issue no session id.
- claude.ai custom connector on `/mcp-oauth-dynamic` with dynamic client registration against a live backend: OAuth discovery starts with POST, the full session (401 challenge + 12 authenticated POSTs including a tool call after an idle gap) completed with zero GETs, so the pre-auth 405 does not affect it.
- Not exercised: Cursor (~9% of GETs, main untested exposure), undici-based clients, opencode. DELETE was validated in the original 2026-08 pass (curl 405), not re-run on 2026-09-18.

Post-deploy verification: in Sentry spans, `is_transaction:true transaction:*mcp* http.request.method:GET` grouped by `user_agent.original` and `http.response.status_code` - expect one 405 per session initialize and unchanged POST volume per agent (a burst of 405s from one agent means a retry loop; a drop in its POSTs means it gave up). Also expect the Mastra "Failed to handle serverless MCP request / aborted" log entries to stop and p95/p99 response time on the MCP service to fall from ~15 minutes to milliseconds.

# QA

1. [ ] Start the backend and run `curl -i -X GET <backend>/mcp` - expect 405 with `Allow: POST, OPTIONS` (previously the connection hung open).
2. [ ] `curl -i -X DELETE <backend>/mcp` - expect the same 405.
3. [ ] `curl -i -X OPTIONS <backend>/mcp` - expect 200 as before.
4. [ ] `curl -i -X GET <backend>/mcp-oauth-dynamic` - expect 405 with the CORS headers present, without any auth.
5. [ ] POST an `initialize` request with a valid API key to `/mcp` and `/mcp/<api-key>` - expect the normal JSON-RPC response, unchanged.
6. [ ] `curl -N <backend>/sse/<api-key>` - expect the legacy SSE transport to still emit its endpoint event.
7. [ ] Connect Claude Code (`claude mcp add --transport http postiz <backend>/mcp -H "Authorization: Bearer <key>"`) and run a tool call - expect it to work with no stuck connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb6XUm6D33vL8KnkvNPfXq
