### PR TITLE
feat(orchestrator): route Temporal SDK logs through console for Sentry

### DIFF
--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -8,7 +8,37 @@ dayjs.extend(utc);
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from '@gitroom/orchestrator/app.module';
 import * as dns from 'node:dns';
+import { DefaultLogger, Runtime } from '@temporalio/worker';
+import { format } from 'node:util';
 dns.setDefaultResultOrder('ipv4first');
+
+// The Temporal SDK writes its own logs (TS side straight to stderr, native
+// core straight to the console), so Sentry's console integration never sees
+// them - route both through console, in the SDK's own line format, so they
+// are shipped along with app logs.
+Runtime.install({
+  logger: new DefaultLogger(
+    'INFO',
+    ({ level, timestampNanos, message, meta }) => {
+      const date = new Date(Number(timestampNanos / BigInt(1000000)));
+      const line =
+        meta === undefined
+          ? `${format(date)} [${level}] ${message}`
+          : `${format(date)} [${level}] ${message} ${format(meta)}`;
+      if (level === 'ERROR' || level === 'WARN') {
+        console.error(line);
+      } else {
+        console.log(line);
+      }
+    }
+  ),
+  telemetryOptions: {
+    logging: {
+      filter: { core: 'WARN', other: 'ERROR' },
+      forward: {},
+    },
+  },
+});
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
# What kind of change does this PR introduce?

Observability improvement (orchestrator logging). Installs the Temporal `Runtime` once in `apps/orchestrator/src/main.ts`, before Nest creates any worker, with a `DefaultLogger('INFO')` that prints the SDK's own line format through `console.error` (WARN/ERROR) or `console.log`, plus `telemetryOptions.logging` with the SDK default filter and `forward: {}` so native core logs take the same path. This lets Sentry's console integration capture Temporal SDK lines, which previously existed only in the Railway container logs. Levels and content are unchanged.

# Why was this change needed?

The Temporal SDK's own log lines are the most useful signal when debugging a stuck or failed post workflow: `[WARN] Activity failed {workflowId, activityType, taskQueue, error, durationMs}` from the TS side, and `Activity not found on completion` / `Task not found when completing` from the native core. Neither goes through `console`, so Sentry's console logging integration (`initializeSentry`) never captures them; today they exist only in the Railway container logs.

Railway is the live production environment with no read-only access, so investigating a customer report means pulling raw container logs by hand. Sentry Logs already hold every `console.*` line from backend and orchestrator and are queryable read-only (also through the Sentry MCP), so the goal is to have the Temporal SDK lines land there as well.

This installs the Temporal Runtime once in `apps/orchestrator/src/main.ts`, before Nest creates any worker, with:
- a `DefaultLogger('INFO')` whose log function prints the SDK's own line format (`<ISO ts> [LEVEL] message {meta}`, built with `util.format` exactly like the SDK's default function) via `console.error` for WARN/ERROR and `console.log` otherwise;
- `telemetryOptions.logging` with the SDK's default filter (`core: WARN, other: ERROR`) and `forward: {}` so native core logs go through the same logger.

Levels and content are unchanged: the SDK default logger is INFO, and the native filter is the SDK default, so Railway sees the same set of lines as before. Only the native core lines change shape, from the Rust free-text format to the SDK's structured `{ sdkComponent: 'core', target, ... }` meta, since that is how the SDK forwards them.

# Other information:

Verified locally against the current `origin/main` build by running both builds against a local Temporal and provoking the same failure (starting an unregistered workflow type):
- TS-side lines (`[INFO] Worker state changed ...`, `[ERROR] Failed to process Workflow Activation {...}`) are byte-identical apart from timestamps/run ids.
- The native `Failing workflow task` warning is now emitted as `[WARN] Failing workflow task { sdkComponent: 'core', target: 'temporalio_sdk_core::worker::workflow', runId, failure }` with the same content.
- Because forwarding buffers SDK log lines for ~100 ms for ordering (per the SDK docs), Temporal lines can appear slightly after neighbouring app log lines in the raw stream; the SDK timestamp is kept in the line for that reason.

Not covered by this change: process-level events (OOM, SIGKILL, container restarts) never pass through the process's own logging and remain visible only on the platform side.

# QA

1. [ ] Start a local Temporal server (`temporal server start-dev`) and the stack (`pnpm run dev:docker`, then `pnpm run dev`), or just the orchestrator with `pnpm run dev:orchestrator`.
2. [ ] Watch the orchestrator's stdout as it boots. Expected: Temporal SDK lines now appear in the process output in the SDK's own format, e.g. `<ISO timestamp> [INFO] Worker state changed { state: 'RUNNING', ... }`, printed through `console.log` (INFO/DEBUG) rather than straight to stderr.
3. [ ] Provoke a workflow failure: `temporal workflow start --type DoesNotExist --task-queue main --workflow-id qa-temporal-logs`.
4. [ ] Expected in the orchestrator output: `<ISO timestamp> [ERROR] Failed to process Workflow Activation { ... }` via `console.error`, and the native core line as `<ISO timestamp> [WARN] Failing workflow task { sdkComponent: 'core', target: 'temporalio_sdk_core::worker::workflow', runId, failure }` - same content as before, now in the SDK's structured meta shape instead of the Rust free-text format.
5. [ ] Compare against `origin/main`: check out main, restart the orchestrator, repeat step 3. Expected: the same set of lines with the same levels - only the native core lines change shape, nothing is added or silenced.
6. [ ] With `NEXT_PUBLIC_SENTRY_DSN` set, repeat step 3 and open Sentry Logs for the orchestrator, searching for `Failing workflow task`. Expected: the Temporal lines are now present there. On `origin/main` the same search returns nothing, because the SDK never wrote them to `console`.
7. [ ] Regression: schedule and publish a normal post end to end. Expected: the workflow completes, the post publishes, and the app's own log lines are unchanged. Note that forwarded SDK lines may appear up to ~100 ms after neighbouring app lines (the SDK buffers for ordering), which is why the SDK timestamp is kept in the line itself.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
