### PR TITLE
Fix YouTube Brand Account channel picker

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -288,7 +288,11 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
     return {
       url: client.generateAuthUrl({
         access_type: 'offline',
-        prompt: 'consent',
+        // Force Google to show the account chooser. For users who manage a
+        // personal channel and one or more Brand Account channels, this also
+        // lets Google present the channel identity picker instead of silently
+        // authorizing the previously selected (usually personal) channel.
+        prompt: 'consent select_account',
         state,
         redirect_uri: `${process.env.FRONTEND_URL}/integrations/social/youtube`,
         scope: this.scopes.slice(0),


### PR DESCRIPTION
## What changed

- Request `select_account` together with `consent` in the YouTube OAuth flow.
- Document why the explicit account chooser is required for users who manage personal and Brand Account channels.

## Why

Google can otherwise reuse the previously selected identity and skip the account/channel chooser. Users who manage a YouTube Brand Account then authorize their personal channel instead and cannot select the intended channel after returning to Postiz.

This addresses the behavior reported in #1238, which is still present on the current `main` branch.

## User impact

Connecting YouTube now prompts users to choose the Google account and allows Google's Brand Account channel picker to appear, so the intended channel can be authorized.

## Validation

- `git diff --check`
- Verified the generated OAuth option uses Google's supported space-delimited `prompt` values.

The full test suite was not run because dependencies are not installed in the local checkout.
