### PR TITLE
fix(public-api): persist original filename on /upload so Media Library shows a name

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -90,11 +90,16 @@ export class PublicIntegrationsController {
       throw new HttpException({ msg: 'No file provided' }, 400);
     }
 
+    // Capture the uploaded file's name before uploadFile replaces originalname
+    // with the generated storage name, so the media record keeps a real display
+    // name (matching the internal /upload-server handler).
+    const originalName = file?.originalname || '';
     const getFile = await this.storage.uploadFile(file);
     return this._mediaService.saveFile(
       org.id,
       getFile.originalname,
-      getFile.path
+      getFile.path,
+      originalName
     );
   }
 


### PR DESCRIPTION
Fixes #1862.

The public API endpoint `POST /public/v1/upload` always stores `originalName: null`, so anything uploaded through the public API (n8n, Zapier, scripts) shows up in the Media Library with a blank, unsearchable name. The same file uploaded through the web UI keeps its name.

The cause is that the public handler drops the filename. Compare it with the internal `/upload-server` handler in `media.controller.ts`, which grabs the name before uploading and passes it through:

```ts
const originalName = file?.originalname || '';
const uploadedFile = await this.storage.uploadFile(file);
return this._mediaService.saveFile(
  org.id,
  uploadedFile.originalname,
  uploadedFile.path,
  originalName
);
```

The public `/upload` handler called `saveFile(org.id, getFile.originalname, getFile.path)` with no fourth argument, and `saveFile` stores `originalName: originalName || null`, so it was always null.

The order matters here: `storage.uploadFile(file)` returns the generated storage name as `originalname` (the hashed `name` used for the file on disk), so the real display name has to be read off `file.originalname` before that call. This change captures it first and passes it as the fourth argument, exactly like the internal handler.

I kept the change to the one endpoint the issue is about. The reporter also mentions #1147 (upload-from-url returning an empty name); that path builds a synthetic filename from the URL and is a separate question, so I left it alone here.

There is no backend spec suite for these controllers (the internal upload handlers have no tests either), so this follows the existing pattern. Verified by lining the handler up against the working `/upload-server` one.