### PR TITLE
fix(x): correct character counting for t.co URL shortening

### DIFF
--- a/apps/frontend/src/components/launches/information.component.tsx
+++ b/apps/frontend/src/components/launches/information.component.tsx
@@ -8,6 +8,7 @@ import SafeImage from '@gitroom/react/helpers/safe.image';
 import { capitalize } from 'lodash';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { hasLinks } from '@gitroom/helpers/utils/strip.links';
+import { weightedLength } from '@gitroom/helpers/utils/count.length';
 
 const Valid: FC = () => {
   return (
@@ -91,6 +92,12 @@ export const InformationComponent: FC<{
 
   const showStripLinkWarning = stripLinkNames.length > 0;
 
+  const charsForIdentifier = useMemo(() => {
+    const xWeighted = weightedLength(text || '');
+    return (identifier: string) =>
+      identifier === 'x' ? xWeighted : totalChars;
+  }, [text, totalChars]);
+
   const isInternal = useMemo(() => {
     if (!isGlobal) {
       return [];
@@ -127,7 +134,10 @@ export const InformationComponent: FC<{
           return false;
         }
 
-        return totalChars > (chars?.[p.integration.id] || 0);
+        return (
+          charsForIdentifier(p.integration.identifier) >
+          (chars?.[p.integration.id] || 0)
+        );
       })
     ) {
       return false;
@@ -141,6 +151,8 @@ export const InformationComponent: FC<{
     isPicture,
     chars,
     showStripLinkWarning,
+    charsForIdentifier,
+    selectedIntegrations,
   ]);
 
   const globalDisplayLimit = useMemo(() => {
@@ -221,46 +233,53 @@ export const InformationComponent: FC<{
           )}
           {isGlobal && (
             <div className="grid grid-cols-[auto_auto_auto] text-[14px] font-[500] gap-[8px] items-center">
-              {selectedIntegrations.map((p, index) => (
-                <Fragment key={p.integration.id}>
-                  <div>
-                    <SafeImage
-                      src={`/icons/platforms/${p.integration.identifier}.png`}
-                      alt={p.integration.name}
-                      className="rounded-[4px] w-[16px] h-[16px] min-w-[16px] min-h-[16px]"
-                      width={16}
-                      height={16}
-                    />
-                  </div>
-                  <div
-                    className={clsx(
-                      'whitespace-nowrap',
-                      isInternal?.[index]
-                        ? ''
-                        : totalChars > (chars?.[p.integration.id] || 0)
-                        ? 'text-[#FF3F3F]'
-                        : ''
-                    )}
-                  >
-                    {p.integration.name} (
-                    {capitalize(p.integration.identifier.split('-')[0])}):
-                  </div>
-                  <div
-                    className={clsx(
-                      'whitespace-nowrap',
-                      isInternal?.[index]
-                        ? ''
-                        : totalChars > (chars?.[p.integration.id] || 0)
-                        ? 'text-[#FF3F3F]'
-                        : ''
-                    )}
-                  >
-                    {isInternal?.[index]
-                      ? t('internal_edit', 'Internal Edit')
-                      : `${totalChars}/${chars?.[p.integration.id] || 0}`}
-                  </div>
-                </Fragment>
-              ))}
+              {selectedIntegrations.map((p, index) => {
+                const integrationChars = charsForIdentifier(
+                  p.integration.identifier
+                );
+                const exceeds =
+                  integrationChars > (chars?.[p.integration.id] || 0);
+                return (
+                  <Fragment key={p.integration.id}>
+                    <div>
+                      <SafeImage
+                        src={`/icons/platforms/${p.integration.identifier}.png`}
+                        alt={p.integration.name}
+                        className="rounded-[4px] w-[16px] h-[16px] min-w-[16px] min-h-[16px]"
+                        width={16}
+                        height={16}
+                      />
+                    </div>
+                    <div
+                      className={clsx(
+                        'whitespace-nowrap',
+                        isInternal?.[index]
+                          ? ''
+                          : exceeds
+                          ? 'text-[#FF3F3F]'
+                          : ''
+                      )}
+                    >
+                      {p.integration.name} (
+                      {capitalize(p.integration.identifier.split('-')[0])}):
+                    </div>
+                    <div
+                      className={clsx(
+                        'whitespace-nowrap',
+                        isInternal?.[index]
+                          ? ''
+                          : exceeds
+                          ? 'text-[#FF3F3F]'
+                          : ''
+                      )}
+                    >
+                      {isInternal?.[index]
+                        ? t('internal_edit', 'Internal Edit')
+                        : `${integrationChars}/${chars?.[p.integration.id] || 0}`}
+                    </div>
+                  </Fragment>
+                );
+              })}
             </div>
           )}
           {showStripLinkWarning && (

--- a/apps/frontend/src/components/new-launch/editor.tsx
+++ b/apps/frontend/src/components/new-launch/editor.tsx
@@ -46,6 +46,7 @@ import Text from '@tiptap/extension-text';
 import Paragraph from '@tiptap/extension-paragraph';
 import Underline from '@tiptap/extension-underline';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
+import { weightedLength } from '@gitroom/helpers/utils/count.length';
 import { History } from '@tiptap/extension-history';
 import { BulletList, ListItem } from '@tiptap/extension-list';
 import { Bullets } from '@gitroom/frontend/components/new-launch/bullets.component';
@@ -663,6 +664,12 @@ export const Editor: FC<{
     return stripHtmlValidation('normal', props.value || '', true);
   }, [props.value]);
 
+  const valueWithoutHtmlChars = useMemo(() => {
+    return identifier === 'x'
+      ? weightedLength(valueWithoutHtml)
+      : valueWithoutHtml.length;
+  }, [valueWithoutHtml, identifier]);
+
   const addText = useCallback(
     (emoji: string) => {
       editorRef?.current?.editor?.commands?.insertContent(emoji);
@@ -770,7 +777,7 @@ export const Editor: FC<{
                     <InformationComponent
                       isPicture={pictures?.length > 0}
                       chars={chars}
-                      totalChars={valueWithoutHtml.length}
+                      totalChars={valueWithoutHtmlChars}
                       totalAllowedChars={props.totalChars}
                       text={valueWithoutHtml}
                     />

--- a/libraries/helpers/src/utils/count.length.ts
+++ b/libraries/helpers/src/utils/count.length.ts
@@ -30,7 +30,10 @@ export const textSlicer = (
 
   return {
     start: 0,
-    end: valid ? text.length : validRangeEnd,
+    // validRangeEnd is the index of the last valid character (inclusive),
+    // so the slice end (exclusive) needs a +1 or the last valid character
+    // gets highlighted as if it were part of the overflow.
+    end: valid ? text.length : validRangeEnd + 1,
   };
 };
 

--- a/libraries/helpers/src/utils/count.length.ts
+++ b/libraries/helpers/src/utils/count.length.ts
@@ -30,7 +30,7 @@ export const textSlicer = (
 
   return {
     start: 0,
-    end: valid ? end : validRangeEnd,
+    end: valid ? text.length : validRangeEnd,
   };
 };
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -837,9 +837,7 @@ export class PostsService {
 
         const tooLong = (post.value || []).some((a) => {
           const strip = stripHtmlValidation('normal', a.content || '', true);
-          const weighted = isX ? weightedLength(strip) : strip.length;
-          const totalCharacters =
-            weighted > strip.length ? weighted : strip.length;
+          const totalCharacters = isX ? weightedLength(strip) : strip.length;
           return totalCharacters > (maximumCharacters || 1000000);
         });
 


### PR DESCRIPTION
## Problem

X's character counter and validation didn't account for X's t.co URL shortening (every URL counts as 23 characters against the tweet limit, regardless of its actual length). This surfaced as several related but independent bugs, all with the same root symptom: posts containing a URL could be shown/treated as over the limit even though X itself would accept them.

## Root causes and fixes (4 commits, 5 bugs)

1. **Frontend counter** (`apps/frontend/.../new-launch/editor.tsx`): the character count fed into `InformationComponent` was always the raw stripped-text length, for every provider. Now uses `weightedLength()` (already used elsewhere for X) when the active integration is `x`.

2. **Backend validation** (`posts.service.ts`): the `tooLong` check computed `weightedLength()` for X but then took `Math.max(weighted, raw)`, which silently falls back to the raw (un-shortened) length whenever a URL makes the weighted length smaller than the raw one — i.e. in the common case of a post containing a link. That line effectively made the X-specific weighting dead code. Now uses the weighted length directly, matching the `emptyContent` check just above it.

3. **Preview crop highlight — valid case** (`count.length.ts`, `textSlicer`): when a tweet passed the weighted-length validation, `textSlicer`'s X branch still returned the raw numeric limit (e.g. `280`) as the slice end — a raw string index. Since a shortened URL is much shorter in weighted length than in raw characters, any valid post whose *raw* text exceeded 280 characters had its tail wrongly highlighted red as "will be cropped". Now returns `text.length` when valid, so nothing is highlighted.

4. **Preview crop highlight — off-by-one** (same function, invalid case): `validRangeEnd` from `twitter-text`'s `parseTweet()` is the index of the last *valid* character (inclusive), but was used directly as the slice end (exclusive), so the last valid character was swept into the highlighted overflow region. A post exactly 1 character over the limit highlighted the last 2 characters instead of just the 1 that pushed it over. Fixed with `validRangeEnd + 1`.

5. **Global (multi-platform) editing mode** (`information.component.tsx`): the aggregate validity check and per-platform breakdown tooltip compared the same raw character count against every selected platform's limit, including X's. Selecting X as a target while the post contained a link would mark the whole post invalid (red) in global view — even though it was within X's real limit — until the user opened X's per-integration tab and customized it (which incidentally excludes X from this aggregate check by design). Added a per-integration weighted count (weightedLength for `x`, raw otherwise), used both in the validity check and the tooltip breakdown.

## Scope / known limitation

The global-mode fix (#5) corrects the *validity* check, but the numeric badge shown at the top of the composer in global mode still displays the raw character count rather than a per-platform figure — fully resolving that would require restructuring `totalChars` into a per-integration value across the whole global-edit UI, which felt out of scope here.

## Testing

- `tsc --noEmit` on `apps/frontend` and `apps/backend`/libraries touched by each commit — clean throughout.
- `twitter-text`'s `parseTweet()` behavior (weightedLength, validRangeEnd semantics) verified in isolation with realistic text/URL combinations before each fix, to confirm the fix's assumptions rather than guess at them.
- Manually verified in a running instance (Docker image built from this branch): counter, preview highlighting (valid/invalid/exact-limit cases), and global multi-platform mode, using real post text with embedded URLs.