### PR TITLE
feat(instagram): use custom thumbnail as reel cover via cover_url

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
@@ -27,6 +27,19 @@ const attachmentUrl = z
     message: validUrlExtension.defaultMessage({} as any),
   });
 
+// Attachments are either a plain URL string or { path, thumbnail? } where
+// thumbnail is an image URL (jpeg/png) used as the video's thumbnail / cover.
+const attachment = z.union([
+  attachmentUrl,
+  z.object({
+    path: attachmentUrl,
+    thumbnail: attachmentUrl.optional(),
+  }),
+]);
+
+const toMedia = (a: string | { path: string; thumbnail?: string }) =>
+  typeof a === 'string' ? { path: a } : { path: a.path, thumbnail: a.thumbnail };
+
 @Injectable()
 export class IntegrationSchedulePostTool implements AgentToolInterface {
   constructor(
@@ -93,8 +106,10 @@ If the tools return errors, you would need to rerun it with the right parameters
                         "The content of the post, HTML, Each line must be wrapped in <p> here is the possible tags: h1, h2, h3, u, strong, li, ul, p (you can't have u and strong together)"
                       ),
                     attachments: z
-                      .array(attachmentUrl)
-                      .describe('The image of the post (URLS)'),
+                      .array(attachment)
+                      .describe(
+                        'The media of the post: either an uploaded media URL string, or { path, thumbnail } where path is the uploaded video URL and thumbnail is the path of an uploaded jpeg/png (returned by uploadFromUrlTool) used as the video thumbnail / cover (e.g. Instagram Reel cover)'
+                      ),
                   })
                 )
                 .describe(
@@ -163,9 +178,7 @@ If the tools return errors, you would need to rerun it with the right parameters
                 settings,
                 value: platform.postsAndComments.map((p: any) => ({
                   content: p.content,
-                  image: (p.attachments || []).map((path: string) => ({
-                    path,
-                  })),
+                  image: (p.attachments || []).map(toMedia),
                 })),
               },
             ]
@@ -229,9 +242,9 @@ If the tools return errors, you would need to rerun it with the right parameters
                   content: p.content,
                   id: makeId(10),
                   delay: 0,
-                  image: p.attachments.map((p: any) => ({
+                  image: p.attachments.map((a: any) => ({
                     id: makeId(10),
-                    path: p,
+                    ...toMedia(a),
                   })),
                 })),
               },

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -670,6 +670,10 @@ export class InstagramProvider
           ? firstPost?.media?.length === 1
             ? isStory
               ? `video_url=${m.path}&media_type=STORIES`
+              : m?.thumbnail
+              ? `video_url=${m.path}&media_type=REELS&cover_url=${encodeURIComponent(
+                  m.thumbnail
+                )}`
               : `video_url=${m.path}&media_type=REELS&thumb_offset=${
                   m?.thumbnailTimestamp || 0
                 }`


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature.

# Why was this change needed?

Instagram Reels published through Postiz always derived their cover from the video itself (`thumb_offset` with the captured-frame timestamp). Instagram's Content Publishing API also supports `cover_url` on REELS media containers, which uses a hosted image as the reel cover in the feed and profile grid. When a reel's media has a thumbnail set, the provider now sends it as `cover_url`; media without a thumbnail keep publishing via `thumb_offset` exactly as before. Stories, carousel items and images are untouched. No schema change — this reuses the existing `Media.thumbnail` column that already flows to providers.

Second commit: the MCP `integrationSchedulePostTool` now accepts attachments as either a URL string or `{ path, thumbnail }` and forwards `thumbnail` as the media thumbnail, so MCP clients can set the Reel cover too. The public API already accepted `image[].thumbnail`, no change needed there.

Docs: gitroomhq/postiz-docs#238, agent docs: gitroomhq/postiz-agent#18 (both to be merged after this PR is deployed).

# Other information:

E2e-tested on a Facebook-Login Instagram channel: published reels with both JPEG and PNG cover images and confirmed the cover renders on the profile reels grid (PNG is accepted in practice even though Meta's docs list JPEG only). The standalone Instagram-Login provider delegates to the same `postPending`, so it is covered by the same code path (not separately e2e-tested for lack of a connected standalone channel).

MCP + public API: published one Reel via `integrationSchedulePostTool` with `{ path, thumbnail }` and one via `POST /public/v1/posts` with `image[].thumbnail`; both covers rendered correctly on Instagram.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
