### PR TITLE
fix(youtube): map 403 forbidden upload errors to a curated message

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -239,6 +239,14 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
       };
     }
 
+    if (body.includes('"forbidden"')) {
+      return {
+        type: 'bad-body',
+        value:
+          'YouTube refused the upload for this channel. Make sure the Google account you connected with can upload to this channel, then reconnect it.',
+      };
+    }
+
     if (body.includes('Unauthorized')) {
       return {
         type: 'refresh-token',


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, YouTube provider error mapping). Adds a `body.includes('"forbidden"')` branch to `YoutubeProvider.handleErrors`, placed above the existing `Unauthorized` branch, returning `type: 'bad-body'` with a message telling the user the connected Google account cannot upload to that channel and that they should reconnect. Previously these 403s fell through to `undefined` and reached the user as "Unknown Error". The `refresh-token` branches for `Unauthorized`, `UNAUTHENTICATED` and `invalid_grant` are deliberately left as they were.

# Why was this change needed?

A customer with five connected YouTube channels had one channel failing on every upload (7/7 attempts since it was connected) while the other four published normally. The API response on the video insert was:

```
{"error":{"code":403,"message":"Access forbidden. The request may not be properly authorized.","errors":[{"message":"Access forbidden. The request may not be properly authorized.","domain":"youtube.common","reason":"forbidden"}]}}
```

`YoutubeProvider.handleErrors` has no mapping for the `forbidden` reason, so this fell through to the `Unknown Error` placeholder — the failure email told the user nothing and they could not self-serve. The sibling-channels-work pattern points to the connected Google account not being allowed to upload to that particular channel (e.g. a brand channel where the account is not an owner/manager), which the user has to fix on Google's side and then reconnect.

This adds a curated `bad-body` mapping, matched on the quoted `"forbidden"` reason token (so the plain word inside another message cannot trigger it):

> YouTube refused the upload for this channel. Make sure the Google account you connected with can upload to this channel, then reconnect it.

`bad-body` (non-retryable) rather than `refresh-token`: the token is valid (other channels under it work), and a reconnect alone does not fix a missing channel permission, so flagging the channel as needing re-auth would be misleading. Placed before the existing `Unauthorized`/`UNAUTHENTICATED` token checks.

Companion to #1892 / #1912 (Facebook permission mappings); with #1868 the message shows on the failed post in the calendar too.

# Other information:

Verified against production data: the affected channel had this exact 403 body on 100% of its attempts while the same account's other channels published fine.

# QA

1. [ ] Connect a YouTube channel using a Google account that has no upload rights on it, for example a brand account where the user is only a viewer
2. [ ] Schedule a video post to that channel and let it publish
3. [ ] The post moves to ERROR and the notification names the upload-permission problem and tells the user to reconnect - not "Unknown Error"
4. [ ] Connect a properly permissioned account and publish a video to confirm the new branch does not fire on the happy path
5. [ ] Revoke Postiz access from Google account settings, then publish again - the post still routes to the reconnect / refresh-token flow rather than the new branch

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
