### PR TITLE
Add cancellation to channel configuration

### DIFF
--- a/apps/backend/src/api/routes/no.auth.integrations.controller.ts
+++ b/apps/backend/src/api/routes/no.auth.integrations.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpException,
   Param,
@@ -333,6 +334,33 @@ export class NoAuthIntegrationsController {
     const org = await this._organizationService.getOrgById(organization);
 
     return this._integrationService.saveProviderPage(org.id, id, body);
+  }
+
+  @Delete('/public/provider/:id')
+  async cancelProviderPage(@Param('id') id: string, @Body() body: any) {
+    if (!body.state) {
+      throw new HttpException('Invalid state', 400);
+    }
+
+    const organization = await ioRedis.get(`organization:${body.state}`);
+    if (!organization) {
+      throw new HttpException('Organization not found', 404);
+    }
+
+    const org = await this._organizationService.getOrgById(organization);
+    const integration = await this._integrationService.getIntegrationById(
+      org.id,
+      id
+    );
+
+    if (!integration || !integration.inBetweenSteps) {
+      throw new HttpException('Integration not found', 404);
+    }
+
+    await this._integrationService.deleteChannel(org.id, id);
+    await ioRedis.del(`organization:${body.state}`, `redirect:${body.state}`);
+
+    return { success: true };
   }
 
   @Post('/extension-refresh')

--- a/apps/frontend/src/components/launches/continue.integration.tsx
+++ b/apps/frontend/src/components/launches/continue.integration.tsx
@@ -11,6 +11,7 @@ import { continueProviderList } from '@gitroom/frontend/components/new-launch/pr
 import { IntegrationContext } from '@gitroom/frontend/components/launches/helpers/use.integration';
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
+import { Button } from '@gitroom/react/form/button';
 
 interface TwoStepState {
   integrationId: string;
@@ -38,6 +39,7 @@ export const ContinueIntegration: FC<{
   const [twoStepState, setTwoStepState] = useState<TwoStepState | null>(null);
   const [successState, setSuccessState] = useState<SuccessState | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
 
   // Helper to handle navigation - redirects if logged or returnURL exists, otherwise shows inline
   const navigateOrShow = useCallback(
@@ -245,6 +247,39 @@ export const ContinueIntegration: FC<{
     [twoStepState, fetch, modifiedParams, provider, navigateOrShow]
   );
 
+  const onCancel = useCallback(async () => {
+    if (!twoStepState) return;
+
+    setIsCancelling(true);
+
+    try {
+      const response = await fetch(
+        `/integrations/public/provider/${twoStepState.integrationId}`,
+        {
+          method: 'DELETE',
+          body: JSON.stringify({ state: modifiedParams.state }),
+        }
+      );
+
+      if (response.status !== HttpStatusCode.Ok) {
+        const errorData = await response.json().catch(() => ({}));
+        setErrorMessage(
+          errorData.message || 'Failed to cancel channel configuration'
+        );
+        setError(true);
+        return;
+      }
+
+      navigateOrShow(
+        '/launches',
+        twoStepState.returnURL,
+        t('channel_configuration_cancelled', 'Channel configuration cancelled')
+      );
+    } finally {
+      setIsCancelling(false);
+    }
+  }, [twoStepState, fetch, modifiedParams.state, navigateOrShow, t]);
+
   const Provider = useMemo(() => {
     return (
       continueProviderList[provider as keyof typeof continueProviderList] ||
@@ -355,6 +390,15 @@ export const ContinueIntegration: FC<{
                 initialData={twoStepState.pages}
                 isSaving={isSaving}
               />
+              <Button
+                secondary
+                className="w-full"
+                disabled={isSaving}
+                loading={isCancelling}
+                onClick={onCancel}
+              >
+                {t('cancel', 'Cancel')}
+              </Button>
             </IntegrationContext.Provider>
           </div>
         </div>


### PR DESCRIPTION
## What changed

Adds a **Cancel** action to the channel configuration screen displayed by providers that require a second selection step.

Cancelling now soft-deletes the provisional integration and invalidates the OAuth state, then returns the user to the channel list or invite return URL.

## Why

The previous screen only offered Save. Users who selected the wrong page or account could close the window, leaving a provisional integration behind and no clear way to abandon the flow.

## Impact

Users can exit a multi-step channel connection safely without creating a visible or reusable partial channel connection.

## Root cause

The OAuth callback persisted the integration before the user chose the final page or account, but the selection UI had no cancellation path.

## Validation

- `npx --yes prettier@2.8.8 --check apps/frontend/src/components/launches/continue.integration.tsx apps/backend/src/api/routes/no.auth.integrations.controller.ts`
- `git diff --check`
