### PR TITLE
fix(facebook): flag channels holding a non-page token as needing reconnection

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -81,6 +81,20 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       };
     }
 
+    // The token is valid but belongs to the user, not to the page - the page
+    // was never granted to the app, so only reconnecting can fix it
+    if (
+      body.indexOf(
+        'Unpublished posts must be posted to a page as the page itself'
+      ) > -1
+    ) {
+      return {
+        type: 'refresh-token' as const,
+        value:
+          'Postiz is not authorized to publish as this page, please reconnect the channel',
+      };
+    }
+
     if (body.indexOf('1366046') > -1) {
       return {
         type: 'bad-body' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A customer reported repeated Facebook failures, all reading "An error occurred while posting on facebook: Unknown Error", on a channel that looked perfectly connected and authorized in Postiz.

The channel was in fact holding the user's access token instead of the page's. That happens when a page is only reachable through a Business portfolio: `pages()` lists it via `/me/businesses` → `owned_pages`, but if the page was not ticked in the OAuth page-selection screen, Graph returns no `access_token` for it. `fetchPageInformation` then returns `access_token: undefined`, the update passes `token: undefined`, and Prisma treats that as "field not present" and leaves the between-steps user token in place. The channel flips out of the between-steps state and looks healthy, while Facebook rejects every publish with:

`(#200) Unpublished posts must be posted to a page as the page itself.`

That message was not mapped in `handleErrors`, so it fell through to the generic `BadBody` / "Unknown Error" path. The result: the post fails, the channel stays unflagged, no notification is sent, and neither the user nor support can distinguish a token problem from a content problem. The customer's recurring post also silently stopped recurring, since the recurrence chain only continues from a successful publish.

This PR maps the message to `refresh-token`, so the failure routes through the refresh path: the channel is flagged `refreshNeeded`, the reconnect notification is sent, and the post is not retried against a token that can never work. The user is told what is actually wrong and what to do about it.

Matching is on the message text rather than code 200, since 200 is Facebook's generic permission bucket and covers many unrelated errors.

# Other information:

#1719 is the prevention side of this: it filters pages with no `access_token` out of the picker, so a channel can no longer be created in this state. This PR is the complement for channels already in it — #1719 cannot heal them, and there is no other signal that would surface them, because a `(#200)` error carries a valid token and so never reaches the refresh path.

Testing — reproduced the exact customer state end to end against a Meta test app, without any database manipulation:

- Target page belongs to a Business portfolio; in the OAuth dialog the portfolio was granted but the page itself was left unticked in the page list.
- The page still appeared in the Postiz channel picker (via the Business branch of `pages()`) and could be added. The resulting channel showed as connected and authorized, while its stored token resolved to the personal user, not the page.
- Publishing an image post to that channel produced the `(#200) Unpublished posts must be posted to a page as the page itself` error from Graph.

Before this change: post moved to ERROR with "Unknown Error", channel unflagged, no notification.

After this change: same Graph error, but the post fails as a token error — channel flagged with the reconnect indicator, refresh-needed email delivered, no retry against the bad token. Verified in Temporal, in the channel list, and in the received email.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
