### PR TITLE
Document Instagram standalone credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ THREADS_APP_ID=""
 THREADS_APP_SECRET=""
 FACEBOOK_APP_ID=""
 FACEBOOK_APP_SECRET=""
+# Instagram (Standalone): use the Instagram App ID and App Secret from
+# Meta > Instagram > API setup with Instagram Business Login.
+INSTAGRAM_APP_ID=""
+INSTAGRAM_APP_SECRET=""
 YOUTUBE_CLIENT_ID=""
 YOUTUBE_CLIENT_SECRET=""
 TIKTOK_CLIENT_ID=""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,10 @@ services:
       THREADS_APP_SECRET: ''
       FACEBOOK_APP_ID: ''
       FACEBOOK_APP_SECRET: ''
+      # Instagram (Standalone) uses the credentials from Meta's Instagram
+      # Business Login setup, not the Facebook Login credentials above.
+      INSTAGRAM_APP_ID: ''
+      INSTAGRAM_APP_SECRET: ''
       YOUTUBE_CLIENT_ID: ''
       YOUTUBE_CLIENT_SECRET: ''
       TIKTOK_CLIENT_ID: ''


### PR DESCRIPTION
## What changed

- Expose `INSTAGRAM_APP_ID` and `INSTAGRAM_APP_SECRET` in the example environment and Docker Compose configuration.
- Document that Instagram Standalone must be configured in Meta's Instagram Business Login setup; Facebook Login alone does not enable this flow.

## Why

The standalone provider reads `INSTAGRAM_APP_*`, but the stock self-hosted examples omitted those variables. That makes it easy to configure only Facebook Login; Meta then rejects the standalone OAuth request with `Invalid platform app` because Instagram Business Login has not been configured.

## Validation

- `git diff --check`
- `docker compose -f docker-compose.yaml config`
