### PR TITLE
fix(providers): wire the LinkedIn and Moltbook settings DTOs

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -58,6 +58,7 @@ type LinkedinPendingData = {
 export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   identifier = 'linkedin';
   name = 'LinkedIn';
+  dto = LinkedinDto;
   oneTimeToken = true;
 
   isBetweenSteps = false;

--- a/libraries/nestjs-libraries/src/integrations/social/moltbook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/moltbook.provider.ts
@@ -6,6 +6,7 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import { MoltbookDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/moltbook.dto';
 import dayjs from 'dayjs';
 import { Integration } from '@prisma/client';
 
@@ -15,6 +16,7 @@ export class MoltbookProvider extends SocialAbstract implements SocialProvider {
   override maxConcurrentJob = 100; // Moltbook: 100 requests/minute
   identifier = 'moltbook';
   name = 'Moltbook';
+  dto = MoltbookDto;
   isBetweenSteps = false;
   scopes = [] as string[];
   isWeb3 = true;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, provider settings validation). Sets `dto = LinkedinDto` on `LinkedinProvider` and `dto = MoltbookDto` on `MoltbookProvider`, so their settings run through the DTO validation in `PostsService.validatePosts` and are exposed in the public-API and MCP settings schemas, the way the other 26 providers already do. `LinkedinDto` is entirely `@IsOptional`, so the LinkedIn half is inert for existing data. Flag for the reviewer: `MoltbookDto.submolt` is `@IsDefined() @MinLength(1)` while `MoltbookProvider` currently defaults a missing `submolt` to `'general'`, so public-API and MCP posts that omit it start being rejected - either split the Moltbook half out or relax `submolt` to optional before merging.

# Why

`validatePosts` runs settings-DTO validation only when the provider declares `dto`. Three providers never did - **LinkedIn**, **LinkedIn Page** (inherits from `LinkedinProvider`) and **Moltbook** - so for them that validation layer silently didn't run: `LinkedinDto` and `MoltbookDto` existed but were never wired, and any malformed or missing settings value was accepted and stored. Found while testing #1877's `postSettingsTool`: a string value for LinkedIn's boolean `post_as_images_carousel` was accepted without complaint.

## How customers hit it

The dashboard never trips this - its form validates client-side with the same DTO classes (which is why the gap went unnoticed). But the **public API** (`POST /public/v1/posts`, `PUT /public/v1/posts/:id/settings`) and the **agent/MCP tools** share `validatePosts` and were unprotected:

- An API caller's integration code sends a typo'd or wrongly-typed value (`"post_as_images_carousel": "true"` as a string; a moltbook post with no `submolt`) - and gets a 200.
- An agent guesses a settings value (the same failure class as the TikTok UPLOAD incident) - nothing pushes back, so the agent reports success to the user.

The cost then surfaces late instead of at save time:

- Moltbook without `submolt`: the provider falls back to `'general'`, so the post **silently publishes to the wrong community** - no error anywhere.
- LinkedIn with a truthy non-boolean carousel value: treated as carousel-on at publish time and **fails hours/days later** on a post the user was told was valid.

# What changed

3 lines: `dto = LinkedinDto;` on `LinkedinProvider` (covers `linkedin-page` via inheritance - no declaration needed there) and `dto = MoltbookDto;` + import on `MoltbookProvider`. Bad values are now rejected at save time with a specific message (HTTP 400 on the API, `{errors}` to agents, which retry with corrected values per their tool instructions).

Audited all providers (27 settings-DTO files vs 25 `dto` declarations): these were the only unwired ones. Providers without a settings DTO file have no settings to validate.

Note on moltbook: wiring `MoltbookDto` makes `submolt` required at validation (`@IsDefined`, min length 1). That matches the dashboard form (which already requires it via the same class) and the provider's needs; existing DB rows are not re-validated, so nothing breaks retroactively.

# Testing (local backend + MCP tools, end to end)

LinkedIn (via a linkedin-page post, i.e. the inherited path):
- Settings update with `post_as_images_carousel: "yes-please"` on a scheduled post: previously accepted silently - now rejected: "post_as_images_carousel must be a boolean value".
- `true` (valid type, no images): passes the DTO layer, then correctly stopped by the next layer (`checkValidity`: "Carousel can only be created with 2 or more images and no videos") - both validation stages stack.
- `false`: accepted - no regression. Verified via listing that only the passed key changed.

Moltbook (against a real registered Moltbook agent connected as a channel):
- Scheduling without `submolt`: rejected at creation - "submolt should not be null or undefined" (previously accepted).
- Scheduling with `submolt: "general"`: accepted.
- Settings update to `""`: rejected - "submolt must be longer than or equal to 1 characters".
- Settings update to a valid value: applied; verified via listing.

Nothing was published externally during testing.

# QA

1. [ ] Connect a LinkedIn channel, create a post, toggle "post as images carousel", give it a carousel name and save - the post saves normally
2. [ ] Call `GET /public/v1/integrations` with an org API key - the LinkedIn entry now exposes `post_as_images_carousel` and `carousel_name` in its settings schema
3. [ ] Connect a Moltbook channel, create a post leaving Submolt empty and save - the request is now rejected with a `submolt` validation error
4. [ ] POST a Moltbook post through the public API with no `submolt` in settings - confirm whether the 400 is intended, because this currently succeeds and defaults to `general`
5. [ ] Set Submolt to a real value and confirm the post saves and publishes to that submolt
6. [ ] Publish an existing LinkedIn post that has no settings at all to confirm nothing regressed
