### PR TITLE
fix(pinterest): retry transient 'Something went wrong on our end' errors

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -121,6 +121,13 @@ export class PinterestProvider
         value: 'You can upload a maximum of 5 images per post on Pinterest.',
       };
     }
+    if (body.indexOf('Something went wrong on our end') > -1) {
+      return {
+        type: 'retry' as const,
+        value:
+          'Pinterest reported a temporary error on their side. Please try posting again.',
+      };
+    }
     if (body.indexOf('Unable to reach the URL') > -1) {
       return {
         type: 'retry' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Pinterest provider error mapping). Adds a `Something went wrong on our end` branch to `PinterestProvider.handleErrors` returning `type: 'retry'`, so `SocialAbstract.fetch` retries the call up to three times roughly five seconds apart before falling through to a `BadBody`. Pinterest returns this body for transient failures on their side, which previously fell through `handleErrors` and failed the post on the first hit as "Unknown Error". The retry budget is the existing one in `SocialAbstract.fetch` - no new retry mechanism is introduced, and the existing `bad-body` branches are unchanged.

# Why was this change needed?

Pinterest's `POST /v5/pins` intermittently answers with `{"code":2787,"message":"Sorry! Something went wrong on our end."}`. This is a transient error on Pinterest's side: identical pins (same board, link, image) go through minutes before and after. Between Aug 12 and Aug 14 we saw a spike of these across many accounts, and two customers reported it.

The response was unmapped in `PinterestProvider.handleErrors`, so `fetch` threw a non-retryable `BadBody` with the `Unknown Error` placeholder on the first attempt: the post failed for good and the customer only saw "An error occurred while posting on pinterest: Unknown Error".

This maps the message to `type: 'retry'`, so the existing retry path in `social.abstract.ts` re-attempts up to 3 times (5s apart). If it still fails, the curated message ("Pinterest reported a temporary error on their side. Please try posting again.") is carried into the `BadBody`, so once #1868 lands it is surfaced in the calendar tooltip instead of the generic text.

# Other information:

Same shape as the existing "Unable to reach the URL" retry mapping in the same provider. Not exercised end to end against Pinterest (the error is not reproducible on demand); the retry and message plumbing are the existing paths already used by that mapping.

# QA

1. [ ] Connect a Pinterest channel and select a board
2. [ ] Put a proxy or stub in front of the Pinterest pins endpoint so it returns a body containing "Something went wrong on our end"
3. [ ] Publish a pin - backend logs show three attempts roughly five seconds apart before the post fails
4. [ ] Change the stub so it returns the error only on the first call - the pin publishes on the retry and exactly one pin appears on the board
5. [ ] Remove the stub and publish a pin normally to confirm the happy path is unaffected
6. [ ] Confirm a "Board not found" error still fails immediately rather than retrying

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
