### PR TITLE
fix(calendar): surface curated provider errors in the calendar tooltip

### DIFF
--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -59,6 +59,21 @@ import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validatio
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { Button } from '@gitroom/react/form/button';
 
+// Curated provider errors are stored as {"message":"..."} — anything else in
+// post.error (internal strings like 'Refresh channel needed', serialized
+// failures from before curation existed) falls back to the generic tooltip
+const displayErrorMessage = (error?: string | null) => {
+  if (!error) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(error);
+    return typeof parsed?.message === 'string' ? parsed.message : null;
+  } catch (e) {
+    return null;
+  }
+};
+
 // Extend dayjs with necessary plugins
 extend(isSameOrAfter);
 extend(isSameOrBefore);
@@ -1068,7 +1083,8 @@ const CalendarItem: FC<{
         <div
           className="absolute -top-[6px] -left-[6px] z-20 w-[18px] h-[18px] rounded-full bg-red-500 flex items-center justify-center text-white text-[11px] font-bold cursor-pointer"
           data-tooltip-id="tooltip"
-          data-tooltip-content={post.error || 'An error occurred while publishing this post'}
+          data-tooltip-class-name="!max-w-[400px] break-words"
+          data-tooltip-content={displayErrorMessage(post.error) || 'An error occurred while publishing this post'}
         >
           !
         </div>

--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -59,21 +59,6 @@ import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validatio
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { Button } from '@gitroom/react/form/button';
 
-// Curated provider errors are stored as {"message":"..."} — anything else in
-// post.error (internal strings like 'Refresh channel needed', serialized
-// failures from before curation existed) falls back to the generic tooltip
-const displayErrorMessage = (error?: string | null) => {
-  if (!error) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(error);
-    return typeof parsed?.message === 'string' ? parsed.message : null;
-  } catch (e) {
-    return null;
-  }
-};
-
 // Extend dayjs with necessary plugins
 extend(isSameOrAfter);
 extend(isSameOrBefore);
