### PR TITLE
fix(webhooks): send the internal post id so the payload isn't empty

### DIFF
--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.6.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.6.ts
@@ -514,9 +514,12 @@ export async function postWorkflowV106({
     }
   }
 
-  // send webhooks for the post
+  // send webhooks for the post using its internal id. postsResults[0].postId
+  // is the provider's release id (Instagram/LinkedIn/etc.), but sendWebhooks
+  // looks the post up by internal id, so passing the release id found nothing
+  // and every webhook fired with an empty body.
   await sendWebhooks(
-    postsResults[0].postId,
+    post.id,
     post.organizationId,
     post.integration.id
   );


### PR DESCRIPTION
Fixes #1861.

Every webhook delivery goes out with a body of `[]`, so a consumer can see that a request arrived but not which post was published.

The publish workflow calls `sendWebhooks` with the wrong id. In `post.workflow.v1.0.6.ts` it passed `postsResults[0].postId`, which is the provider's release id (the id Instagram/LinkedIn/etc. returns), not Postiz's internal post id. A few lines up the two are clearly distinct, `updatePost` uses `postsList[i].id` for the internal row and `postsResults[i].postId` for the release id:

```ts
await updatePost(
  postsList[i].id,          // internal post id
  postsResults[i].postId,   // provider release id
  postsResults[i].releaseURL
);
```

`sendWebhooks` then looks the value up by internal id:

```ts
const post = await this._postService.getPostByForWebhookId(postId);
...
body: JSON.stringify(post),
```

Given the provider id, that lookup finds nothing and the body serializes to `[]`, which is the empty payload in the report.

This passes `post.id` instead. `post` is the same object already used for `post.organizationId` and `post.integration.id` in that call (it is `postsList[0]`), so its `id` is the internal post id `getPostByForWebhookId` expects.

There are no orchestrator tests around this workflow, so I verified by tracing the id through `updatePost` and `getPostByForWebhookId`. Happy to adjust if you would rather read the id from `postsList[0].id` for symmetry with the loop above.