### PR TITLE
feat(tiktok): expose creator_info via public API

### DIFF
--- a/apps/backend/src/public-api/routes/v1/creator-info.manual-verification.md
+++ b/apps/backend/src/public-api/routes/v1/creator-info.manual-verification.md
@@ -1,0 +1,111 @@
+# Manual verification — `GET /public/v1/integrations/:id/tiktok/creator-info`
+
+This repo has no working test harness at the pinned tag (`v2.21.9`): `jest.config.ts`
+imports `getJestProjects` from `@nx/jest`, but neither `nx.json` nor an `@nx/*`
+package exists anywhere in the workspace, and there are zero `*.spec.ts` /
+`*.test.ts` files in the entire repo (verified by full-repo search before writing
+this patch). `pnpm test` fails immediately on `Cannot find module '@nx/jest'`.
+Because there is no usable/functional test runner to add real coverage to,
+this file documents the manual verification steps instead, per PR-1 task 1.3.
+
+## Prerequisites
+
+- A running self-hosted Postiz instance built from this branch
+  (`feat/creator-info-endpoint`), pointed at a database with at least one
+  **connected, non-expired TikTok integration**.
+- A valid Postiz API key for the organization that owns that integration
+  (Settings → API keys in the Postiz dashboard, or `Organization.apiKey` /
+  the OAuth `pos_` token flow — see `public.auth.middleware.ts`).
+- The TikTok `integrationId` (UUID) for that connected channel. Get it via
+  the existing, already-working route:
+
+```bash
+curl -s \
+  -H "Authorization: $POSTIZ_API_KEY" \
+  "$POSTIZ_BASE_URL/public/v1/integrations" | jq '.[] | select(.identifier=="tiktok")'
+```
+
+## Test 1 — 401 without API key
+
+```bash
+curl -i "$POSTIZ_BASE_URL/public/v1/integrations/$INTEGRATION_ID/tiktok/creator-info"
+```
+
+Expected: `HTTP/1.1 401 Unauthorized`, body `{"msg":"No API Key found"}`
+(handled by `PublicAuthMiddleware`, applied to the whole
+`PublicIntegrationsController` — no per-route change needed).
+
+## Test 2 — 200 with valid key + real connected TikTok channel
+
+```bash
+curl -i \
+  -H "Authorization: $POSTIZ_API_KEY" \
+  "$POSTIZ_BASE_URL/public/v1/integrations/$INTEGRATION_ID/tiktok/creator-info"
+```
+
+Expected: `HTTP/1.1 200 OK`, JSON body matching the `TikTokCreatorInfo` DTO:
+
+```json
+{
+  "nickname": "some_creator_handle",
+  "privacyLevelOptions": ["PUBLIC_TO_EVERYONE", "MUTUAL_FOLLOW_FRIENDS", "SELF_ONLY"],
+  "duetDisabled": false,
+  "stitchDisabled": false,
+  "commentDisabled": false,
+  "maxVideoPostDurationSec": 300
+}
+```
+
+Checklist while inspecting the response:
+
+- [ ] `privacyLevelOptions` is a non-empty array sourced from the live TikTok
+      response (not hardcoded) — cross-check against what the TikTok mobile
+      app / Creator Portal shows as available privacy options for this
+      specific creator.
+- [ ] `duetDisabled` / `stitchDisabled` / `commentDisabled` reflect the
+      creator's actual TikTok settings (toggle one in the TikTok app,
+      re-run the curl, confirm the flag flips).
+- [ ] `maxVideoPostDurationSec` is a sane positive integer (matches the
+      creator's account tier).
+- [ ] No `nickname`/options field is silently defaulted when TikTok returns
+      a non-`ok` `error.code` — instead the route must respond with a
+      `502 {"msg":"Failed to fetch TikTok creator info"}` (see Test 3).
+
+## Test 3 — non-TikTok integration id
+
+```bash
+curl -i \
+  -H "Authorization: $POSTIZ_API_KEY" \
+  "$POSTIZ_BASE_URL/public/v1/integrations/$LINKEDIN_INTEGRATION_ID/tiktok/creator-info"
+```
+
+Expected: `HTTP/1.1 400 Bad Request`,
+`{"msg":"Integration is not a TikTok channel"}`.
+
+## Test 4 — unknown integration id
+
+```bash
+curl -i \
+  -H "Authorization: $POSTIZ_API_KEY" \
+  "$POSTIZ_BASE_URL/public/v1/integrations/00000000-0000-0000-0000-000000000000/tiktok/creator-info"
+```
+
+Expected: `HTTP/1.1 404 Not Found`, `{"msg":"Integration not found"}`.
+
+## Test 5 — expired token / refresh path (best-effort, not always reproducible)
+
+If the connected TikTok token is expired at the time of the call, the route
+should transparently refresh via `RefreshIntegrationService` (same pattern as
+`triggerIntegrationTool` in this controller) and retry once with the new
+access token, or return `401 {"msg":"Channel disconnected due to expired
+token"}` if the refresh itself fails. This is not easily forced on demand;
+note the actual observed behavior in the PR description if/when it happens
+naturally during the sign-off window (task 1.3 in `sdd/canales-pretramite/tasks`).
+
+## Sign-off
+
+This checklist (or equivalent evidence: response bodies/screenshots) MUST be
+attached to the PR-1 description before merge — this is a required manual
+sign-off step, not a CI gate (task 1.3), and is separate from the AGPL
+compliance sign-off gate (task 1.4, blocks VM deploy specifically, not the
+branch/PR itself).

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -59,6 +59,7 @@ import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abst
 import { PostValidationException } from '@gitroom/backend/api/routes/posts.validation.exception';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
+import type { TiktokProvider } from '@gitroom/nestjs-libraries/integrations/social/tiktok.provider';
 
 @ApiTags('Public API')
 @Controller('/public/v1')
@@ -437,6 +438,67 @@ export class PublicIntegrationsController {
         tools: tools[integration.identifier],
       },
     };
