### PR TITLE
fix(youtube,tiktok): request identity encoding on the media reads

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -688,8 +688,13 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
   // read stream for local files.
   private async tiktokChunkStream(path: string, start: number, end: number) {
     if (path.indexOf('http') === 0) {
+      // identity encoding so the store keeps content-length and can answer
+      // with the requested range, matching every other media read
       const response = await fetch(path, {
-        headers: { Range: `bytes=${start}-${end}` },
+        headers: {
+          Range: `bytes=${start}-${end}`,
+          'accept-encoding': 'identity',
+        },
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
 

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -431,9 +431,12 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
   private async youtubeMediaSize(path: string): Promise<number> {
     if (path.indexOf('http') === 0) {
       // the media path is user-influenced, keep the SSRF-safe dispatcher that
-      // this.fetch applies to every other outbound request
+      // this.fetch applies to every other outbound request. identity encoding
+      // so content-length matches the bytes a later GET actually streams
+      // (fetch transparently decompresses encoded bodies).
       const head = await fetch(path, {
         method: 'HEAD',
+        headers: { 'accept-encoding': 'identity' },
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
       const length = head.headers.get('content-length');
@@ -456,8 +459,14 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
   // read stream for local files.
   private async youtubeChunkStream(path: string, start: number, end: number) {
     if (path.indexOf('http') === 0) {
+      // identity encoding so the store keeps content-length and can answer
+      // with the requested range: a transformed (compressed) response loses
+      // its length, and a length-less object is answered with the full body.
       const response = await fetch(path, {
-        headers: { Range: `bytes=${start}-${end}` },
+        headers: {
+          Range: `bytes=${start}-${end}`,
+          'accept-encoding': 'identity',
+        },
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

## The customer report

A customer reported (Discord) that ~1 GB YouTube uploads through Postiz fail often enough that they built a heartbeat agent just to check whether their posts actually went out. Their own investigation was accurate: the same hosted files alternated between passing and failing without being changed, an immediately-failed post succeeded a minute later after restarting the same row, and larger files fail more often without there being a fixed size limit.

## Root cause

`YoutubeProvider.youtubeMediaSize` / `youtubeChunkStream` and `TiktokProvider.tiktokChunkStream` read the stored video back from media storage with their own HEAD and ranged-GET helpers, and none of them asked for identity encoding. Every other media read in the project does — #1835 added `accept-encoding: identity` to `SocialAbstract.mediaSize` / `mediaChunk` / `mediaStream` and to the providers that read media themselves.

That header matters here for two reasons, both documented by Cloudflare:

- Cloudflare may transform (compress) a response, and when it does, ["Cloudflare may remove the `Content-Length` HTTP header of responses delivered to website visitors"](https://developers.cloudflare.com/speed/optimization/content/compression/). Which compression is applied is driven by ["the values visitors provide in the `accept-encoding` request header"](https://developers.cloudflare.com/speed/optimization/content/compression/) — so asking for `identity` is the client-side way to keep the response untransformed and its length intact. (The origin-side equivalent Cloudflare documents is `cache-control: no-transform`, which "must be set by the origin — it cannot be added in client requests".)
- With no `Content-Length` the edge cannot serve a byte range: ["If the origin response does not include the `Content-Length` header, the cache will return the full content with an HTTP 200 response"](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/), instead of the 206 the uploader asked for.

A 200-with-full-body is currently thrown as `BadBody`, which `postWorkflowV106` treats as a permanent platform rejection: the post is marked ERROR immediately with no retry. A 1 GB video needs ~128 ranged reads, so one such answer kills the whole post even though the YouTube upload session itself is still perfectly resumable. That matches the reported symptom, including why it scales with file size and why an identical file behaves differently between attempts.

## Why the header was missing here

This looks like an artifact of PR merge ordering rather than a decision. #1813 introduced these bespoke YouTube/TikTok helpers on 2026-08-03. #1835 swept identity encoding across the project on 2026-08-04, but it had been written against a tree that did not yet contain them — so X and LinkedIn (which had their own bespoke ranged reads at the time, from #1796 and #1786) were consolidated onto the shared helpers and fixed, while YouTube and TikTok were missed. `SocialAbstract` and every provider that reads media through it has had the header since; these three call sites were the only ones left without it.

# Other information:

- **Scope:** this PR only adds the header. Behaviour on a non-206 response is deliberately unchanged, so the fix is a prevention rather than a behaviour change, and its effect can be observed on its own.
- **Please monitor after deploy.** The customer symptom (large YouTube uploads intermittently going to ERROR with "The media storage did not return the requested byte range") should stop. **If it recurs, the follow-up is to stop treating that specific answer as permanent:** a documented 200-with-full-body would be thrown as a plain `Error` instead of `BadBody`, which the v1.0.6 workflow already knows how to handle — it re-probes the upload session and resumes from the exact committed byte offset, with a bounded consecutive-failure budget. That behaviour was prototyped and verified end-to-end against a storage server injecting Cloudflare-style 200s: pre-change the post died at the third chunk; with the reclassification the same upload survived five injected failures, resuming byte-exactly each time, and published in 98 s. It is being held back deliberately in favour of trying the smaller, in-pattern fix first.
- **Suggested follow-ups (not included here):**
  - Delete `youtubeMediaSize` and call `SocialAbstract.mediaSize` instead, as TikTok already does. The generic helper is a strict superset: it also rejects a non-ok HEAD and a zero/NaN length (a failed HEAD can still carry the `Content-Length` of its error body, which would poison the chunk-count math downstream).
  - Consolidate `youtubeChunkStream` / `tiktokChunkStream` into a single `mediaChunkStream` on `SocialAbstract`, next to `mediaChunk` (ranged, buffered) and `mediaStream` (whole file, streamed). The ranged-*stream* shape is the one combination the abstract does not offer today, which is why both providers hand-rolled it; a shared helper would have been swept automatically by #1835 and would keep the non-206 classification in one place. Note the two callers do not want identical error semantics — YouTube can probe and resume its session, TikTok cannot — so the shared helper should throw one error type and let each caller classify it.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