@@ -1084,7 +1069,7 @@ const CalendarItem: FC<{
           className="absolute -top-[6px] -left-[6px] z-20 w-[18px] h-[18px] rounded-full bg-red-500 flex items-center justify-center text-white text-[11px] font-bold cursor-pointer"
           data-tooltip-id="tooltip"
           data-tooltip-class-name="!max-w-[400px] break-words"
-          data-tooltip-content={displayErrorMessage(post.error) || 'An error occurred while publishing this post'}
+          data-tooltip-content={post.error || 'An error occurred while publishing this post'}
         >
           !
         </div>

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -173,6 +173,7 @@ export class PostsRepository {
         releaseURL: true,
         releaseId: true,
         state: true,
+        error: true,
         intervalInDays: true,
         group: true,
         creationMethod: true,
@@ -412,15 +413,34 @@ export class PostsRepository {
   }
 
   async changeState(id: string, state: State, err?: any, body?: any) {
+    // The calendar tooltip only surfaces curated provider messages: bad_body
+    // failures whose message came from a handleErrors mapping or a
+    // hand-written provider throw (unmapped API responses carry the
+    // 'Unknown Error' placeholder instead). Those are stored as
+    // {"message":"..."} so the frontend can tell them apart from everything
+    // this column held until now (internal strings like 'Refresh channel
+    // needed', serialized failures), which keeps rendering the generic
+    // tooltip. Internal strings are still stored for debugging, and the full
+    // failure is kept in the Errors table below.
+    const failureMessage =
+      err?.cause?.failure?.message || err?.failure?.cause?.message;
+    const errorMessage = !err
+      ? undefined
+      : typeof err === 'string'
+      ? err // stored for debugging, rendered as the generic tooltip
+      : err?.cause?.type === 'bad_body' &&
+        failureMessage &&
+        failureMessage !== 'Unknown Error'
+      ? JSON.stringify({ message: failureMessage })
+      : undefined;
+
     const update = await this._post.model.post.update({
       where: {
         id,
       },
       data: {
         state,
-        ...(err
-          ? { error: typeof err === 'string' ? err : JSON.stringify(err) }
-          : {}),
+        ...(errorMessage ? { error: errorMessage } : {}),
       },
       include: {
         integration: {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -440,7 +440,10 @@ export class PostsRepository {
       },
       data: {
         state,
-        ...(errorMessage ? { error: errorMessage } : {}),
+        // Always overwrite on a new failure - keeping the previous value would
+        // show a stale (and now wrong) message for a post that failed again
+        // for a different reason.
+        ...(err ? { error: errorMessage ?? null } : {}),
       },
       include: {
         integration: {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -127,6 +127,32 @@ export class PostsRepository {
     });
   }
 
+  // Post.error persists the raw serialized workflow failure; only curated
+  // provider messages are surfaced to the calendar and the public API —
+  // bad_body failures whose message came from a provider handleErrors
+  // mapping or a hand-written provider throw (unmapped API responses carry
+  // the 'Unknown Error' placeholder instead). Internal debug strings (e.g.
+  // 'Refresh channel needed') and unmapped failures come out as null.
+  private curatedError(error?: string | null): string | null {
+    if (!error) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(error);
+      const [type, message] = parsed?.cause?.failure?.message
+        ? [parsed?.cause?.type, parsed?.cause?.failure?.message]
+        : [
+            parsed?.failure?.cause?.applicationFailureInfo?.type,
+            parsed?.failure?.cause?.message,
+          ];
+      return type === 'bad_body' && message && message !== 'Unknown Error'
+        ? message
+        : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
   async getPosts(orgId: string, query: GetPostsDto) {
     // Use the provided start and end dates directly
     const startDate = dayjs.utc(query.startDate).toDate();
@@ -194,7 +220,9 @@ export class PostsRepository {
       },
     });
 
-    return list.reduce((all, post) => {
+    return list
+      .map((post) => ({ ...post, error: this.curatedError(post.error) }))
+      .reduce((all, post) => {
       if (!post.intervalInDays) {
         return [...all, post];
       }
@@ -413,37 +441,15 @@ export class PostsRepository {
   }
 
   async changeState(id: string, state: State, err?: any, body?: any) {
-    // The calendar tooltip only surfaces curated provider messages: bad_body
-    // failures whose message came from a handleErrors mapping or a
-    // hand-written provider throw (unmapped API responses carry the
-    // 'Unknown Error' placeholder instead). Those are stored as
-    // {"message":"..."} so the frontend can tell them apart from everything
-    // this column held until now (internal strings like 'Refresh channel
-    // needed', serialized failures), which keeps rendering the generic
-    // tooltip. Internal strings are still stored for debugging, and the full
-    // failure is kept in the Errors table below.
-    const failureMessage =
-      err?.cause?.failure?.message || err?.failure?.cause?.message;
-    const errorMessage = !err
-      ? undefined
-      : typeof err === 'string'
-      ? err // stored for debugging, rendered as the generic tooltip
-      : err?.cause?.type === 'bad_body' &&
-        failureMessage &&
-        failureMessage !== 'Unknown Error'
-      ? JSON.stringify({ message: failureMessage })
-      : undefined;
-
     const update = await this._post.model.post.update({
       where: {
         id,
       },
       data: {
         state,
-        // Always overwrite on a new failure - keeping the previous value would
-        // show a stale (and now wrong) message for a post that failed again
-        // for a different reason.
-        ...(err ? { error: errorMessage ?? null } : {}),
+        ...(err
+          ? { error: typeof err === 'string' ? err : JSON.stringify(err) }
+          : {}),
       },
       include: {
         integration: {

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -215,11 +215,13 @@ export abstract class SocialAbstract {
     pendingData: any,
     integration: Integration
   ): Promise<PendingCheckResponse> {
+    // 'Unknown Error' keeps this developer guard out of the user-facing
+    // post.error (changeState only surfaces curated bad_body messages)
     throw new BadBody(
       this.identifier,
+      '{"error":"checkPostStatus is not implemented for this provider"}',
       '{}',
-      '{}',
-      'checkPostStatus is not implemented for this provider'
+      'Unknown Error'
     );
   }
 
@@ -231,9 +233,9 @@ export abstract class SocialAbstract {
   ): Promise<PendingCheckResponse> {
     throw new BadBody(
       this.identifier,
+      '{"error":"finalizePost is not implemented for this provider"}',
       '{}',
-      '{}',
-      'finalizePost is not implemented for this provider'
+      'Unknown Error'
     );
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix / UX improvement

# Why was this change needed?

Failed posts show a red error badge in the calendar, but the tooltip always says the generic "An error occurred while publishing this post" — even when the provider produced an actionable, human-written message like "The specified board was not found. Please check the board ID.". The same gap exists in the public API: `GET /public/v1/posts` returns failed posts with only `state: "ERROR"` and no reason at all — a customer whose posts were failing due to a platform-side account restriction had no way to see why through the API, and the actual cause was only visible to us in internal tables.

This is a reworked revival of #1803, which was closed because it surfaced *every* stored error. This version surfaces only curated provider messages, and does it at **read time**: `Post.error` keeps persisting the raw serialized failure exactly as before (the DB write path is unchanged), and the shared `getPosts` path replaces the value with the curated message or null. Curated means a `bad_body` failure whose message came from a provider `handleErrors` mapping or a hand-written provider throw; unmapped API responses carry the `'Unknown Error'` placeholder at the throw site, so raw API bodies, unexpected exceptions, and internal workflow strings ('Refresh channel needed') all come out as null — the calendar keeps showing the generic tooltip for those, exactly as today. The `checkPostStatus`/`finalizePost` developer-guard throws are demoted to the unmapped placeholder so they can never surface either. Emails and in-app notifications are untouched.

Because `getPosts` also serves `GET /public/v1/posts`, the public API now returns the same curated-or-null `error` field. Read-time extraction is also retroactive: posts that already errored get the curated message with no migration, since the mapped message lives inside the stored failure blob. Tooltip is capped at 400px with wrapping.

Verified e2e through real Temporal workflows on a local run, checking all three surfaces per case (DB row, rendered calendar DOM, public API response):

| Failure | DB keeps | Tooltip | Public API `error` |
|---|---|---|---|
| Real Pinterest "Board not found" (handleErrors mapping) | raw failure | curated message | curated message |
| Unmapped API error | raw failure | generic | null |
| Internal workflow string ('Refresh channel needed') | the string | generic | null |
| Pre-existing errored post whose stored blob holds a mapped message | raw failure | curated message (retroactive) | curated message |
| Pre-existing errored post with a crash-shaped blob | raw failure | generic | null |

# Other information:

Replaces the closed #1803; follow-up to the investigation behind #1802/#1804.

Companion docs PR: https://github.com/gitroomhq/postiz-docs/pull/243 documents the new `error` field in the Public API List Posts response — it should be merged only after this PR deploys.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)