### PR TITLE
feat(instagram): forward media thumbnail as cover_url for Reels (#1572)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -666,13 +666,18 @@ export class InstagramProvider
           (firstPost?.media?.length || 0) > 1 && !isStory
             ? `&is_carousel_item=true`
             : ``;
+        // A cover attached to the media wins over thumb_offset on Meta's side,
+        // so it is only sent when the user actually picked one.
+        const coverUrl = m?.thumbnail
+          ? `&cover_url=${encodeURIComponent(m.thumbnail)}`
+          : ``;
         const mediaType = hasExtension(m.path, 'mp4')
           ? firstPost?.media?.length === 1
             ? isStory
               ? `video_url=${m.path}&media_type=STORIES`
               : `video_url=${m.path}&media_type=REELS&thumb_offset=${
                   m?.thumbnailTimestamp || 0
-                }`
+                }${coverUrl}`
             : isStory
             ? `video_url=${m.path}&media_type=STORIES`
             : `video_url=${m.path}&media_type=VIDEO&thumb_offset=${


### PR DESCRIPTION
Closes #1572.

### Problem

A Reel's cover can currently only be a frame of the video: the provider sends `thumb_offset` and nothing else, so the cover is whatever frame sits at that offset. Videos that fade in from black therefore land on the profile grid as a black tile.

Postiz already has every piece needed to do better:

- `Media.thumbnail` exists in the schema and is settable from `media.settings.component.tsx`;
- the public API's `MediaDto` already accepts `thumbnail`;
- `MediaContent.thumbnail` is already on the provider-facing type;
- other providers already consume it — `reddit.provider.ts` (`mediaThumbnail`), `tumblr.provider.ts`, `lemmy.provider.ts` (`custom_thumbnail`).

Only the Instagram provider drops it.

### Change

Send the attached thumbnail as `cover_url` on the REELS container. Six lines, no new fields, no migration.

Meta gives `cover_url` precedence over `thumb_offset`, and the parameter is only appended when a thumbnail is actually attached — so media without a thumbnail behaves exactly as before.

### Verification

I checked that `cover_url` is honoured on `graph.instagram.com/v20.0` — the same host and version this provider posts to — since Meta's published reference for `cover_url` documents the Facebook Login variant, not this one.

Three containers were created against a real Instagram Business account with the same `video_url`, varying only the cover, and none of them were published:

| container | `status_code` |
|---|---|
| no `cover_url` | `FINISHED` |
| valid `cover_url` | `FINISHED` |
| `cover_url` pointing at a nonexistent file | **`ERROR`** |

The cover URL was the only variable, and it changed the outcome — Meta fetches and validates it on this API variant.

### Scope

Deliberately limited to `media_type=REELS`, matching the issue. Carousel children (`media_type=VIDEO`) keep `thumb_offset` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)