### PR TITLE
fix(instagram): report untaggable collaborators instead of "Unknown Error"

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -379,6 +379,14 @@ export class InstagramProvider
       };
     }
 
+    if (body.indexOf('2207018') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          "One of the collaborators could not be tagged, please check the username is correct, the account is public, and that it allows collaborator invites",
+      };
+    }
+
     if (body.indexOf('param collaborators is not allowed') > -1) {
       return {
         type: 'bad-body' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Instagram provider error mapping). Adds a `2207018` branch to `InstagramProvider.handleErrors`, above the existing "param collaborators is not allowed" branch, returning `type: 'bad-body'` with a message explaining the collaborator could not be tagged and listing the three real causes: wrong username, private account, or collaborator invites disabled. Previously Instagram subcode 2207018 fell through and reached the user as "Unknown Error". Every other branch and its classification are unchanged.

# Why was this change needed?

A customer got the failure email "An error occurred while posting to Instagram: Unknown Error" and had no way to act on it.

The post carried a collaborator tag, and Instagram rejected the media container with:

```
{"error":{"message":"Invalid user id","type":"OAuthException","code":110,"error_subcode":2207018,
 "error_user_title":"Cannot load user with a private profile or invalid username",
 "error_user_msg":"The following user(s) cannot be accessed: evolve.how"}}
```

`InstagramProvider.handleErrors` had no branch for `2207018`, so it returned `undefined` and `SocialAbstract.fetch` threw `BadBody` with its generic `'Unknown Error'` fallback. Nothing in the email pointed at the collaborator tag, which is the one thing the user can fix.

This maps `2207018` to a bad-body message naming the three real causes: the handle is wrong, the account is private, or it does not allow collaborator invites. `instagram.standalone.provider.ts` delegates to this same `handleErrors`, so both channel types are covered.

Surfacing Meta's own `error_user_msg` instead was considered and rejected: it comes back localized to the connected account's language (Hebrew in the reproduction), so it is not usable as user-facing text.

# Other information:

Verified against a live Instagram channel by creating a media container with the customer's exact handle, which reproduced the identical Meta payload. Pre-fix the thrown `BadBody` carried `Unknown Error`; post-fix it carries the new message. The container is rejected before `media_publish`, so nothing was published.

Worth noting for follow-up, not fixed here: collaborator handles are never validated. The input is free text (the autocomplete only echoes what you type), and the "max 3" rule is enforced only client-side, so the public API can send more.

# QA

1. [ ] Connect an Instagram Business or Creator channel
2. [ ] Create an image post and add a collaborator username that does not exist, for example `thisuserdoesnotexist_qa`
3. [ ] Publish the post - it moves to ERROR with the new collaborator message rather than "Unknown Error"
4. [ ] Edit the post to use a valid public collaborator account and publish again - the post succeeds and the collaborator invite shows up on Instagram
5. [ ] Publish a post with no collaborators at all to confirm the normal path is unaffected

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
