### PR TITLE
fix(instagram): map missing instagram_content_publish permission to a curated message

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -307,6 +307,14 @@ export class InstagramProvider
       };
     }
 
+    if (body.indexOf('Requires instagram_content_publish permission') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          'Instagram rejected the post because Postiz was not granted publishing permission for this account. Reconnect the channel and allow all requested permissions, including content publishing, for this Instagram account.',
+      };
+    }
+
     if (body.indexOf('Not enough permissions to post') > -1) {
       return {
         type: 'bad-body' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Instagram provider error mapping). Adds a `Requires instagram_content_publish permission` branch to `InstagramProvider.handleErrors`, above the existing "Not enough permissions to post" branch, returning `type: 'bad-body'` with a message telling the user Postiz was not granted publishing permission for that account and to reconnect accepting all permissions. Previously this error fell through and surfaced as "Unknown Error". No existing branch, message or classification changes.

# Why was this change needed?

While going through unmapped Instagram publish failures in production, this Graph API response showed up on the Instagram (Facebook-login) provider (5 occurrences since 2026-07-01):

```
{"error":{"message":"(#10) Requires instagram_content_publish permission to manage the object","type":"OAuthException","code":10}}
```

It means the connected user did not grant Postiz the `instagram_content_publish` permission for that specific Instagram account (Meta lets users trim per-account permissions in the OAuth dialog and later under Settings > Business integrations). `InstagramProvider.handleErrors` only matches the subcode-`2207081` variant of code 10 (Trial Reels) and the literal `Not enough permissions to post`, so this body fell through to the `Unknown Error` placeholder — the failure email said nothing actionable.

This adds a curated `bad-body` mapping on `Requires instagram_content_publish permission`:

> Instagram rejected the post because Postiz was not granted publishing permission for this account. Reconnect the channel and allow all requested permissions, including content publishing, for this Instagram account.

Non-retryable (`bad-body`): retrying cannot help; the user has to re-grant the permission. Placed before the generic `'190,'` rule. `instagram-standalone` delegates to the same `handleErrors`, so it is covered too.

The far more frequent bare `(#10) Application does not have permission for this action` (no subcode, ~40 occurrences in the same window) is deliberately left unmapped here: its causes are heterogeneous (account type, broken IG↔Page link, missing grant) and not documented by Meta, so a single instruction would be wrong for many users.

Companion to #1892 / #1912 / #1913 (Facebook and YouTube permission mappings); with #1868 the message also shows on the failed post in the calendar.

# Other information:

Not tested end to end; the change is a string match in `handleErrors` following the existing pattern, and the matched string is taken verbatim from the production error bodies.

# QA

1. [ ] Start connecting an Instagram channel and, on the Meta consent screen, deny the content-publishing permission
2. [ ] Finish the connect flow so the channel appears in Postiz
3. [ ] Schedule an image post to that channel and let it publish
4. [ ] The post moves to ERROR and the notification names the missing publishing permission and tells the user to reconnect - not "Unknown Error"
5. [ ] Reconnect the same channel accepting all permissions and publish again - the post succeeds
6. [ ] Confirm the "Not enough permissions to post" case still produces its own original message

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
