### PR TITLE
fix(orchestrator): anchor v1.0.5 recycle delay to publishDate, not workflow-start time

### DIFF
--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.5.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.5.ts
@@ -77,7 +77,6 @@ export async function postWorkflowV105({
     poked = true;
   });
 
-  const startTime = new Date();
   // get all the posts and comments to post
   const firstPost = await getPost(organizationId, postId);
 
@@ -100,6 +99,13 @@ export async function postWorkflowV105({
         : dayjs(firstPost.publishDate).diff(dayjs(), 'millisecond')
     );
   }
+
+  // Anchor the repeat-interval countdown to the moment this occurrence
+  // actually starts processing (after waiting for publishDate), not to
+  // workflow-start time — otherwise the wait-for-publishDate delay gets
+  // subtracted from intervalInDays on the first cycle and every future
+  // recurrence permanently drifts away from the intended schedule.
+  const startTime = new Date();
 
   const postsListBefore = await getPostsList(organizationId, postId);
   const [post] = postsListBefore;


### PR DESCRIPTION
# fix(orchestrator): anchor v1.0.5 recycle delay to publishDate, not workflow-start time

## What kind of change does this PR introduce?

Bug fix (Temporal workflow scheduling) for `post.workflow.v1.0.5.ts`.

## Why was this change needed?

Found independently in production while debugging why a weekly recurring
Telegram reminder stopped firing at its configured time. Root cause traced
via Temporal workflow history (`tctl workflow show`), not just DB inspection.

`startTime` is captured at the very top of `postWorkflowV105`, **before**
the `if (!postNow) { await sleep(diff-to-publishDate) }` block that waits
for the post's first scheduled occurrence. The repeat-interval delay is
computed later as:

```ts
delay = intervalInDays * 24 * 60 * 60 * 1000 - (Date.now() - startTime.getTime())
```

For the very first cycle (`postNow=false`), the entire wait-for-publishDate
sleep — which can be hours or days, depending on how far in the future the
post was scheduled when created — gets counted as "elapsed" and subtracted
from the interval budget. This silently shifts every future recurrence's
anchor from the intended `publishDate` (e.g. every Tuesday 08:00 UTC) to
`createdAt` (whenever the post row happened to be inserted).

Confirmed in production: a post created 2026-08-02 14:32 with
`publishDate=2026-08-04 08:00` and `intervalInDays=7` fired correctly on
its first occurrence (08-04 08:00, on schedule), then drifted to firing on
2026-08-09 14:32 — exactly `createdAt + 7d`, nearly 2 days early and 6.5
hours off the intended time of day. Each subsequent cycle stays
self-consistently anchored to that wrong point, since `postNow=true`
children skip the sleep and their own `startTime` capture is accurate
relative to *their* (already wrong) start — the drift is injected exactly
once, on the first `postNow=false → postNow=true` transition, and then
persists forever.

## The fix

Move `const startTime = new Date();` from before the `getPost`/sleep block
to immediately after it (right before `getPostsList`). This makes
`startTime` represent the moment the occurrence actually begins doing real
work (after any wait for the nominal `publishDate`), so the interval
countdown only ever absorbs genuine activity-processing overhead (seconds),
never the scheduling wait. One-line move, no behavior change to command
ordering (activities/timers/signals unchanged in count or sequence), so
it's safe to replay against already-running workflow histories.

## Relationship to #1840

@giladresisi's #1840 fixes the same root cause, more thoroughly (also
addresses release-record clobbering on recycle and re-arming on schedule
edits) via a new `postWorkflowV107` + legacy-handoff mechanism, deliberately
leaving v1.0.5/v1.0.6 untouched per the workflow-versioning convention.

This PR is a much smaller, complementary fix for anyone running v1.0.5
who hasn't (yet) picked up v1.0.7: it corrects the anchor bug at its
source instead of relying on a runtime handoff to detect and redirect
already-fired legacy chains. Either can land independently; happy to
close this in favor of #1840 if the maintainers would rather keep a
single fix path.

## Testing

- Verified against a live production Temporal deployment: after patching
  and restarting the orchestrator worker, a fresh `postWorkflowV105`
  execution (`postNow=false`) for a previously-drifted recurring post slept
  for exactly the duration matching its `publishDate`, confirmed via
  `tctl workflow show` (`TimerStarted` event timing matched to the second).
- No unit tests added — this repo doesn't appear to have workflow-replay
  tests for v1.0.5; happy to add one following the pattern in #1840's test
  suite if useful.

## Checklist

- [x] I have read the CONTRIBUTING guide.
- [x] I checked that there were no similar issues or PRs already open for
      this (found #1840 — noted above, not a duplicate scope).
- [x] This PR fixes just ONE issue.
