### PR TITLE
fix(facebook): map (#200) permission errors to a curated message

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -81,6 +81,14 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       };
     }
 
+    if (body.indexOf('(#200)') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          'Facebook rejected the post due to missing permissions. Make sure your Facebook account has full content access to the Page, then reconnect the channel.',
+      };
+    }
+
     if (body.indexOf('1366046') > -1) {
       return {
         type: 'bad-body' as const,

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -307,6 +307,14 @@ export class InstagramProvider
       };
     }
 
+    if (body.indexOf('(#200)') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          'Facebook rejected the post due to missing permissions. Make sure your Facebook account has full content access to the Page linked to this Instagram account, then reconnect the channel.',
+      };
+    }
+
     if (body.indexOf('Not enough permissions to post') > -1) {
       return {
         type: 'bad-body' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix / UX improvement

# Why was this change needed?

A customer's Facebook Page posts were failing 100% of the time with a Graph API OAuthException, code 200: `(#200) ... requires both pages_read_engagement and pages_manage_posts as an admin with sufficient administrative permission`. This happens when the connected Facebook account lacks posting rights on the Page (insufficient page role, or `pages_manage_posts` unchecked in the granular OAuth dialog) — reconnecting alone doesn't fix it, the user has to fix their page access on Facebook first.

Because `FacebookProvider.handleErrors` had no mapping for it, the failure surfaced as the `Unknown Error` placeholder — the failure email told the customer nothing, and they had no way to self-serve.

This adds a curated `bad-body` mapping on the `(#200)` marker:

> Facebook rejected the post due to missing permissions. Make sure your Facebook account has full content access to the Page, then reconnect the channel.

Per [Meta's error-handling docs](https://developers.facebook.com/docs/graph-api/guides/error-handling/), codes 200–299 are "API Permission" errors, so `(#200)` always denotes a permissions problem — the mapping can't mislabel an unrelated failure. The reverse isn't 1-1 (other permission errors use other codes, e.g. 10 or the rest of 200–299; see also [this writeup on error 200 causes](https://www.ayrshare.com/solutions/how-to-fix-meta-error-200-permissions-error-and-insufficient-scopes/)); those still fall back to the generic message, same as today.

With this mapping, the failure email immediately shows the actionable message, and once #1868 (curated calendar error tooltips) merges, the calendar tooltip surfaces it too — so the user can self-serve: fix their Page access on Facebook, reconnect, repost.

Side effect: the `isPresetRejection` retry helper matches `'Unknown Error'`, so a (#200) failure on a preset post previously triggered a pointless second publish attempt without the preset; with the curated message it no longer does.

**Update — Instagram too (cd1e40dc):** the same `(#200)` body also shows up on the Instagram (Facebook-login) provider, where publishing goes through the Facebook Page linked to the Instagram account (5 occurrences in production since 2026-07-01, all previously surfaced as `Unknown Error`). `InstagramProvider.handleErrors` now maps it the same way (non-retryable `bad-body`, message adjusted to point at the linked Page), placed before the generic `'190,'` rule; `instagram-standalone` delegates to the same `handleErrors`, so it is covered as well.

# Other information:

Verified against production data: the failing page had 16/16 posts rejected with this exact error body, including after a fresh reconnect, confirming it's a page-access problem the user must resolve on Facebook's side.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
