### PR TITLE
fix(reddit): retry SUBREDDIT_NOEXIST instead of failing the post

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -519,13 +519,25 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
     // Reddit rejects submissions with a 200 and an errors array: surface the
     // real reason instead of failing later with an unknown outcome.
     if (all?.json?.errors?.length) {
+      const message = `Reddit rejected the post to r/${
+        postData.sr
+      }: ${all.json.errors
+        .map((e: any[]) => e?.[1] || e?.[0] || '')
+        .join(', ')}`;
+
+      // Reddit answers SUBREDDIT_NOEXIST for subreddits that do exist and
+      // accept the very same submission minutes later, so it can't be treated
+      // as a permanent rejection - let the workflow submit it again (the armed
+      // handshake still guards against a double post).
+      if (all.json.errors.some((e: any[]) => e?.[0] === 'SUBREDDIT_NOEXIST')) {
+        throw new Error(message);
+      }
+
       throw new BadBody(
         this.identifier,
         JSON.stringify(all),
         Buffer.from('{}'),
-        `Reddit rejected the post to r/${postData.sr}: ${all.json.errors
-          .map((e: any[]) => e?.[1] || e?.[0] || '')
-          .join(', ')}`
+        message
       );
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Reddit posts failing with "that community doesn't exist" for communities that do exist). A `SUBREDDIT_NOEXIST` error in the 200-response `errors` array from `/api/submit` now throws a plain retryable `Error`, so the post workflow resubmits it, while every other submit error still fails fast as a non-retryable `BadBody`. This restores - deliberately, and only for this one code - the retry behaviour that existed by accident before e287a14.

# Why was this change needed?

Two unrelated customers reported Reddit posts failing with:

`An error occurred while posting on reddit: Reddit rejected the post to r/<subreddit>/: Hmm, that community doesn't exist. Try checking the spelling.`

In both cases the subreddit exists, is public, is not 18+ and is not quarantined, and the user is a moderator of it and posts to it manually without a problem. One customer posts to two subreddits and saw a different single subreddit of the pair flagged on different attempts; the other has a single channel and a single subreddit. Both had successful publishes to the same subreddits, with the same settings and the same account, before and after the failures, with nothing changed in between - including one success roughly 8 hours after a failure.

So Reddit answers `/api/submit` with a 200 and a `SUBREDDIT_NOEXIST` error intermittently, for subreddits that exist and that accept the very same submission on a later attempt.

What changed for the user is on our side. Until https://github.com/gitroomhq/postiz-app/commit/e287a14dd81265be066b76e6568afd34fcdeb4c3 (Aug 5, "feat: pending + finalize for more platforms") the submit response was never inspected for an `errors` array: a rejection left `all.json.data` undefined and the next line, `new WebSocket(all.json.data.websocket_url)`, threw a plain `TypeError`. That is a generic error, and the post workflow retries generic errors - so an intermittent `SUBREDDIT_NOEXIST` was resubmitted, cleared on a retry, and never reached the user. That commit correctly started surfacing submit errors, but classifies all of them as `BadBody`, which is non-retryable and fails the post immediately with a user notification. All the reported failures are from after that change was deployed.

This restores the previous effective behaviour deliberately rather than by accident, and only for this error code: `SUBREDDIT_NOEXIST` now throws a retryable error, every other submit error still fails fast as `BadBody`. Resubmitting is safe because the `armed` handshake in `checkPostStatus` still guards against a double post.

# Other information:

- Reddit's API documents no error taxonomy and no retry guidance for `/api/submit`, and documents `SUBREDDIT_NOEXIST` only as a 404 on a different endpoint. Retrying it here is based on the observed customer evidence above (rejected then accepted, unchanged), not on documented behaviour.
- Scoped to the code returned by Reddit, so a genuinely misspelled subreddit coming from the public API still surfaces an error once the workflow's retries are exhausted, rather than failing on the first attempt as it does today.
- Not reproducible on demand - the condition is intermittent on Reddit's side, so this could not be verified end to end against a live failure.
- Possibly related fix: #1930 strips the trailing slash our subreddit picker stores in subreddit names (`/r/Name/`). Prod data there shows trailing-slash names have a much higher "community doesn't exist" rate among errored posts (21% vs 3.5% for clean names) while still often publishing, so part of the intermittent `SUBREDDIT_NOEXIST` failures this PR retries may actually be Reddit rejecting the trailing-slash shape.
- Follow-up worth considering separately: a per-subreddit failure currently discards the subreddits that already published in the same post, so a multi-subreddit post is reported as fully failed when part of it is live.

# QA

The real condition is intermittent on Reddit's side and cannot be provoked on demand, so the two branches are verified by forcing the submit response locally.

1. [ ] Start a local Temporal server plus the stack (`pnpm run dev:docker`, then `pnpm run dev`), connect a Reddit channel and pick a subreddit you moderate.
2. [ ] In `libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts`, right after the `/api/submit` call and before the `if (all?.json?.errors?.length)` check, temporarily force the retryable case: `all = { json: { errors: [['SUBREDDIT_NOEXIST', "Hmm, that community doesn't exist. Try checking the spelling."]] } };`
3. [ ] Schedule a post to that Reddit channel and let it run. Expected: the post activity throws a plain `Error` with the message `Reddit rejected the post to r/<subreddit>: Hmm, that community doesn't exist...` and the Temporal UI shows the activity being **retried** (attempt count climbing) instead of the post being marked failed. The user gets no immediate failure notification. Before this change the first attempt failed the post outright.
4. [ ] Change the forced value to a different code, e.g. `all = { json: { errors: [['NO_TEXT', 'we need something here']] } };`
5. [ ] Schedule another post. Expected: it fails immediately as a `BadBody` error with the message `Reddit rejected the post to r/<subreddit>: we need something here`, no retries, and the user gets the failure notification - non-`SUBREDDIT_NOEXIST` errors still fail fast.
6. [ ] Mixed case: `all = { json: { errors: [['NO_TEXT', 'we need something here'], ['SUBREDDIT_NOEXIST', "Hmm, that community doesn't exist."]] } };`. Expected: retried (the retryable code wins), and the thrown message lists both reasons.
7. [ ] Remove the temporary override and schedule a real post to the subreddit. Expected: it publishes normally and the Reddit URL is stored on the post - the happy path is untouched.
8. [ ] Double-post check: while the forced `SUBREDDIT_NOEXIST` retry from step 3 is looping, confirm nothing appears on the subreddit - the `armed` handshake in `checkPostStatus` still guards resubmission.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