+  }
+
+  @Get('/integrations/:id/tiktok/creator-info')
+  async getTikTokCreatorInfo(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string
+  ) {
+    Sentry.metrics.count('public_api-request', 1);
+    const getIntegration = await this._integrationService.getIntegrationById(
+      org.id,
+      id
+    );
+
+    if (!getIntegration) {
+      throw new HttpException({ msg: 'Integration not found' }, 404);
+    }
+
+    if (getIntegration.providerIdentifier !== 'tiktok') {
+      throw new HttpException(
+        { msg: 'Integration is not a TikTok channel' },
+        400
+      );
+    }
+
+    const integrationProvider = socialIntegrationList.find(
+      (p) => p.identifier === 'tiktok'
+    ) as TiktokProvider | undefined;
+
+    if (!integrationProvider) {
+      throw new HttpException({ msg: 'TikTok provider not found' }, 404);
+    }
+
+    try {
+      return await integrationProvider.getCreatorInfo(getIntegration.token);
+    } catch (err) {
+      if (err instanceof RefreshToken) {
+        const data = await this._refreshIntegrationService.refresh(
+          getIntegration
+        );
+
+        if (!data) {
+          await this._integrationService.disconnectChannel(
+            org.id,
+            getIntegration
+          );
+          throw new HttpException(
+            { msg: 'Channel disconnected due to expired token' },
+            401
+          );
+        }
+
+        if (data.accessToken) {
+          return await integrationProvider.getCreatorInfo(data.accessToken);
+        }
+      }
+
+      throw new HttpException(
+        { msg: 'Failed to fetch TikTok creator info' },
+        502
+      );
+    }
   }
 
   @Get('/posts/:id/missing')

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -17,6 +17,28 @@ import { hasExtension } from '@gitroom/helpers/utils/has.extension';
 import { Integration } from '@prisma/client';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
