### PR TITLE
chore(tiktok): log fail_reason when a post stays in progress

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -455,7 +455,8 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       return { status: 'pending', pendingData };
     }
 
-    const { status, publicaly_available_post_id } = post?.data || {};
+    const { status, fail_reason, publicaly_available_post_id } =
+      post?.data || {};
 
     if (status === 'SEND_TO_USER_INBOX') {
       return {
@@ -486,6 +487,16 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
         JSON.stringify(post),
         Buffer.from(JSON.stringify(post)),
         handleError?.value || ''
+      );
+    }
+
+    // TikTok documents fail_reason alongside the FAILED status, so a post that
+    // keeps reporting progress and never publishes leaves us nothing to show
+    // the user. Log it if it ever arrives here, on a status we treat as still
+    // in progress - a no-op while the API behaves as documented.
+    if (fail_reason) {
+      console.log(
+        `[tiktok-status] publishId=${pendingData.publishId} channel=${integration.internalId} status=${status} fail_reason=${fail_reason}`
       );
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Logging only, for troubleshooting. No behaviour change.

# Why was this change needed?

Multiple users are hitting the same TikTok failure: the post is accepted by TikTok and comes back with a publish id, but every subsequent status check reports the post as still in progress for the entire 30 minute polling window. It never reaches `PUBLISH_COMPLETE` and it is never returned as `FAILED`, so we exhaust the checks and mark the post as unconfirmed, which is all the user sees.

These posts do not appear to publish at all. One affected user posts image carousels to their TikTok inbox and reports the content never arrives there; another hits the same thing with direct posts. So the format is common to both, the posting method is not, and in every case TikTok gives us no reason we could show the user.

TikTok's status response includes a `fail_reason` field alongside `status`. Today we only benefit from it on `FAILED`, where `handleErrors` already matches the `spam_risk*` values and surfaces them; on every other status we read `status` and drop the rest. If TikTok ever populates `fail_reason` while still reporting the post as in progress, that is exactly the explanation we have been missing, and it would also give us a stop condition for the polling instead of waiting out the full window and giving up.

This logs the field only on the path that returns "still pending" - after the two success branches and after `FAILED` - so nothing is logged when the API behaves as documented. It is a no-op in the healthy case.

# Other information:

Deliberately observe-only. The value is logged and nothing acts on it, because failing a post on an undocumented signal could kill publishes that would otherwise have completed. Once we have real values we can decide whether to end the polling early on it.

Trade-offs worth knowing:
- If it does fire, a single stuck post can log up to 90 lines, one per poll (`maxPendingChecks = 90` at 20 second intervals). Noisy per incident, but only in the case we want to see, and these are rare.
- We will not see `fail_reason` if it only ever arrives on a status we treat as successful. That is intentional: the post published either way, so it would be logging for nothing.

Reference: https://developers.tiktok.com/doc/content-posting-api-reference-get-video-status

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue