### PR TITLE
fix(facebook): map page-permission (code 190) errors to a curated message

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -81,6 +81,14 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       };
     }
 
+    if (body.indexOf("before impersonating a user's page") > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          'Facebook rejected the post because your account is missing permissions on this Page. Make sure your Facebook account has full content access to the Page, then reconnect the channel.',
+      };
+    }
+
     if (body.indexOf('1366046') > -1) {
       return {
         type: 'bad-body' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix / UX improvement

# Why was this change needed?

A customer with several Facebook Pages had posts failing on some pages only, every time, with this Graph API response:

```
{"error":{"message":"Any of the pages_read_engagement, pages_manage_metadata, pages_read_user_content, pages_manage_ads, pages_show_list or pages_messaging permission(s) must be granted before impersonating a user's page.","type":"OAuthException","code":190}}
```

Although it carries code 190, this is a page-permission problem (the connected Facebook user lacks adequate access on that specific Page), not an expired/invalid token: sibling pages under the same account publish fine, and the customer had already reconnected without effect. `FacebookProvider.handleErrors` only recognizes the token-validation 190 variants (`Error validating access token`, `REVOKED_ACCESS_TOKEN`), so this body fell through to the `Unknown Error` placeholder — the failure email said nothing useful and the customer could not self-serve.

This adds a curated `bad-body` mapping on the distinctive `before impersonating a user's page` phrase:

> Facebook rejected the post because your account is missing permissions on this Page. Make sure your Facebook account has full content access to the Page, then reconnect the channel.

`bad-body` (non-retryable) rather than `refresh-token`, because reconnecting alone does not fix it and flagging the channel as needing re-auth would be misleading. Placed before the existing bare `'490'` substring check so it takes precedence.

Companion to #1892, which maps the sibling `(#200)` permission error; together with #1868 (curated calendar tooltips) the user sees the actionable message directly on the failed post.

Reference on this error string: https://docs.contentstudio.io/article/688-facebook-errors (same message, attributed to missing page administration access).

# Other information:

Verified against production data: on the affected pages 100% of attempts carried this exact body (dozens of occurrences across three pages, continuing after a fresh reconnect), while the customer's other pages published normally.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)