### PR TITLE
fix(instagram): make 'Media fetch failed' (2207052) retryable

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -186,7 +186,7 @@ export class InstagramProvider
 
     if (body.indexOf('2207052') > -1) {
       return {
-        type: 'bad-body' as const,
+        type: 'retry' as const,
         value: 'Media fetch failed, please try again',
       };
     }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Instagram provider error mapping). Flips the existing `2207052` ("Media fetch failed") branch in `InstagramProvider.handleErrors` from `type: 'bad-body'` to `type: 'retry'`. 2207052 is raised while creating the media container, so nothing has been published at that point and a retry cannot duplicate a post; `SocialAbstract.fetch` bounds it to three attempts roughly five seconds apart before falling through to a `BadBody` with the same message. The message text and every other branch are unchanged.

# Why was this change needed?

Instagram error subcode 2207052 is currently mapped to a non-retryable `bad-body` failure, so a single failed media fetch fails the whole post permanently.

Prod occurrence: a 6-image carousel on an instagram-standalone channel failed on item #5 while the other 5 images (same host, same format, same dimensions, created in the same `Promise.all`) were accepted. Meta's response:

```
"message": "Only photo or video can be accepted as media type.",
"code": 9004, "error_subcode": 2207052, "is_transient": false,
"error_user_title": "Media download has failed. The media URI doesn't meet our requirements.",
"error_user_msg": "The media could not be fetched from this URI: https://uploads.postiz.com/<file>.png. Please check the limitations section ..."
```

The file was publicly reachable and identical in format to its siblings, so this looks like a transient fetch failure on Meta's side. This PR maps 2207052 to `retry` (same path as "An unknown error occurred") so the activity is retried instead of failing outright. The user-facing message stays "Media fetch failed, please try again".

Disclaimer: Meta marks this error `is_transient: false`. We are deliberately ignoring that flag based on the observed behavior above and on Meta's own "please try again" wording; if the media is genuinely unfetchable the retries will exhaust and the post will still end in error.

# Other information:

Not tested end to end; the change is a one-line mapping switch to an existing error type.

# QA

1. [ ] Connect an Instagram channel
2. [ ] Stub the Instagram media-container endpoint to return error subcode 2207052 on the first call only
3. [ ] Publish an image post - logs show one retry, the post publishes, and exactly one post appears on Instagram with no duplicate
4. [ ] Change the stub to return 2207052 every time - after three attempts the post moves to ERROR with "Media fetch failed, please try again"
5. [ ] Remove the stub and publish an image post normally to confirm the happy path is unaffected
6. [ ] Check the Instagram account after step 4 to confirm nothing was published

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
