### PR TITLE
feat(instagram): add "Share Reel to Feed" toggle (share_to_feed)

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/instagram/instagram.collaborators.tsx
+++ b/apps/frontend/src/components/new-launch/providers/instagram/instagram.collaborators.tsx
@@ -86,6 +86,16 @@ const InstagramCollaborators: FC<{
       {postCurrentType === 'post' && (
         <div className="mt-[18px] flex flex-col gap-[18px]">
           <Checkbox
+            {...register('share_to_feed', {
+              value: true,
+            })}
+            label={t(
+              'instagram_share_to_feed',
+              'Share Reel to Feed (Reels only - single video)'
+            )}
+          />
+
+          <Checkbox
             {...register('is_trial_reel', {
               value: false,
             })}

--- a/i18n.lock
+++ b/i18n.lock
@@ -229,6 +229,7 @@ checksums:
     please_add_at_least_one_subreddit: e142943a891554b60b4ed454bcacea3e
     add_community: c99eed390de61bf1f2461ee6dc908aad
     select_post_type: 76bdff7f68f2ad4ae103b5486bdb2212
+    instagram_share_to_feed: 203f4e3fcc8561e1b311a10ed9474a12
     we_couldn_t_find_any_business_connected_to_your_linkedin_page: ab9c8aefab51eafd55f7e176670a33d8
     please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again: a75998c2cf997b9b1de736b67e91b18f
     select_linkedin_page: ec0c852d588b2b8ee56ca3fcdae2b4bc

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/instagram.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/instagram.dto.ts
@@ -1,6 +1,7 @@
 import { Type } from 'class-transformer';
 import {
   IsArray,
+  IsBoolean,
   IsDefined,
   IsIn,
   IsNumber,
@@ -54,7 +55,12 @@ export class InstagramDto {
   post_type: 'post' | 'story';
 
   @IsOptional()
+  @IsBoolean()
   is_trial_reel?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  share_to_feed?: boolean;
 
   @IsIn(['MANUAL', 'SS_PERFORMANCE'])
   @IsOptional()

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -691,6 +691,18 @@ export class InstagramProvider
             )}`
           : ``;
 
+        // share_to_feed is only supported for Reels (single video, not a story),
+        // and only sent when the user explicitly turned it off (Meta defaults to true)
+        const shareToFeed =
+          typeof firstPost?.settings?.share_to_feed !== 'undefined' &&
+          firstPost?.settings?.share_to_feed !== null &&
+          !this.assetBoolean(firstPost.settings.share_to_feed) &&
+          !isStory &&
+          firstPost?.media?.length === 1 &&
+          hasExtension(m.path, 'mp4')
+            ? `&share_to_feed=false`
+            : ``;
+
         const collaborators =
           firstPost?.settings?.collaborators?.length && !isStory
             ? `&collaborators=${JSON.stringify(
@@ -723,7 +735,7 @@ export class InstagramProvider
 
         const { id: photoId } = await (
           await this.fetch(
-            `https://${type}/v20.0/${id}/media?${mediaType}${isCarousel}${collaborators}${trialParams}${audioConfiguration}&access_token=${accessToken}${caption}`,
+            `https://${type}/v20.0/${id}/media?${mediaType}${isCarousel}${collaborators}${trialParams}${audioConfiguration}${shareToFeed}&access_token=${accessToken}${caption}`,
             {
               method: 'POST',
             }

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "يرجى إضافة منتدى فرعي واحد على الأقل",
   "add_community": "أضف مجتمع",
   "select_post_type": "اختر نوع المنشور...",
+  "instagram_share_to_feed": "مشاركة الريل على الخلاصات (ريلز فقط - فيديو واحد)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "لم نتمكن من العثور على أي نشاط تجاري مرتبط بصفحة لينكدإن الخاصة بك.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "يرجى إغلاق هذه النافذة، وإنشاء صفحة جديدة، ثم إضافة قناة جديدة مرة أخرى.",
   "select_linkedin_page": "اختر صفحة لينكدإن:",

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "অনুগ্রহ করে কমপক্ষে একটি সাবরেডিট যোগ করুন",
   "add_community": "কমিউনিটি যোগ করুন",
   "select_post_type": "পোস্টের ধরন নির্বাচন করুন...",
+  "instagram_share_to_feed": "রিল ফিডে শেয়ার করুন (শুধুমাত্র রিলস - একক ভিডিও)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "আমরা আপনার LinkedIn পৃষ্ঠার সাথে সংযুক্ত কোনো ব্যবসা খুঁজে পাইনি।",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "অনুগ্রহ করে এই ডায়ালগটি বন্ধ করুন, একটি নতুন পৃষ্ঠা তৈরি করুন এবং আবার একটি নতুন চ্যানেল যোগ করুন।",
   "select_linkedin_page": "LinkedIn পৃষ্ঠা নির্বাচন করুন:",

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Bitte fügen Sie mindestens einen Subreddit hinzu",
   "add_community": "Community hinzufügen",
   "select_post_type": "Beitragstyp auswählen...",
+  "instagram_share_to_feed": "Reel im Feed teilen (nur Reels – einzelnes Video)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "Wir konnten kein Unternehmen finden, das mit Ihrer LinkedIn-Seite verbunden ist.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Bitte schließen Sie diesen Dialog, erstellen Sie eine neue Seite und fügen Sie erneut einen neuen Kanal hinzu.",
   "select_linkedin_page": "LinkedIn-Seite auswählen:",

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Please add at least one Subreddit",
   "add_community": "Add Community",
   "select_post_type": "Select Post Type...",
+  "instagram_share_to_feed": "Share Reel to Feed (Reels only - single video)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "We couldn't find any business connected to your LinkedIn Page.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Please close this dialog, create a new page, and add a new channel again.",
   "select_linkedin_page": "Select Linkedin Page:",

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Por favor, agrega al menos un Subreddit",
   "add_community": "Agregar comunidad",
   "select_post_type": "Seleccionar tipo de publicación...",
+  "instagram_share_to_feed": "Compartir Reel en el feed (solo Reels - un solo video)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "No pudimos encontrar ningún negocio conectado a tu página de LinkedIn.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Por favor, cierra este diálogo, crea una nueva página y agrega un nuevo canal nuevamente.",
   "select_linkedin_page": "Selecciona la página de LinkedIn:",

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Veuillez ajouter au moins un subreddit",
   "add_community": "Ajouter une communauté",
   "select_post_type": "Sélectionner le type de publication...",
+  "instagram_share_to_feed": "Partager le Reel dans le fil d’actualité (Reels uniquement – vidéo unique)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "Nous n'avons trouvé aucune entreprise liée à votre page LinkedIn.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Veuillez fermer cette fenêtre, créer une nouvelle page et ajouter à nouveau un nouveau canal.",
   "select_linkedin_page": "Sélectionnez la page LinkedIn :",

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "אנא הוסף לפחות סאב-רדיט אחד",
   "add_community": "הוסף קהילה",
   "select_post_type": "בחר סוג פוסט...",
+  "instagram_share_to_feed": "שתף/י ריל בפיד (רק רילס - סרטון בודד)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "לא הצלחנו למצוא עסק שמחובר לעמוד הלינקדאין שלך.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "אנא סגור את החלון הזה, צור עמוד חדש והוסף ערוץ חדש שוב.",
   "select_linkedin_page": "בחר עמוד לינקדאין:",

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Per favore aggiungi almeno un Subreddit",
   "add_community": "Aggiungi Comunità",
   "select_post_type": "Seleziona tipo di post...",
+  "instagram_share_to_feed": "Condividi Reel nel Feed (solo Reels - video singolo)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "Non siamo riusciti a trovare nessuna azienda collegata alla tua pagina LinkedIn.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Per favore chiudi questa finestra di dialogo, crea una nuova pagina e aggiungi nuovamente un nuovo canale.",
   "select_linkedin_page": "Seleziona pagina LinkedIn:",

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "少なくとも1つのサブレディットを追加してください",
   "add_community": "コミュニティを追加",
   "select_post_type": "投稿タイプを選択...",
+  "instagram_share_to_feed": "リールをフィードでシェア（リールのみ・単一動画）",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "あなたのLinkedInページに接続されているビジネスが見つかりませんでした。",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "このダイアログを閉じて、新しいページを作成し、再度新しいチャンネルを追加してください。",
   "select_linkedin_page": "LinkedInページを選択：",

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "최소한 하나의 서브레딧을 추가해 주세요.",
   "add_community": "커뮤니티 추가",
   "select_post_type": "게시물 유형 선택...",
+  "instagram_share_to_feed": "릴을 피드에 공유 (릴 전용 - 단일 비디오)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "연결된 LinkedIn 페이지에 연결된 비즈니스를 찾을 수 없습니다.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "이 대화 상자를 닫고, 새 페이지를 만든 후 새 채널을 다시 추가해 주세요.",
   "select_linkedin_page": "LinkedIn 페이지 선택:",

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Por favor, adicione pelo menos um Subreddit",
   "add_community": "Adicionar Comunidade",
   "select_post_type": "Selecionar Tipo de Postagem...",
+  "instagram_share_to_feed": "Compartilhar Reel no Feed (apenas Reels - um único vídeo)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "Não conseguimos encontrar nenhum negócio conectado à sua página do LinkedIn.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Por favor, feche este diálogo, crie uma nova página e adicione um novo canal novamente.",
   "select_linkedin_page": "Selecione a Página do Linkedin:",

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Пожалуйста, добавьте хотя бы один сабреддит",
   "add_community": "Добавить сообщество",
   "select_post_type": "Выберите тип поста...",
+  "instagram_share_to_feed": "Поделиться рилсом в ленте (только Reels — одно видео)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "Мы не смогли найти ни одного бизнеса, связанного с вашей страницей LinkedIn.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Пожалуйста, закройте это окно, создайте новую страницу и снова добавьте новый канал.",
   "select_linkedin_page": "Выберите страницу LinkedIn:",

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Lütfen en az bir Subreddit ekleyin",
   "add_community": "Topluluk Ekle",
   "select_post_type": "Gönderi Türü Seç...",
+  "instagram_share_to_feed": "Reel'i Akışta Paylaş (Yalnızca Reels – tek video)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "LinkedIn Sayfanıza bağlı herhangi bir işletme bulamadık.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Lütfen bu pencereyi kapatın, yeni bir sayfa oluşturun ve tekrar yeni bir kanal ekleyin.",
   "select_linkedin_page": "LinkedIn Sayfası Seç:",

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "Vui lòng thêm ít nhất một Subreddit",
   "add_community": "Thêm cộng đồng",
   "select_post_type": "Chọn loại bài đăng...",
+  "instagram_share_to_feed": "Chia sẻ Reel lên Bảng tin (Chỉ áp dụng cho Reels - video đơn)",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "Chúng tôi không tìm thấy doanh nghiệp nào liên kết với Trang LinkedIn của bạn.",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "Vui lòng đóng hộp thoại này, tạo một trang mới và thêm kênh mới lại.",
   "select_linkedin_page": "Chọn Trang Linkedin:",

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -225,6 +225,7 @@
   "please_add_at_least_one_subreddit": "请至少添加一个子版块",
   "add_community": "添加社区",
   "select_post_type": "选择帖子类型...",
+  "instagram_share_to_feed": "分享到动态（仅限Reels - 单个视频）",
   "we_couldn_t_find_any_business_connected_to_your_linkedin_page": "我们未能找到与您的 LinkedIn 页面关联的任何企业。",
   "please_close_this_dialog_create_a_new_page_and_add_a_new_channel_again": "请关闭此对话框，创建新页面并再次添加新频道。",
   "select_linkedin_page": "选择 Linkedin 页面：",


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature - a new optional Instagram post setting, `share_to_feed`, exposed as a "Share Reel to Feed" checkbox.

# Why was this change needed?

Customer feature request: users publishing Reels through Postiz want to keep their profile grid organized, but today every Reel we publish also lands on the grid with no way to opt out.

Meta supports `share_to_feed` on REELS media container creation:
- `true` - the reel can appear in both the Feed and the Reels tabs
- `false` - the reel can only appear in the Reels tab

The checkbox defaults to checked, which is today's behaviour.

Backward compatibility was the main constraint, so the param is only appended when the user explicitly turns the toggle off. When it is on or absent we send nothing at all, which keeps every existing user's container request byte-identical to before. Meta's reference lists the parameter as optional and does not state a default, so relying on "send nothing" rather than sending `share_to_feed=true` avoids depending on an undocumented default. The field is optional in `InstagramDto`, so posts stored before this change (which have no `share_to_feed` key) keep validating and publishing unchanged.

The param is scoped to the single-video, non-story `media_type=REELS` container only - it is not appended to stories, image containers, or multi-video carousel children.

`is_trial_reel` also gains `@IsBoolean()`. It was the only field in that folder declared with `@IsOptional()` alone, which also meant the derived agent/MCP schema did not describe it as a boolean. This was checked against every input shape that can reach the DTO before tightening it: the Checkbox component hands react-hook-form a real boolean, and posting through the UI stores real JSON booleans (`"share_to_feed": true` / `false`), as does the public API with a JSON boolean body.

# Other information:

Sent ungated to both login types. `share_to_feed` is documented on the legacy Instagram Graph API (Facebook Login) `ig-user/media` reference, and the newer Instagram Platform publishing guide does not mention it, so there was no positive confirmation that `graph.instagram.com` supported it. This was tested end to end rather than assumed: it is accepted and honoured on Instagram Login too, so it behaves like `collaborators` / `trial_params` / `thumb_offset` rather than like `audio_configuration`, which stays gated to Facebook Login because the Audio API requires it.

Worth noting for support: Meta describes the value as a hint, not a guarantee. A reel with `share_to_feed` true may still not surface in the Feed if it does not meet eligibility requirements. The `false` direction is the reliable one, which is what the requester actually wants.

Testing - verified end to end against real connected channels, capturing the outgoing container request in each case:

- Facebook Login channel, box checked: request contains no `share_to_feed` param at all; reel published and appears on the profile grid.
- Facebook Login channel, box unchecked: request contains `share_to_feed=false`; reel published successfully.
- Instagram Login (standalone) channel, box unchecked: request to `graph.instagram.com` contains `share_to_feed=false`; reel published successfully and appears only in the Reels tab, not on the profile grid.
- Post type "story": the toggle is hidden and no `share_to_feed` param is sent.
- Backward compatibility: an Instagram post stored before this change, with no `share_to_feed` key in its settings, still validates and publishes unchanged.

Not covered by live tests: image posts and multi-media carousels rely on the provider guard (single media plus `.mp4`) rather than a published post, and the interaction between `share_to_feed` and `is_trial_reel` was not exercised.

Like the existing Trial Reel checkbox and Audio selector, the toggle is rendered for any non-story post and states "Reels only - single video" in its label rather than being conditionally hidden based on the attached media.

New `t()` key `instagram_share_to_feed` was run through lingo.dev, so all 14 target locales are included.

Docs for the public API settings schema are handled in a separate postiz-docs PR.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
