### PR TITLE
fix(pinterest): read pin analytics from summary_metrics instead of lifetime_metrics

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -638,40 +638,43 @@ export class PinterestProvider
       const result: AnalyticsData[] = [];
       const metrics = data.all;
 
-      if (metrics.lifetime_metrics) {
-        const lifetimeMetrics = metrics.lifetime_metrics;
+      // The requested metric types are period metrics: Pinterest returns them
+      // in summary_metrics, never in lifetime_metrics (that only ever carries
+      // TOTAL_COMMENTS / TOTAL_REACTIONS).
+      if (metrics.summary_metrics) {
+        const summaryMetrics = metrics.summary_metrics;
 
-        if (lifetimeMetrics.IMPRESSION !== undefined) {
+        if (summaryMetrics.IMPRESSION !== undefined) {
           result.push({
             label: 'Impressions',
             percentageChange: 0,
-            data: [{ total: String(lifetimeMetrics.IMPRESSION), date: today }],
+            data: [{ total: String(summaryMetrics.IMPRESSION), date: today }],
           });
         }
 
-        if (lifetimeMetrics.PIN_CLICK !== undefined) {
+        if (summaryMetrics.PIN_CLICK !== undefined) {
           result.push({
             label: 'Pin Clicks',
             percentageChange: 0,
-            data: [{ total: String(lifetimeMetrics.PIN_CLICK), date: today }],
+            data: [{ total: String(summaryMetrics.PIN_CLICK), date: today }],
           });
         }
 
-        if (lifetimeMetrics.OUTBOUND_CLICK !== undefined) {
+        if (summaryMetrics.OUTBOUND_CLICK !== undefined) {
           result.push({
             label: 'Outbound Clicks',
             percentageChange: 0,
             data: [
-              { total: String(lifetimeMetrics.OUTBOUND_CLICK), date: today },
+              { total: String(summaryMetrics.OUTBOUND_CLICK), date: today },
             ],
           });
         }
 
-        if (lifetimeMetrics.SAVE !== undefined) {
+        if (summaryMetrics.SAVE !== undefined) {
           result.push({
             label: 'Saves',
             percentageChange: 0,
-            data: [{ total: String(lifetimeMetrics.SAVE), date: today }],
+            data: [{ total: String(summaryMetrics.SAVE), date: today }],
           });
         }
       }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix: Pinterest per-post analytics always showed no data.

# Why was this change needed?

A customer reported that no stats are pulled for any of their Pinterest posts. Root cause: `postAnalytics` requests `metric_types=IMPRESSION,PIN_CLICK,OUTBOUND_CLICK,SAVE` but reads the results from `data.all.lifetime_metrics`. Pinterest returns the requested period metrics in `summary_metrics` (and `daily_metrics`) — `lifetime_metrics` only ever carries the lifetime metric types (`TOTAL_COMMENTS`/`TOTAL_REACTIONS`), which we don't request, and a single request cannot mix lifetime and non-lifetime types. So `lifetime_metrics` was always absent/empty and the method returned `[]` for every pin, for every user.

Evidence:
- Pinterest community thread with a support-confirmed response showing `"lifetime_metrics": {}` alongside populated `summary_metrics` for these metric types: https://community.pinterest.biz/t5/developer-discussions/how-to-get-pin-likes-and-comments-count/td-p/64257
- Pinterest's generated client docs: `summary_metrics` = "the metric name and value over the requested period for each requested metric": https://github.com/pinterest/pinterest-python-generated-api-client/blob/main/docs/PinAnalyticsMetricsResponse.md

Verified end-to-end against the live Pinterest API: published a real pin, before the fix `postAnalytics` returned `[]`, after the fix it returns all four metrics (raw API response confirmed: `"all":{"summary_metrics":{"IMPRESSION":0,"OUTBOUND_CLICK":0,"SAVE":0,"PIN_CLICK":0},...}`).

# Other information:

Note the customer who triggered this also has no channel (account) analytics — that part is a Pinterest limitation (analytics exist only for business accounts), answered separately.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)