+// Raw shape of TikTok's `creator_info/query` `data` payload (snake_case, as
+// documented by the Content Posting API).
+interface TikTokCreatorInfoApiData {
+  creator_nickname: string;
+  privacy_level_options: string[];
+  comment_disabled: boolean;
+  duet_disabled: boolean;
+  stitch_disabled: boolean;
+  max_video_post_duration_sec: number;
+}
+
+// DTO exposed to callers (publishing-ms via the public-api route) — camelCase,
+// no static/hardcoded fallback allowed on any of these fields.
+export interface TikTokCreatorInfo {
+  nickname: string;
+  privacyLevelOptions: string[];
+  duetDisabled: boolean;
+  stitchDisabled: boolean;
+  commentDisabled: boolean;
+  maxVideoPostDurationSec: number;
+}
+
 @Rules(
   'TikTok can have one video or one picture or multiple pictures, it cannot be without an attachment'
 )
@@ -384,9 +406,27 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
-  async maxVideoLength(accessToken: string) {
+  /**
+   * Wraps TikTok's `creator_info/query` endpoint (Content Posting API) and
+   * returns the full creator-scoped compliance surface: display name,
+   * selectable privacy levels, per-creator interaction toggles that are
+   * disabled server-side, and the max video duration this creator can post.
+   *
+   * Callers MUST source privacy/toggle defaults from this response — TikTok's
+   * posting guidelines forbid hardcoding a static privacy_level default or
+   * assuming duet/stitch/comment are always enabled.
+   */
+  async getCreatorInfo(accessToken: string): Promise<TikTokCreatorInfo> {
     const {
-      data: { max_video_post_duration_sec },
+      data: {
+        creator_nickname,
+        privacy_level_options,
+        comment_disabled,
+        duet_disabled,
+        stitch_disabled,
+        max_video_post_duration_sec,
+      } = {} as TikTokCreatorInfoApiData,
+      error,
     } = await (
       await fetch(
         'https://open.tiktokapis.com/v2/post/publish/creator_info/query/',
@@ -400,8 +440,19 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       )
     ).json();
 
+    if (error && error.code !== 'ok') {
+      throw new Error(
+        error.message || 'Failed to fetch TikTok creator info'
+      );
+    }
+
     return {
-      maxDurationSeconds: max_video_post_duration_sec,
+      nickname: creator_nickname,
+      privacyLevelOptions: privacy_level_options,
+      duetDisabled: duet_disabled,
+      stitchDisabled: stitch_disabled,
+      commentDisabled: comment_disabled,
+      maxVideoPostDurationSec: max_video_post_duration_sec,
     };
   }
 


### PR DESCRIPTION
## What

Exposes TikTok's `creator_info/query` through the public API so API consumers can build compliant TikTok posting UIs.

- Extends the existing (previously unused) `maxVideoLength()` call in `tiktok.provider.ts` into `getCreatorInfo(accessToken)`, returning the full creator info TikTok requires UIs to display: `nickname`, `privacyLevelOptions`, `duetDisabled`, `stitchDisabled`, `commentDisabled`, `maxVideoPostDurationSec`.
- Adds `GET /public/v1/integrations/:id/tiktok/creator-info` to the public API controller, reusing the controller-level API key auth (no new auth code).

## Why

TikTok's [Content Sharing Guidelines](https://developers.tiktok.com/doc/content-sharing-guidelines) require that posting UIs query `creator_info` before rendering the composer (privacy options without defaults, disabled interaction toggles, creator nickname). Today Postiz fetches this data internally but never exposes it, so API consumers cannot pass TikTok's content audit.

Closes the gap requested in #1362 and #1563.

## Notes

- Based on v2.21.9; happy to rebase on latest main if there's interest.
- Error handling follows the existing provider patterns: 404 unknown integration, 400 non-TikTok integration, 401 on failed token refresh, 502 on upstream TikTok failure.
- Manual verification steps documented in `apps/backend/src/public-api/routes/v1/creator-info.manual-verification.md` (the repo's jest harness appears non-functional on this tag — happy to add specs if there's a working setup on main).
