### PR TITLE
fix(integrations): reconnecting a channel wiped its stored refresh token

### DIFF
--- a/apps/backend/src/api/routes/no.auth.integrations.controller.ts
+++ b/apps/backend/src/api/routes/no.auth.integrations.controller.ts
@@ -136,7 +136,14 @@ export class NoAuthIntegrationsController {
               refresh,
               auth.accessToken
             );
-            return res({ ...newAuth, refreshToken: body.refresh });
+            // keep the fresh refresh token and expiration from the new
+            // authentication, otherwise the stored refresh token is wiped and
+            // the channel breaks again as soon as the access token expires
+            return res({
+              ...newAuth,
+              refreshToken: auth.refreshToken,
+              expiresIn: auth.expiresIn,
+            });
           } catch (err: any) {
             return res({
               error: err.message,

--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -460,7 +460,10 @@ export class PostActivity {
 
       return refresh;
     } catch (err) {
-      await this._refreshIntegrationService.setBetweenSteps(integration);
+      await this._refreshIntegrationService.setBetweenSteps(
+        integration,
+        (err as Error)?.message || ''
+      );
       return false;
     }
   }
@@ -489,7 +492,10 @@ export class PostActivity {
 
       return refresh;
     } catch (err) {
-      await this._refreshIntegrationService.setBetweenSteps(integration, cause);
+      await this._refreshIntegrationService.setBetweenSteps(
+        integration,
+        cause || (err as Error)?.message || ''
+      );
       return false;
     }
   }

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.repository.ts
@@ -284,7 +284,8 @@ export class IntegrationRepository {
         profile: username,
         providerIdentifier: provider,
         token,
-        refreshToken,
+        // never wipe a stored refresh token with an empty one
+        ...(refreshToken ? { refreshToken } : {}),
         ...(expiresIn
           ? { tokenExpiration: new Date(Date.now() + expiresIn * 1000) }
           : {}),

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -183,9 +183,9 @@ export class IntegrationService {
     }
   }
 
-  async disconnectChannel(orgId: string, integration: Integration) {
+  async disconnectChannel(orgId: string, integration: Integration, err = '') {
     await this._integrationRepository.disconnectChannel(orgId, integration.id);
-    await this.informAboutRefreshError(orgId, integration);
+    await this.informAboutRefreshError(orgId, integration, err);
   }
 
   async informAboutRefreshError(
@@ -195,7 +195,7 @@ export class IntegrationService {
   ) {
     await this._notificationService.inAppNotification(
       orgId,
-      `Could not refresh your ${integration.providerIdentifier} channel ${err}`,
+      `Could not refresh your ${integration.providerIdentifier} channel`,
       `Could not refresh your ${integration.providerIdentifier} channel ${err}. Please go back to the system and connect it again ${process.env.FRONTEND_URL}/launches`,
       true,
       false,

--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -73,25 +73,31 @@ export class RefreshIntegrationService {
     socialProvider: SocialProvider,
     cause = ''
   ): Promise<AuthTokenDetails | false> {
+    let refreshError: any = undefined;
     const refresh: false | AuthTokenDetails = await socialProvider
       .refreshToken(integration.refreshToken)
-      .catch((err) => false);
+      .catch((err) => {
+        refreshError = err;
+        return false as const;
+      });
 
     if (!refresh || !refresh.accessToken) {
+      if (refreshError) {
+        console.error(
+          `Could not refresh ${integration.providerIdentifier} integration ${integration.id}`,
+          refreshError?.response?.data || refreshError?.message || refreshError
+        );
+      }
+
       await this._integrationService.refreshNeeded(
         integration.organizationId,
         integration.id
       );
 
-      await this._integrationService.informAboutRefreshError(
-        integration.organizationId,
-        integration,
-        cause
-      );
-
       await this._integrationService.disconnectChannel(
         integration.organizationId,
-        integration
+        integration,
+        socialProvider.refreshErrorMessage?.(refreshError) || cause
       );
 
       return false;
@@ -104,11 +110,20 @@ export class RefreshIntegrationService {
       return refresh;
     }
 
-    const reConnect = await socialProvider.reConnect(
-      integration.rootInternalId,
-      integration.internalId,
-      refresh.accessToken
-    );
+    let reConnect;
+    try {
+      reConnect = await socialProvider.reConnect(
+        integration.rootInternalId,
+        integration.internalId,
+        refresh.accessToken
+      );
+    } catch (err: any) {
+      console.error(
+        `Could not reconnect ${integration.providerIdentifier} integration ${integration.id} after a successful token refresh`,
+        err?.response?.data || err?.message || err
+      );
+      throw err;
+    }
 
     return {
       ...refresh,

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -167,6 +167,7 @@ export interface SocialProvider
   convertToJPEG?: boolean;
   stripLinks?: () => boolean;
   refreshCron?: boolean;
+  refreshErrorMessage?(err: any): string | undefined;
   dto?: any;
   maxLength: (additionalSettings?: any, settings?: any) => number;
   checkValidity(

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -259,6 +259,19 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
     return undefined;
   }
 
+  refreshErrorMessage(err: any): string | undefined {
+    const data = err?.response?.data || {};
+    const text = `${data.error_subtype || ''} ${data.error_description || ''} ${
+      err?.message || ''
+    }`;
+
+    if (text.includes('invalid_rapt')) {
+      return `because your organization's Google Workspace session policy invalidated its access. Ask your Google Workspace admin to mark Postiz as a trusted app and turn on "Exempt trusted apps" (https://support.google.com/a/answer/9368756) to prevent this from happening again`;
+    }
+
+    return undefined;
+  }
+
   async refreshToken(refresh_token: string): Promise<AuthTokenDetails> {
     const { client, oauth2 } = clientAndYoutube();
     client.setCredentials({ refresh_token });
@@ -394,10 +407,17 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
     requiredId: string,
     accessToken: string
   ): Promise<Omit<AuthTokenDetails, 'refreshToken' | 'expiresIn'>> {
-    const pages = await this.pages(accessToken);
-    const findPage = pages.find((p) => p.id === requiredId);
+    const { client, youtube } = clientAndYoutube();
+    client.setCredentials({ access_token: accessToken });
 
-    if (!findPage) {
+    // don't go through pages() here, it swallows the real Google error and an
+    // empty list would be reported as a missing channel
+    const { data } = await youtube(client).channels.list({
+      part: ['id'],
+      mine: true,
+    });
+
+    if (!(data.items || []).some((p) => p.id === requiredId)) {
       throw new Error('Channel not found');
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (+ observability for refresh failures).

# Why was this change needed?

A customer reported their YouTube channel demanded reconnection almost daily, even though Google showed Postiz holding a valid, unrevoked grant the whole time.

Root cause: the reconnect flow resolved the auth result with `refreshToken: body.refresh` — a field that is empty on the OAuth callback — so **every reconnect overwrote the stored refresh token with an empty string** and set a ~31-year token expiration (the `createOrUpdateIntegration` defaults). From then on the channel only worked while the fresh access token lived (~1h for YouTube/GMB): the next refresh threw before even reaching the provider ("No refresh token is set"), the channel was flagged for reconnection, and the next reconnect wiped the token again — a permanent loop no re-authorizing could escape. All `reConnect` providers were affected; FB/IG/LinkedIn just take ~60 days to hit it instead of an hour.

Changes:
- The reconnect branch now stores `auth.refreshToken`/`auth.expiresIn` from the new authentication (a reconnect IS a full OAuth authorization; `reConnect()` stays identity-verification only, per the contract from 943acec8).
- Repository guard: an empty refresh token can never overwrite a stored one.
- Refresh/reConnect failures are logged with the real provider error instead of being swallowed, and the error reaches the user notification (previously the notification was generic and the error was discarded — this investigation was blind because of it).
- New optional `refreshErrorMessage(err)` provider hook: YouTube maps Google's `invalid_rapt` (Workspace session-control policy) to a message telling the user to have their admin mark Postiz as a trusted app.
- YouTube `reConnect` no longer goes through `pages()`, which swallowed the real Google error and mislabeled every failure as "Channel not found" (this is Sentry CLOUD-A9).
- Removed the duplicated disconnect notification (users previously got two emails per failed refresh).

# Other information:

Verified end to end against a real connected YouTube channel:
1. With a valid stored refresh token and an expired access token, the analytics path refreshed successfully through `refreshProcess` including `reConnect` (baseline).
2. Reproduced the customer's state (`refreshNeeded`) and ran the full reconnect flow through Google's OAuth consent: the row now stores the newly issued refresh token with a real ~1h expiration and the flag cleared. Before this fix the same flow stored an empty token and a 31-year expiration.
3. Force-expired the access token again: the next refresh succeeded using the token stored by the reconnect — the loop is closed.

Also observed during testing: for a channel owned by a Brand Account, picking the wrong identity in Google's chooser makes the reconnect fail with "Channel not found" — loudly, before anything is written — but the UI redirects back to the calendar without surfacing why. Possible UX follow-up.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)