### PR TITLE
feat(media): pick video thumbnail from the media gallery

### DIFF
--- a/apps/frontend/src/components/launches/helpers/media.settings.component.tsx
+++ b/apps/frontend/src/components/launches/helpers/media.settings.component.tsx
@@ -7,6 +7,8 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { hasExtension } from '@gitroom/helpers/utils/has.extension';
 import { useLaunchStore } from '@gitroom/frontend/components/new-launch/store';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
+import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+import { MediaBox } from '@gitroom/frontend/components/media/media.component';
 const postUrlEmitter = new EventEmitter();
 
 export const MediaSettingsLayout = () => {
@@ -311,6 +313,7 @@ export const MediaComponentInner: FC<{
   const { onClose, onSelect, media } = props;
   const setActivateExitButton = useLaunchStore((e) => e.setActivateExitButton);
   const newFetch = useFetch();
+  const modals = useModals();
   const [newThumbnail, setNewThumbnail] = useState<string | null>(null);
   const [isEditingThumbnail, setIsEditingThumbnail] = useState(false);
   const [altText, setAltText] = useState<string>(media?.alt || '');
@@ -382,30 +385,55 @@ export const MediaComponentInner: FC<{
           <div>
             {!isEditingThumbnail ? (
               <div className="flex flex-col">
-                {/* Show existing thumbnail if it exists */}
-                {(newThumbnail || thumbnail) && (
-                  <div className="flex flex-col space-y-2">
-                    <span className="text-sm text-textColor">
-                      Current Thumbnail:
-                    </span>
+                <div className="flex flex-col space-y-2">
+                  <span className="text-sm text-textColor">Thumbnail:</span>
+                  {(newThumbnail || thumbnail) && (
                     <img
                       src={newThumbnail || thumbnail}
                       alt="Current thumbnail"
                       className="max-w-full max-h-[500px] object-contain rounded-lg border border-tableBorder"
                     />
-                  </div>
-                )}
+                  )}
+                </div>
 
                 {/* Action Buttons */}
-                <div className="flex space-x-2">
+                <div className="flex space-x-2 mt-[12px]">
                   <button
                     disabled={loading}
                     onClick={() => setIsEditingThumbnail(true)}
-                    className="bg-third text-textColor px-6 py-2 rounded-lg hover:bg-opacity-80 transition-all flex-1 border border-tableBorder"
+                    className="bg-third text-textColor px-6 py-2 rounded-lg hover:bg-opacity-80 transition-all flex-1 border border-tableBorder whitespace-nowrap"
                   >
-                    {media.thumbnail || newThumbnail
-                      ? 'Edit Thumbnail'
-                      : 'Create Thumbnail'}
+                    Select Frame
+                  </button>
+                  <button
+                    disabled={loading}
+                    onClick={() =>
+                      modals.openModal({
+                        title: 'Media Library',
+                        askClose: false,
+                        closeOnEscape: true,
+                        fullScreen: true,
+                        size: 'calc(100% - 80px)',
+                        height: 'calc(100% - 80px)',
+                        children: (close) => (
+                          <MediaBox
+                            type="image-static"
+                            closeModal={close}
+                            setMedia={(m) => {
+                              const [first] = m || [];
+                              if (first) {
+                                setNewThumbnail(null);
+                                setThumbnail(first.path);
+                                setThumbnailTimestamp(null);
+                              }
+                            }}
+                          />
+                        ),
+                      })
+                    }
+                    className="bg-third text-textColor px-6 py-2 rounded-lg hover:bg-opacity-80 transition-all flex-1 border border-tableBorder whitespace-nowrap"
+                  >
+                    From Gallery
                   </button>
                   {(thumbnail || newThumbnail) && (
                     <button
@@ -414,9 +442,9 @@ export const MediaComponentInner: FC<{
                         setNewThumbnail(null);
                         setThumbnail(null);
                       }}
-                      className="bg-red-600 text-white px-6 py-2 rounded-lg hover:bg-opacity-80 transition-all flex-1 border border-red-700"
+                      className="bg-red-600 text-white px-6 py-2 rounded-lg hover:bg-opacity-80 transition-all flex-1 border border-red-700 whitespace-nowrap"
                     >
-                      Clear Thumbnail
+                      Clear
                     </button>
                   )}
                 </div>

--- a/apps/frontend/src/components/media/media.component.tsx
+++ b/apps/frontend/src/components/media/media.component.tsx
@@ -532,8 +532,8 @@ export const MediaBox: FC<{
                 } else if (type === 'image') {
                   return !hasExtension(f.path, 'mp4');
                 } else if (type === 'image-static') {
-                  return (
-                    !hasExtension(f.path, 'mp4') && !hasExtension(f.path, 'gif')
+                  return ['jpg', 'jpeg', 'png'].some((ext) =>
+                    hasExtension(f.path, ext)
                   );
                 }
                 return true;

--- a/apps/frontend/src/components/media/media.component.tsx
+++ b/apps/frontend/src/components/media/media.component.tsx
@@ -203,7 +203,7 @@ const MAX_UPLOAD_SIZE = 1024 * 1024 * 1024; // 1 GB
 export const MediaBox: FC<{
   setMedia: (params: { id: string; path: string }[]) => void;
   standalone?: boolean;
-  type?: 'image' | 'video';
+  type?: 'image' | 'image-static' | 'video';
   closeModal: () => void;
 }> = ({ type, standalone, setMedia }) => {
   const [page, setPage] = useState(0);
@@ -236,6 +236,8 @@ export const MediaBox: FC<{
     allowedFileTypes:
       type == 'image'
         ? 'image/*'
+        : type == 'image-static'
+        ? 'image/jpeg,image/png'
         : type == 'video'
         ? 'video/mp4'
         : 'image/*,video/mp4',
@@ -529,6 +531,10 @@ export const MediaBox: FC<{
                   return hasExtension(f.path, 'mp4');
                 } else if (type === 'image') {
                   return !hasExtension(f.path, 'mp4');
+                } else if (type === 'image-static') {
+                  return (
+                    !hasExtension(f.path, 'mp4') && !hasExtension(f.path, 'gif')
+                  );
                 }
                 return true;
               })
@@ -776,6 +782,7 @@ export const MultiMediaComponent: FC<{
                         onClick={async () => {
                           modals.openModal({
                             title: t('media_settings', 'Media Settings'),
+                            size: '720px',
                             children: (close) => (
                               <MediaComponentInner
                                 media={media as any}


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature.

# Why was this change needed?

The per-media thumbnail settings only offered capturing a frame from the video. Users asked to use an arbitrary image as a video's thumbnail, so the modal now has a "From Gallery" option that opens the media library (including its upload flow) and saves the picked image as the media's thumbnail (clearing the stale frame timestamp).

The gallery opens in a new MediaBox `image-static` mode — videos and GIFs are hidden and the uploader accepts only JPEG/PNG — because every consumer of this thumbnail treats it as a static image: Instagram reel covers accept JPEG (PNG verified working in practice), Reddit's media-asset API (which re-hosts the thumbnail as `video_poster_url`, mandatory for video posts) accepts JPEG/PNG, and thumbnails never animate anywhere, so offering GIFs or WebP would only mislead. Tumblr reads the field just for dimensions; YouTube uses its separate per-post settings thumbnail and is unaffected.

Also relabels the buttons ("Select Frame" / "From Gallery" / "Clear"), keeps the "Thumbnail" subtitle always visible, and widens the settings modal so the labels fit on one line.

# Other information:

E2e-tested with Instagram reels on a Facebook-Login channel: thumbnails picked (and uploaded) via the gallery — both JPEG and PNG — were saved on the media record with `thumbnailTimestamp` cleared, and published reels showed the picked image as the cover on the profile grid. Reddit was verified by code inspection only: the gallery-picked file flows through the same `uploadFileToReddit` path as frame captures, with the mimetype derived from the file's real extension.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)