### PR TITLE
feat(youtube): add video category selector to the composer

### DIFF
--- a/apps/frontend/src/components/new-launch/providers/youtube/youtube.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/youtube/youtube.provider.tsx
@@ -5,7 +5,11 @@ import {
   PostComment,
   withProvider,
 } from '@gitroom/frontend/components/new-launch/providers/high.order.provider';
-import { YoutubeSettingsDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/youtube.settings.dto';
+import {
+  YoutubeSettingsDto,
+  YOUTUBE_UPLOAD_CATEGORIES,
+  YOUTUBE_DEFAULT_CATEGORY_ID,
+} from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/youtube.settings.dto';
 import { useSettings } from '@gitroom/frontend/components/launches/helpers/use.values';
 import { Input } from '@gitroom/react/form/input';
 import { MediumTags } from '@gitroom/frontend/components/new-launch/providers/medium/medium.tags';
@@ -51,6 +55,18 @@ const YoutubeSettings: FC = () => {
         {type.map((t) => (
           <option key={t.value} value={t.value}>
             {t.label}
+          </option>
+        ))}
+      </Select>
+      <Select
+        label="Category"
+        {...register('categoryId', {
+          value: YOUTUBE_DEFAULT_CATEGORY_ID,
+        })}
+      >
+        {YOUTUBE_UPLOAD_CATEGORIES.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
           </option>
         ))}
       </Select>

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/youtube.settings.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/youtube.settings.dto.ts
@@ -21,6 +21,33 @@ import { Type } from 'class-transformer';
 // two extra characters per tag toward that limit.
 export const YOUTUBE_TAGS_MAX_LENGTH = 500;
 
+// YouTube video categories that accept uploads via the Data API (videos.insert).
+// IDs are the assignable categoryId values (US list; these IDs are stable across
+// locales). Some categories exist for browsing only and reject uploads, so this
+// is a curated subset, not the full list. Default is Education ('27').
+export const YOUTUBE_UPLOAD_CATEGORIES = [
+  { value: '27', label: 'Education' },
+  { value: '26', label: 'Howto & Style' },
+  { value: '22', label: 'People & Blogs' },
+  { value: '28', label: 'Science & Technology' },
+  { value: '24', label: 'Entertainment' },
+  { value: '25', label: 'News & Politics' },
+  { value: '29', label: 'Nonprofits & Activism' },
+  { value: '15', label: 'Pets & Animals' },
+  { value: '17', label: 'Sports' },
+  { value: '10', label: 'Music' },
+  { value: '23', label: 'Comedy' },
+  { value: '19', label: 'Travel & Events' },
+  { value: '1', label: 'Film & Animation' },
+  { value: '20', label: 'Gaming' },
+];
+
+export const YOUTUBE_DEFAULT_CATEGORY_ID = '27';
+
+export const YOUTUBE_UPLOAD_CATEGORY_IDS = YOUTUBE_UPLOAD_CATEGORIES.map(
+  (c) => c.value
+);
+
 export function getYoutubeTagsLength(tags: YoutubeTagsSettings[]): number {
   return (tags ?? []).reduce((total, tag) => {
     const label = tag?.label ?? '';
@@ -73,6 +100,10 @@ export class YoutubeSettingsDto {
   @IsIn(['public', 'private', 'unlisted'])
   @IsDefined()
   type: string;
+
+  @IsIn(YOUTUBE_UPLOAD_CATEGORY_IDS)
+  @IsOptional()
+  categoryId?: string;
 
   @IsIn(['yes', 'no'])
   @IsOptional()

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -572,6 +572,7 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
           snippet: {
             title: settings.title,
             description: firstPost?.message,
+            categoryId: settings.categoryId || '27',
             ...(settings?.tags?.length
               ? { tags: settings.tags.map((p) => p.label) }
               : {}),


### PR DESCRIPTION
## What

Adds a **Category** dropdown to the YouTube provider panel in the composer, so uploads can set the YouTube video category instead of relying on the account/API default.

## Why

The YouTube composer exposed title, privacy, made-for-kids, tags and thumbnail, but not the video category. Category affects discovery/recommendation, so creators generally want to set it per upload.

## Changes

- `youtube.settings.dto.ts`: new optional `categoryId`, validated against an allowlist of upload-capable category IDs (`YOUTUBE_UPLOAD_CATEGORIES`), default Education (`27`).
- `youtube/youtube.provider.tsx`: a `<Select>` for the category next to Type / Made-for-kids.
- `youtube.provider.ts`: sets `snippet.categoryId` on the resumable upload, falling back to `27` when unset.

Backward compatible: the field is optional; existing drafts without it fall back to the previous behavior.

## Testing

Ran the frontend dev composer against a connected YouTube channel: the Category dropdown renders with the full option list and persists into the post settings; `snippet.categoryId` is included on upload.