### PR TITLE
feat(upload): reject mp4 uploads missing the moov atom

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -15,6 +15,8 @@ import {
 import {
   CustomFileValidationPipe,
   getMaxSize,
+  isCompleteMp4,
+  INCOMPLETE_MP4_ERROR,
 } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { ApiTags } from '@nestjs/swagger';
 import { GetOrgFromRequest } from '@gitroom/nestjs-libraries/user/org.from.request';
@@ -137,6 +139,10 @@ export class PublicIntegrationsController {
 
     if (buffer.length > getMaxSize(detected.mime)) {
       throw new HttpException({ msg: 'File is too large.' }, 400);
+    }
+
+    if (detected.mime === 'video/mp4' && !isCompleteMp4(buffer)) {
+      throw new HttpException({ msg: INCOMPLETE_MP4_ERROR }, 400);
     }
 
     const mimetype = detected.mime;

--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -4,7 +4,11 @@ import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import { MediaService } from '@gitroom/nestjs-libraries/database/prisma/media/media.service';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
-import { getMaxSize } from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
+import {
+  getMaxSize,
+  isCompleteMp4,
+  INCOMPLETE_MP4_ERROR,
+} from '@gitroom/nestjs-libraries/upload/custom.upload.validation';
 import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
 import { ssrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import { Readable } from 'stream';
@@ -100,6 +104,10 @@ so the attachment passes the upload-domain validation. Returns the hosted media 
             return {
               error: `File is too large: ${buffer.length} bytes (max ${maxSize} bytes).`,
             };
+          }
+
+          if (detected.mime === 'video/mp4' && !isCompleteMp4(buffer)) {
+            return { error: INCOMPLETE_MP4_ERROR };
           }
 
           const getFile = await this.storage.uploadFile({

--- a/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
+++ b/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
@@ -89,6 +89,10 @@ export function isCompleteMp4(buffer: Buffer): boolean {
         return false;
       }
       size = Number(largeSize);
+      // a largesize box header is 16 bytes, so smaller values are malformed
+      if (size < 16) {
+        return false;
+      }
     }
     if (size < 8) {
       return false;

--- a/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
+++ b/libraries/nestjs-libraries/src/upload/custom.upload.validation.ts
@@ -45,6 +45,10 @@ export class CustomFileValidationPipe implements PipeTransform {
       );
     }
 
+    if (detected.mime === 'video/mp4' && !isCompleteMp4(value.buffer)) {
+      throw new BadRequestException(INCOMPLETE_MP4_ERROR);
+    }
+
     value.mimetype = detected.mime;
     const safeBase = (value.originalname || 'upload')
       .replace(/\.[^./\\]*$/, '')
@@ -55,6 +59,43 @@ export class CustomFileValidationPipe implements PipeTransform {
     return value;
   }
 
+}
+
+export const INCOMPLETE_MP4_ERROR =
+  'Video file is corrupted or incomplete (missing moov atom). This usually means the file was uploaded before the encoder finished writing it — wait for the render to complete and upload it again.';
+
+// A playable mp4 must contain a top-level moov box (the index of the file).
+// Encoders write it last (or rewrite the file with it first for faststart),
+// so a file grabbed mid-encode has only ftyp + mdat and can't be played or
+// published anywhere.
+export function isCompleteMp4(buffer: Buffer): boolean {
+  let offset = 0;
+  while (offset + 8 <= buffer.length) {
+    let size: number = buffer.readUInt32BE(offset);
+    const type = buffer.toString('latin1', offset + 4, offset + 8);
+    if (type === 'moov') {
+      return true;
+    }
+    if (size === 0) {
+      // box extends to end of file
+      return false;
+    }
+    if (size === 1) {
+      if (offset + 16 > buffer.length) {
+        return false;
+      }
+      const largeSize = buffer.readBigUInt64BE(offset + 8);
+      if (largeSize > BigInt(Number.MAX_SAFE_INTEGER)) {
+        return false;
+      }
+      size = Number(largeSize);
+    }
+    if (size < 8) {
+      return false;
+    }
+    offset += size;
+  }
+  return false;
 }
 
 export function getMaxSize(mimeType: string): number {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix / validation feature

# Why was this change needed?

A customer's API automation uploaded mp4 renders before their video generator finished writing them. Postiz stored the files (black tiles in the media gallery), and the scheduled posts failed days later at publish time with Pinterest's "The file is corrupted and cannot be uploaded".

Per ISO/IEC 14496-12 §8.2.1, every mp4 must contain exactly one `moov` box — it holds the codec config and sample tables, so a file without it is permanently unplayable. Encoders write `moov` last, which is why a file grabbed mid-encode has only `ftyp` + `free` + zero-sized `mdat`. Two such production files showed this exact signature.

The upload validation now walks the mp4's top-level boxes (a few size-field hops, negligible cost, 64-bit largesize handled) and rejects files with no `moov`, so automations get an immediate 400 instead of a delayed publish failure. Covered paths: public API `/upload` and `/upload-from-url`, the agent upload tool, and the validation-pipe routes; the hosted web-UI path (browser → R2 via Uppy) never passes bytes through the server, which matches the failure mode — only automation races the encoder.

The second commit hardens the box walker: a `size==1` box carries a 64-bit largesize with a 16-byte header, so any largesize under 16 is malformed; the generic `size<8` guard let 8–15 through and misaligned the walk on crafted input.

# Other information:

Verified e2e locally: `/upload` returns 201 for a valid mp4 and 400 for a moov-less one; the MCP upload-from-URL tool succeeds on a known-good production file and returns the graceful error for the customer's actual corrupt file. A structurally complete mp4 with undecodable tracks still passes — catching that class would need ffprobe-level demuxing.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue