### PR TITLE
feat: create additional organizations + rename organization

### DIFF
--- a/apps/backend/src/api/routes/settings.controller.ts
+++ b/apps/backend/src/api/routes/settings.controller.ts
@@ -14,6 +14,7 @@ import { CheckPolicies } from '@gitroom/backend/services/auth/permissions/permis
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { AddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/add.team.member.dto';
 import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/admin.add.team.member.dto';
+import { OrganizationNameDto } from '@gitroom/nestjs-libraries/dtos/settings/organization-name.dto';
 import { ShortlinkPreferenceDto } from '@gitroom/nestjs-libraries/dtos/settings/shortlink-preference.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthorizationActions, Sections } from '@gitroom/backend/services/auth/permissions/permission.exception.class';
@@ -87,5 +88,19 @@ export class SettingsController {
       org.id,
       body.shortlink
     );
+  }
+
+  @Get('/organization-name')
+  async getOrganizationName(@GetOrgFromRequest() org: Organization) {
+    return this._organizationService.getOrganizationName(org.id);
+  }
+
+  @Post('/organization-name')
+  @CheckPolicies([AuthorizationActions.Create, Sections.ADMIN])
+  async updateOrganizationName(
+    @GetOrgFromRequest() org: Organization,
+    @Body() body: OrganizationNameDto
+  ) {
+    return this._organizationService.updateOrganizationName(org.id, body.name);
   }
 }

--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -23,6 +23,7 @@ import { getCookieUrlFromDomain } from '@gitroom/helpers/subdomain/subdomain.man
 import { pricing } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/pricing';
 import { ApiTags } from '@nestjs/swagger';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
+import { CreateOrganizationDto } from '@gitroom/nestjs-libraries/dtos/organizations/create.organization.dto';
 import { UserDetailDto } from '@gitroom/nestjs-libraries/dtos/users/user.details.dto';
 import { EmailNotificationsDto } from '@gitroom/nestjs-libraries/dtos/users/email-notifications.dto';
 import { HttpForbiddenException } from '@gitroom/nestjs-libraries/services/exception.filter';
@@ -302,6 +303,14 @@ export class UsersController {
     return (await this._orgService.getOrgsByUserId(user.id)).filter(
       (f) => !f.users[0].disabled
     );
+  }
+
+  @Post('/organizations')
+  createOrg(
+    @GetUserFromRequest() user: User,
+    @Body() body: CreateOrganizationDto
+  ) {
+    return this._orgService.createOrgForUser(user.id, body);
   }
 
   @Post('/change-org')

--- a/apps/frontend/src/components/layout/check.payment.tsx
+++ b/apps/frontend/src/components/layout/check.payment.tsx
@@ -4,6 +4,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { useToaster } from '@gitroom/react/toaster/toaster';
 import { useDecisionModal } from '@gitroom/frontend/components/layout/new-modal';
+import { usePathname, useRouter } from 'next/navigation';
 export const CheckPayment: FC<{
   check: string;
   mutate: () => void;
@@ -24,6 +25,8 @@ export const CheckPaymentInner: FC<{
   const fetch = useFetch();
   const toaster = useToaster();
   const modal = useDecisionModal();
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (showLoader) {
@@ -60,6 +63,7 @@ export const CheckPaymentInner: FC<{
     if (status === 2) {
       setShowLoader(false);
       props.mutate();
+      router.replace(pathname);
     }
   }, []);
   useEffect(() => {

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -18,18 +18,22 @@ export const CreateOrganization = () => {
   const [loading, setLoading] = useState(false);
   const create = useCallback(async () => {
     setLoading(true);
-    const { id } = await (
-      await fetch('/user/organizations', {
+    try {
+      const { id } = await (
+        await fetch('/user/organizations', {
+          method: 'POST',
+          body: JSON.stringify({ name }),
+        })
+      ).json();
+      await fetch('/user/change-org', {
         method: 'POST',
-        body: JSON.stringify({ name }),
-      })
-    ).json();
-    await fetch('/user/change-org', {
-      method: 'POST',
-      body: JSON.stringify({ id }),
-    });
-    modals.closeAll();
-    window.location.reload();
+        body: JSON.stringify({ id }),
+      });
+      modals.closeAll();
+      window.location.reload();
+    } finally {
+      setLoading(false);
+    }
   }, [name]);
   return (
     <div className="relative flex gap-[10px] flex-col flex-1 p-[16px] pt-0">

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -1,13 +1,58 @@
 'use client';
 
-import React, { FC, useCallback, useMemo } from 'react';
+import React, { FC, useCallback, useMemo, useState } from 'react';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import useSWR from 'swr';
 import { useUser } from '@gitroom/frontend/components/layout/user.context';
 import clsx from 'clsx';
+import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+import { Input } from '@gitroom/react/form/input';
+import { Button } from '@gitroom/react/form/button';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+
+export const CreateOrganization = () => {
+  const t = useT();
+  const fetch = useFetch();
+  const modals = useModals();
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const create = useCallback(async () => {
+    setLoading(true);
+    const { id } = await (
+      await fetch('/user/organizations', {
+        method: 'POST',
+        body: JSON.stringify({ name }),
+      })
+    ).json();
+    await fetch('/user/change-org', {
+      method: 'POST',
+      body: JSON.stringify({ id }),
+    });
+    modals.closeAll();
+    window.location.reload();
+  }, [name]);
+  return (
+    <div className="relative flex gap-[10px] flex-col flex-1 p-[16px] pt-0">
+      <Input
+        value={name}
+        disableForm={true}
+        removeError={true}
+        onChange={(e) => setName(e.target.value)}
+        name="name"
+        label={t('organization_name', 'Organization name')}
+        placeholder={t('organization_name', 'Organization name')}
+      />
+      <Button type="button" className="mt-[18px]" onClick={create} disabled={loading}>
+        {t('create', 'Create')}
+      </Button>
+    </div>
+  );
+};
 export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
   asOpenSelect,
 }) => {
+  const t = useT();
+  const modals = useModals();
   const fetch = useFetch();
   const user = useUser();
   const load = useCallback(async () => {
@@ -38,7 +83,17 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
     },
     []
   );
-  if (isLoading || (!isLoading && data?.length === 1)) {
+  const createOrg = useCallback(() => {
+    modals.openModal({
+      classNames: {
+        modal: 'bg-transparent text-textColor',
+      },
+      title: t('create_new_organization', 'Create New Organization'),
+      withCloseButton: true,
+      children: <CreateOrganization />,
+    });
+  }, [t]);
+  if (isLoading) {
     return null;
   }
   return (
@@ -68,7 +123,7 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
               )}
             </div>
           )}
-          {data?.length > 1 && (
+          {(data?.length > 1 || !asOpenSelect) && (
             <div
               className={clsx(
                 'hidden py-[12px] px-[12px] group-hover:flex absolute top-[100%] end-0 w-max max-w-[400px] bg-third border-tableBorder border gap-[12px] cursor-pointer flex-col',
@@ -101,6 +156,11 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
                     )}
                   </div>
                 )
+              )}
+              {!asOpenSelect && (
+                <div onClick={createOrg} className="whitespace-nowrap">
+                  {t('create_new_organization', 'Create New Organization')} +
+                </div>
               )}
             </div>
           )}

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -9,11 +9,13 @@ import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 import { Input } from '@gitroom/react/form/input';
 import { Button } from '@gitroom/react/form/button';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useToaster } from '@gitroom/react/toaster/toaster';
 
 export const CreateOrganization = () => {
   const t = useT();
   const fetch = useFetch();
   const modals = useModals();
+  const toaster = useToaster();
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
   const create = useCallback(async () => {
@@ -25,6 +27,13 @@ export const CreateOrganization = () => {
           body: JSON.stringify({ name }),
         })
       ).json();
+      if (!id) {
+        toaster.show(
+          t('could_not_create_organization', 'Could not create organization'),
+          'warning'
+        );
+        return;
+      }
       await fetch('/user/change-org', {
         method: 'POST',
         body: JSON.stringify({ id }),

--- a/apps/frontend/src/components/settings/global.settings.tsx
+++ b/apps/frontend/src/components/settings/global.settings.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import dynamic from 'next/dynamic';
+import OrganizationNameComponent from '@gitroom/frontend/components/settings/organization-name.component';
 import EmailNotificationsComponent from '@gitroom/frontend/components/settings/email-notifications.component';
 import ShortlinkPreferenceComponent from '@gitroom/frontend/components/settings/shortlink-preference.component';
 import DeleteAccountComponent from '@gitroom/frontend/components/settings/delete-account.component';
@@ -19,6 +20,7 @@ export const GlobalSettings = () => {
   return (
     <div className="flex flex-col">
       <h3 className="text-[20px]">{t('global_settings', 'Global Settings')}</h3>
+      <OrganizationNameComponent />
       <MetricComponent />
       <EmailNotificationsComponent />
       <ShortlinkPreferenceComponent />

--- a/apps/frontend/src/components/settings/organization-name.component.tsx
+++ b/apps/frontend/src/components/settings/organization-name.component.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import useSWR, { useSWRConfig } from 'swr';
+import { Input } from '@gitroom/react/form/input';
+import { Button } from '@gitroom/react/form/button';
+import { useToaster } from '@gitroom/react/toaster/toaster';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useUser } from '@gitroom/frontend/components/layout/user.context';
+
+export const useOrganizationName = () => {
+  const fetch = useFetch();
+
+  const load = useCallback(async () => {
+    return (await fetch('/settings/organization-name')).json();
+  }, []);
+
+  return useSWR<{ name: string }>('organization-name', load, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+    revalidateOnMount: true,
+    refreshWhenHidden: false,
+    refreshWhenOffline: false,
+  });
+};
+
+const OrganizationNameComponent = () => {
+  const t = useT();
+  const fetch = useFetch();
+  const toaster = useToaster();
+  const user = useUser();
+  const { mutate: globalMutate } = useSWRConfig();
+  const { data, isLoading, mutate } = useOrganizationName();
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    setName(data?.name || '');
+  }, [data]);
+
+  const save = useCallback(async () => {
+    await fetch('/settings/organization-name', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+    mutate({ name });
+    globalMutate('organizations');
+    toaster.show(t('settings_updated', 'Settings updated'), 'success');
+  }, [name, mutate, toaster, t]);
+
+  if (isLoading || user?.role === 'USER') {
+    return null;
+  }
+
+  return (
+    <div className="my-[16px] mt-[16px] bg-sixth border-fifth border rounded-[4px] p-[24px] flex flex-col gap-[24px]">
+      <div className="mt-[4px]">
+        {t('organization_settings', 'Organization Settings')}
+      </div>
+      <div className="flex items-center gap-[24px]">
+        <div className="flex flex-col flex-1">
+          <div className="text-[14px]">
+            {t('organization_name', 'Organization name')}
+          </div>
+          <div className="text-[12px] text-customColor18">
+            {t(
+              'organization_name_description',
+              'The name shown in the organization switcher.'
+            )}
+          </div>
+        </div>
+        <Input
+          value={name}
+          disableForm={true}
+          removeError={true}
+          onChange={(e) => setName(e.target.value)}
+          name="name"
+          label=""
+        />
+        <Button className="h-[44px] mt-[7px]" disabled={!name.trim()} onClick={save}>
+          {t('save', 'Save')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OrganizationNameComponent;

--- a/apps/frontend/src/components/settings/organization-name.component.tsx
+++ b/apps/frontend/src/components/settings/organization-name.component.tsx
@@ -40,10 +40,17 @@ const OrganizationNameComponent = () => {
   }, [data]);
 
   const save = useCallback(async () => {
-    await fetch('/settings/organization-name', {
+    const response = await fetch('/settings/organization-name', {
       method: 'POST',
       body: JSON.stringify({ name }),
     });
+    if (!response.ok) {
+      toaster.show(
+        t('could_not_update_organization_name', 'Could not update organization name'),
+        'warning'
+      );
+      return;
+    }
     mutate({ name });
     globalMutate('organizations');
     toaster.show(t('settings_updated', 'Settings updated'), 'success');

--- a/i18n.lock
+++ b/i18n.lock
@@ -579,6 +579,7 @@ checksums:
     email_address: 0ee22bbbe989a0c61a18023407d12dc2
     email_already_exists: ad25f0ca7a16c0d37e566a9c090a0fd2
     google: 6cc462fb53d90d404f48d5a6695c1de1
+    apple: 4e2ced07ca66bd1cf0562882d019aff2
     farcaster: b09af25fcb497663e8594b9fc514b969
     edit_autopost: 2cde36144cddda0acc069e6913e095f9
     add_autopost_title: d018d5d12c9f41c0b610da4b101d77e9
@@ -742,3 +743,8 @@ checksums:
     post_already_published_republish_warning: b552a207c31d6381fb831da005dac9ed
     republish_at: 282cf74a2c63ff46388104f9853bfaf8
     republish_recurring_note: e0eafbc730f5e8d5f9f5cb5aab48fe2d
+    create: 757ccd28dd533ff3a933355273c1e32a
+    create_new_organization: 66a3ebeea4f71c289e0c378459d2516e
+    organization_settings: d31952131ad5f0ec72ad96f1ed11bef6
+    organization_name: e69fb0acbe75358352890a6f04e4b9c0
+    organization_name_description: fc0874a90542efd411fe73f8fa552ebb

--- a/i18n.lock
+++ b/i18n.lock
@@ -748,3 +748,4 @@ checksums:
     organization_settings: d31952131ad5f0ec72ad96f1ed11bef6
     organization_name: e69fb0acbe75358352890a6f04e4b9c0
     organization_name_description: fc0874a90542efd411fe73f8fa552ebb
+    could_not_create_organization: 632bfcc6464390bc3e8eae128e54444f

--- a/i18n.lock
+++ b/i18n.lock
@@ -749,3 +749,4 @@ checksums:
     organization_name: e69fb0acbe75358352890a6f04e4b9c0
     organization_name_description: fc0874a90542efd411fe73f8fa552ebb
     could_not_create_organization: 632bfcc6464390bc3e8eae128e54444f
+    could_not_update_organization_name: c0c3a9387e7e418f09946de3a436c6db

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -449,4 +449,46 @@ export class OrganizationRepository {
       },
     });
   }
+
+  createOrgForUser(userId: string, name: string) {
+    return this._organization.model.organization.create({
+      data: {
+        name,
+        apiKey: AuthService.fixedEncryption(makeId(20)),
+        allowTrial: false,
+        isTrailing: false,
+        users: {
+          create: {
+            role: Role.SUPERADMIN,
+            userId,
+          },
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+  }
+
+  getOrganizationName(orgId: string) {
+    return this._organization.model.organization.findUnique({
+      where: {
+        id: orgId,
+      },
+      select: {
+        name: true,
+      },
+    });
+  }
+
+  updateOrganizationName(orgId: string, name: string) {
+    return this._organization.model.organization.update({
+      where: {
+        id: orgId,
+      },
+      data: {
+        name,
+      },
+    });
+  }
 }

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
@@ -7,6 +7,7 @@ import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/a
 import { pricing } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/pricing';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import dayjs from 'dayjs';
+import { CreateOrganizationDto } from '@gitroom/nestjs-libraries/dtos/organizations/create.organization.dto';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { Organization, ShortLinkPreference, User } from '@prisma/client';
 import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
@@ -190,5 +191,20 @@ export class OrganizationService {
       orgId,
       shortlink
     );
+  }
+
+  createOrgForUser(userId: string, body: CreateOrganizationDto) {
+    return this._organizationRepository.createOrgForUser(
+      userId,
+      body.name?.trim() || 'My Organization'
+    );
+  }
+
+  getOrganizationName(orgId: string) {
+    return this._organizationRepository.getOrganizationName(orgId);
+  }
+
+  updateOrganizationName(orgId: string, name: string) {
+    return this._organizationRepository.updateOrganizationName(orgId, name);
   }
 }

--- a/libraries/nestjs-libraries/src/dtos/organizations/create.organization.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/organizations/create.organization.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateOrganizationDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  name?: string;
+}

--- a/libraries/nestjs-libraries/src/dtos/settings/organization-name.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/settings/organization-name.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class OrganizationNameDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name: string;
+}

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "إعدادات المنظمة",
   "organization_name": "اسم المنظمة",
   "organization_name_description": "الاسم المعروض في مُبدّل المنظمات.",
-  "could_not_create_organization": "تعذّر إنشاء المؤسسة"
+  "could_not_create_organization": "تعذّر إنشاء المؤسسة",
+  "could_not_update_organization_name": "تعذر تحديث اسم المؤسسة"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "إنشاء منظمة جديدة",
   "organization_settings": "إعدادات المنظمة",
   "organization_name": "اسم المنظمة",
-  "organization_name_description": "الاسم المعروض في مُبدّل المنظمات."
+  "organization_name_description": "الاسم المعروض في مُبدّل المنظمات.",
+  "could_not_create_organization": "تعذّر إنشاء المؤسسة"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -575,6 +575,7 @@
   "email_address": "عنوان البريد الإلكتروني",
   "email_already_exists": "البريد الإلكتروني موجود بالفعل",
   "google": "جوجل",
+  "apple": "تفاحة",
   "farcaster": "فاركاستر",
   "edit_autopost": "تعديل النشر التلقائي",
   "add_autopost_title": "إضافة نشر تلقائي",
@@ -737,5 +738,10 @@
   "republish_the_post": "إعادة نشر المنشور",
   "post_already_published_republish_warning": "تم نشر هذا المنشور بالفعل. إعادة النشر ستقوم بنشره مرة أخرى على",
   "republish_at": "في",
-  "republish_recurring_note": "هذا منشور متكرر: ستنطبق تغييراتك على جميع التكرارات المستقبلية بدءًا من الآن."
+  "republish_recurring_note": "هذا منشور متكرر: ستنطبق تغييراتك على جميع التكرارات المستقبلية بدءًا من الآن.",
+  "create": "إنشاء",
+  "create_new_organization": "إنشاء منظمة جديدة",
+  "organization_settings": "إعدادات المنظمة",
+  "organization_name": "اسم المنظمة",
+  "organization_name_description": "الاسم المعروض في مُبدّل المنظمات."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "সংস্থার সেটিংস",
   "organization_name": "সংস্থার নাম",
   "organization_name_description": "সংস্থা সুইচারে প্রদর্শিত নাম।",
-  "could_not_create_organization": "সংস্থা তৈরি করা যায়নি"
+  "could_not_create_organization": "সংস্থা তৈরি করা যায়নি",
+  "could_not_update_organization_name": "সংস্থার নাম আপডেট করা যায়নি"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -575,6 +575,7 @@
   "email_address": "ইমেইল ঠিকানা",
   "email_already_exists": "ইমেইল ইতিমধ্যে বিদ্যমান",
   "google": "গুগল",
+  "apple": "আপেল",
   "farcaster": "ফারকাস্টার",
   "edit_autopost": "অটোপোস্ট সম্পাদনা করুন",
   "add_autopost_title": "অটোপোস্ট যোগ করুন",
@@ -737,5 +738,10 @@
   "republish_the_post": "পোস্টটি পুনঃপ্রকাশ করুন",
   "post_already_published_republish_warning": "এই পোস্টটি ইতিমধ্যে প্রকাশিত হয়েছে। পুনঃপ্রকাশ করলে এটি আবার প্রকাশিত হবে",
   "republish_at": "সময়",
-  "republish_recurring_note": "এটি একটি পুনরাবৃত্তিমূলক পোস্ট: আপনার পরিবর্তনসমূহ এখন থেকে শুরু করে সকল ভবিষ্যৎ পুনরাবৃত্তিতে প্রয়োগ হবে।"
+  "republish_recurring_note": "এটি একটি পুনরাবৃত্তিমূলক পোস্ট: আপনার পরিবর্তনসমূহ এখন থেকে শুরু করে সকল ভবিষ্যৎ পুনরাবৃত্তিতে প্রয়োগ হবে।",
+  "create": "তৈরি করুন",
+  "create_new_organization": "নতুন সংস্থা তৈরি করুন",
+  "organization_settings": "সংস্থার সেটিংস",
+  "organization_name": "সংস্থার নাম",
+  "organization_name_description": "সংস্থা সুইচারে প্রদর্শিত নাম।"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "নতুন সংস্থা তৈরি করুন",
   "organization_settings": "সংস্থার সেটিংস",
   "organization_name": "সংস্থার নাম",
-  "organization_name_description": "সংস্থা সুইচারে প্রদর্শিত নাম।"
+  "organization_name_description": "সংস্থা সুইচারে প্রদর্শিত নাম।",
+  "could_not_create_organization": "সংস্থা তৈরি করা যায়নি"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -575,6 +575,7 @@
   "email_address": "E-Mail-Adresse",
   "email_already_exists": "E-Mail existiert bereits",
   "google": "Google",
+  "apple": "Apfel",
   "farcaster": "Farcaster",
   "edit_autopost": "Autopost bearbeiten",
   "add_autopost_title": "Autopost hinzufügen",
@@ -737,5 +738,10 @@
   "republish_the_post": "Beitrag erneut veröffentlichen",
   "post_already_published_republish_warning": "Dieser Beitrag wurde bereits veröffentlicht. Durch erneutes Veröffentlichen wird er erneut veröffentlicht auf",
   "republish_at": "um",
-  "republish_recurring_note": "Dies ist ein wiederkehrender Beitrag: Ihre Änderungen gelten ab jetzt für alle zukünftigen Wiederholungen."
+  "republish_recurring_note": "Dies ist ein wiederkehrender Beitrag: Ihre Änderungen gelten ab jetzt für alle zukünftigen Wiederholungen.",
+  "create": "Erstellen",
+  "create_new_organization": "Neue Organisation erstellen",
+  "organization_settings": "Organisationseinstellungen",
+  "organization_name": "Organisationsname",
+  "organization_name_description": "Der Name, der im Organisationsumschalter angezeigt wird."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Organisationseinstellungen",
   "organization_name": "Organisationsname",
   "organization_name_description": "Der Name, der im Organisationsumschalter angezeigt wird.",
-  "could_not_create_organization": "Organisation konnte nicht erstellt werden"
+  "could_not_create_organization": "Organisation konnte nicht erstellt werden",
+  "could_not_update_organization_name": "Organisationsname konnte nicht aktualisiert werden"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Neue Organisation erstellen",
   "organization_settings": "Organisationseinstellungen",
   "organization_name": "Organisationsname",
-  "organization_name_description": "Der Name, der im Organisationsumschalter angezeigt wird."
+  "organization_name_description": "Der Name, der im Organisationsumschalter angezeigt wird.",
+  "could_not_create_organization": "Organisation konnte nicht erstellt werden"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -740,5 +740,10 @@
   "republish_the_post": "Republish the post",
   "post_already_published_republish_warning": "This post was already published. Republishing will publish it again to",
   "republish_at": "at",
-  "republish_recurring_note": "This is a recurring post: your changes apply to all future recurrences starting now."
+  "republish_recurring_note": "This is a recurring post: your changes apply to all future recurrences starting now.",
+  "create": "Create",
+  "create_new_organization": "Create New Organization",
+  "organization_settings": "Organization Settings",
+  "organization_name": "Organization name",
+  "organization_name_description": "The name shown in the organization switcher."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -746,5 +746,6 @@
   "organization_settings": "Organization Settings",
   "organization_name": "Organization name",
   "organization_name_description": "The name shown in the organization switcher.",
-  "could_not_create_organization": "Could not create organization"
+  "could_not_create_organization": "Could not create organization",
+  "could_not_update_organization_name": "Could not update organization name"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -745,5 +745,6 @@
   "create_new_organization": "Create New Organization",
   "organization_settings": "Organization Settings",
   "organization_name": "Organization name",
-  "organization_name_description": "The name shown in the organization switcher."
+  "organization_name_description": "The name shown in the organization switcher.",
+  "could_not_create_organization": "Could not create organization"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Configuración de la organización",
   "organization_name": "Nombre de la organización",
   "organization_name_description": "El nombre que se muestra en el cambiador de organización.",
-  "could_not_create_organization": "No se pudo crear la organización"
+  "could_not_create_organization": "No se pudo crear la organización",
+  "could_not_update_organization_name": "No se pudo actualizar el nombre de la organización"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Crear nueva organización",
   "organization_settings": "Configuración de la organización",
   "organization_name": "Nombre de la organización",
-  "organization_name_description": "El nombre que se muestra en el cambiador de organización."
+  "organization_name_description": "El nombre que se muestra en el cambiador de organización.",
+  "could_not_create_organization": "No se pudo crear la organización"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -575,6 +575,7 @@
   "email_address": "Dirección de correo electrónico",
   "email_already_exists": "El correo electrónico ya existe",
   "google": "Google",
+  "apple": "Manzana",
   "farcaster": "Farcaster",
   "edit_autopost": "Editar autopublicación",
   "add_autopost_title": "Agregar autopublicación",
@@ -737,5 +738,10 @@
   "republish_the_post": "Volver a publicar la publicación",
   "post_already_published_republish_warning": "Esta publicación ya fue publicada. Volver a publicarla la publicará nuevamente en",
   "republish_at": "a las",
-  "republish_recurring_note": "Esta es una publicación recurrente: tus cambios se aplican a todas las recurrencias futuras a partir de ahora."
+  "republish_recurring_note": "Esta es una publicación recurrente: tus cambios se aplican a todas las recurrencias futuras a partir de ahora.",
+  "create": "Crear",
+  "create_new_organization": "Crear nueva organización",
+  "organization_settings": "Configuración de la organización",
+  "organization_name": "Nombre de la organización",
+  "organization_name_description": "El nombre que se muestra en el cambiador de organización."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Créer une nouvelle organisation",
   "organization_settings": "Paramètres de l'organisation",
   "organization_name": "Nom de l'organisation",
-  "organization_name_description": "Le nom affiché dans le sélecteur d'organisation."
+  "organization_name_description": "Le nom affiché dans le sélecteur d'organisation.",
+  "could_not_create_organization": "Impossible de créer l'organisation"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -575,6 +575,7 @@
   "email_address": "Adresse e-mail",
   "email_already_exists": "L'adresse e-mail existe déjà",
   "google": "Google",
+  "apple": "Pomme",
   "farcaster": "Farcaster",
   "edit_autopost": "Modifier l'autopost",
   "add_autopost_title": "Ajouter un autopost",
@@ -737,5 +738,10 @@
   "republish_the_post": "Republier la publication",
   "post_already_published_republish_warning": "Cette publication a déjà été publiée. La republier la publiera à nouveau sur",
   "republish_at": "à",
-  "republish_recurring_note": "Il s'agit d'une publication récurrente : vos modifications s'appliquent à toutes les récurrences futures à partir de maintenant."
+  "republish_recurring_note": "Il s'agit d'une publication récurrente : vos modifications s'appliquent à toutes les récurrences futures à partir de maintenant.",
+  "create": "Créer",
+  "create_new_organization": "Créer une nouvelle organisation",
+  "organization_settings": "Paramètres de l'organisation",
+  "organization_name": "Nom de l'organisation",
+  "organization_name_description": "Le nom affiché dans le sélecteur d'organisation."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Paramètres de l'organisation",
   "organization_name": "Nom de l'organisation",
   "organization_name_description": "Le nom affiché dans le sélecteur d'organisation.",
-  "could_not_create_organization": "Impossible de créer l'organisation"
+  "could_not_create_organization": "Impossible de créer l'organisation",
+  "could_not_update_organization_name": "Impossible de mettre à jour le nom de l'organisation"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -575,6 +575,7 @@
   "email_address": "כתובת אימייל",
   "email_already_exists": "האימייל כבר קיים",
   "google": "גוגל",
+  "apple": "תפוח",
   "farcaster": "Farcaster",
   "edit_autopost": "ערוך פרסום אוטומטי",
   "add_autopost_title": "הוסף פרסום אוטומטי",
@@ -737,5 +738,10 @@
   "republish_the_post": "לפרסם מחדש את הפוסט",
   "post_already_published_republish_warning": "הפוסט הזה כבר פורסם. פרסום מחדש יפרסם אותו שוב ב",
   "republish_at": "בשעה",
-  "republish_recurring_note": "זהו פוסט חוזר: השינויים שלך יחולו על כל ההופעות העתידיות החל מעכשיו."
+  "republish_recurring_note": "זהו פוסט חוזר: השינויים שלך יחולו על כל ההופעות העתידיות החל מעכשיו.",
+  "create": "צור",
+  "create_new_organization": "צור ארגון חדש",
+  "organization_settings": "הגדרות ארגון",
+  "organization_name": "שם הארגון",
+  "organization_name_description": "השם שמוצג בבורר הארגונים."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "הגדרות ארגון",
   "organization_name": "שם הארגון",
   "organization_name_description": "השם שמוצג בבורר הארגונים.",
-  "could_not_create_organization": "לא ניתן היה ליצור ארגון"
+  "could_not_create_organization": "לא ניתן היה ליצור ארגון",
+  "could_not_update_organization_name": "לא ניתן היה לעדכן את שם הארגון"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "צור ארגון חדש",
   "organization_settings": "הגדרות ארגון",
   "organization_name": "שם הארגון",
-  "organization_name_description": "השם שמוצג בבורר הארגונים."
+  "organization_name_description": "השם שמוצג בבורר הארגונים.",
+  "could_not_create_organization": "לא ניתן היה ליצור ארגון"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Crea nuova organizzazione",
   "organization_settings": "Impostazioni organizzazione",
   "organization_name": "Nome dell'organizzazione",
-  "organization_name_description": "Il nome visualizzato nel selettore dell'organizzazione."
+  "organization_name_description": "Il nome visualizzato nel selettore dell'organizzazione.",
+  "could_not_create_organization": "Impossibile creare l'organizzazione"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Impostazioni organizzazione",
   "organization_name": "Nome dell'organizzazione",
   "organization_name_description": "Il nome visualizzato nel selettore dell'organizzazione.",
-  "could_not_create_organization": "Impossibile creare l'organizzazione"
+  "could_not_create_organization": "Impossibile creare l'organizzazione",
+  "could_not_update_organization_name": "Impossibile aggiornare il nome dell'organizzazione"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -575,6 +575,7 @@
   "email_address": "Indirizzo email",
   "email_already_exists": "L'email esiste già",
   "google": "Google",
+  "apple": "Mela",
   "farcaster": "Farcaster",
   "edit_autopost": "Modifica autopost",
   "add_autopost_title": "Aggiungi autopost",
@@ -737,5 +738,10 @@
   "republish_the_post": "Ripubblica il post",
   "post_already_published_republish_warning": "Questo post è già stato pubblicato. Ripubblicandolo verrà pubblicato nuovamente su",
   "republish_at": "a",
-  "republish_recurring_note": "Questo è un post ricorrente: le tue modifiche verranno applicate a tutte le future ricorrenze a partire da ora."
+  "republish_recurring_note": "Questo è un post ricorrente: le tue modifiche verranno applicate a tutte le future ricorrenze a partire da ora.",
+  "create": "Crea",
+  "create_new_organization": "Crea nuova organizzazione",
+  "organization_settings": "Impostazioni organizzazione",
+  "organization_name": "Nome dell'organizzazione",
+  "organization_name_description": "Il nome visualizzato nel selettore dell'organizzazione."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "組織の設定",
   "organization_name": "組織名",
   "organization_name_description": "組織切り替え時に表示される名前です。",
-  "could_not_create_organization": "組織を作成できませんでした"
+  "could_not_create_organization": "組織を作成できませんでした",
+  "could_not_update_organization_name": "組織名を更新できませんでした"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "新しい組織を作成",
   "organization_settings": "組織の設定",
   "organization_name": "組織名",
-  "organization_name_description": "組織切り替え時に表示される名前です。"
+  "organization_name_description": "組織切り替え時に表示される名前です。",
+  "could_not_create_organization": "組織を作成できませんでした"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -575,6 +575,7 @@
   "email_address": "メールアドレス",
   "email_already_exists": "メールアドレスは既に存在します",
   "google": "Google",
+  "apple": "アップル",
   "farcaster": "Farcaster",
   "edit_autopost": "自動投稿を編集",
   "add_autopost_title": "自動投稿を追加",
@@ -737,5 +738,10 @@
   "republish_the_post": "投稿を再公開する",
   "post_already_published_republish_warning": "この投稿は既に公開されています。再公開すると、もう一度投稿されます：",
   "republish_at": "公開日時：",
-  "republish_recurring_note": "これは定期投稿です：今後すべての繰り返しに対して変更が適用されます。"
+  "republish_recurring_note": "これは定期投稿です：今後すべての繰り返しに対して変更が適用されます。",
+  "create": "作成",
+  "create_new_organization": "新しい組織を作成",
+  "organization_settings": "組織の設定",
+  "organization_name": "組織名",
+  "organization_name_description": "組織切り替え時に表示される名前です。"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "새 조직 생성",
   "organization_settings": "조직 설정",
   "organization_name": "조직 이름",
-  "organization_name_description": "조직 전환기에서 표시되는 이름입니다."
+  "organization_name_description": "조직 전환기에서 표시되는 이름입니다.",
+  "could_not_create_organization": "조직을 생성할 수 없습니다"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -575,6 +575,7 @@
   "email_address": "이메일 주소",
   "email_already_exists": "이미 존재하는 이메일입니다",
   "google": "구글",
+  "apple": "애플",
   "farcaster": "파캐스터",
   "edit_autopost": "자동 게시 수정",
   "add_autopost_title": "자동 게시 추가",
@@ -737,5 +738,10 @@
   "republish_the_post": "게시물 다시 게시하기",
   "post_already_published_republish_warning": "이 게시물은 이미 게시되었습니다. 다시 게시하면 다음에 다시 게시됩니다:",
   "republish_at": "다음 시간에",
-  "republish_recurring_note": "이 게시물은 반복 게시물입니다. 변경사항은 지금부터 시작하는 모든 향후 반복에 적용됩니다."
+  "republish_recurring_note": "이 게시물은 반복 게시물입니다. 변경사항은 지금부터 시작하는 모든 향후 반복에 적용됩니다.",
+  "create": "생성하기",
+  "create_new_organization": "새 조직 생성",
+  "organization_settings": "조직 설정",
+  "organization_name": "조직 이름",
+  "organization_name_description": "조직 전환기에서 표시되는 이름입니다."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "조직 설정",
   "organization_name": "조직 이름",
   "organization_name_description": "조직 전환기에서 표시되는 이름입니다.",
-  "could_not_create_organization": "조직을 생성할 수 없습니다"
+  "could_not_create_organization": "조직을 생성할 수 없습니다",
+  "could_not_update_organization_name": "조직 이름을 업데이트할 수 없습니다"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Criar nova organização",
   "organization_settings": "Configurações da organização",
   "organization_name": "Nome da organização",
-  "organization_name_description": "O nome exibido no seletor de organizações."
+  "organization_name_description": "O nome exibido no seletor de organizações.",
+  "could_not_create_organization": "Não foi possível criar a organização"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -575,6 +575,7 @@
   "email_address": "Endereço de e-mail",
   "email_already_exists": "O e-mail já existe",
   "google": "Google",
+  "apple": "Maçã",
   "farcaster": "Farcaster",
   "edit_autopost": "Editar autopost",
   "add_autopost_title": "Adicionar autopost",
@@ -737,5 +738,10 @@
   "republish_the_post": "Republicar a publicação",
   "post_already_published_republish_warning": "Esta publicação já foi publicada. Republicar irá publicá-la novamente em",
   "republish_at": "em",
-  "republish_recurring_note": "Esta é uma publicação recorrente: suas alterações se aplicam a todas as futuras recorrências a partir de agora."
+  "republish_recurring_note": "Esta é uma publicação recorrente: suas alterações se aplicam a todas as futuras recorrências a partir de agora.",
+  "create": "Criar",
+  "create_new_organization": "Criar nova organização",
+  "organization_settings": "Configurações da organização",
+  "organization_name": "Nome da organização",
+  "organization_name_description": "O nome exibido no seletor de organizações."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Configurações da organização",
   "organization_name": "Nome da organização",
   "organization_name_description": "O nome exibido no seletor de organizações.",
-  "could_not_create_organization": "Não foi possível criar a organização"
+  "could_not_create_organization": "Não foi possível criar a organização",
+  "could_not_update_organization_name": "Não foi possível atualizar o nome da organização"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -575,6 +575,7 @@
   "email_address": "Адрес электронной почты",
   "email_already_exists": "Электронная почта уже существует",
   "google": "Google",
+  "apple": "Яблоко",
   "farcaster": "Farcaster",
   "edit_autopost": "Редактировать автопост",
   "add_autopost_title": "Добавить автопост",
@@ -737,5 +738,10 @@
   "republish_the_post": "Опубликовать пост повторно",
   "post_already_published_republish_warning": "Этот пост уже был опубликован. Повторная публикация опубликует его снова в",
   "republish_at": "в",
-  "republish_recurring_note": "Это повторяющийся пост: ваши изменения будут применяться ко всем будущим публикациям, начиная с этого момента."
+  "republish_recurring_note": "Это повторяющийся пост: ваши изменения будут применяться ко всем будущим публикациям, начиная с этого момента.",
+  "create": "Создать",
+  "create_new_organization": "Создать новую организацию",
+  "organization_settings": "Настройки организации",
+  "organization_name": "Название организации",
+  "organization_name_description": "Имя, отображаемое в переключателе организаций."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Создать новую организацию",
   "organization_settings": "Настройки организации",
   "organization_name": "Название организации",
-  "organization_name_description": "Имя, отображаемое в переключателе организаций."
+  "organization_name_description": "Имя, отображаемое в переключателе организаций.",
+  "could_not_create_organization": "Не удалось создать организацию"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Настройки организации",
   "organization_name": "Название организации",
   "organization_name_description": "Имя, отображаемое в переключателе организаций.",
-  "could_not_create_organization": "Не удалось создать организацию"
+  "could_not_create_organization": "Не удалось создать организацию",
+  "could_not_update_organization_name": "Не удалось обновить название организации"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Organizasyon Ayarları",
   "organization_name": "Organizasyon adı",
   "organization_name_description": "Organizasyon değiştiricisinde gösterilen isim.",
-  "could_not_create_organization": "Organizasyon oluşturulamadı"
+  "could_not_create_organization": "Organizasyon oluşturulamadı",
+  "could_not_update_organization_name": "Organizasyon adı güncellenemedi"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -575,6 +575,7 @@
   "email_address": "E-posta Adresi",
   "email_already_exists": "E-posta zaten mevcut",
   "google": "Google",
+  "apple": "Elma",
   "farcaster": "Farcaster",
   "edit_autopost": "Otomatik Gönderiyi Düzenle",
   "add_autopost_title": "Otomatik Gönderi Ekle",
@@ -737,5 +738,10 @@
   "republish_the_post": "Gönderiyi tekrar yayımla",
   "post_already_published_republish_warning": "Bu gönderi zaten yayımlanmış. Tekrar yayımlamak, gönderiyi yeniden yayımlar",
   "republish_at": "tarihinde/saatinde",
-  "republish_recurring_note": "Bu tekrar eden bir gönderi: yaptığınız değişiklikler bundan sonraki tüm tekrarlar için geçerli olacaktır."
+  "republish_recurring_note": "Bu tekrar eden bir gönderi: yaptığınız değişiklikler bundan sonraki tüm tekrarlar için geçerli olacaktır.",
+  "create": "Oluştur",
+  "create_new_organization": "Yeni Organizasyon Oluştur",
+  "organization_settings": "Organizasyon Ayarları",
+  "organization_name": "Organizasyon adı",
+  "organization_name_description": "Organizasyon değiştiricisinde gösterilen isim."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Yeni Organizasyon Oluştur",
   "organization_settings": "Organizasyon Ayarları",
   "organization_name": "Organizasyon adı",
-  "organization_name_description": "Organizasyon değiştiricisinde gösterilen isim."
+  "organization_name_description": "Organizasyon değiştiricisinde gösterilen isim.",
+  "could_not_create_organization": "Organizasyon oluşturulamadı"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "Cài Đặt Tổ Chức",
   "organization_name": "Tên tổ chức",
   "organization_name_description": "Tên được hiển thị trong bộ chuyển đổi tổ chức.",
-  "could_not_create_organization": "Không thể tạo tổ chức"
+  "could_not_create_organization": "Không thể tạo tổ chức",
+  "could_not_update_organization_name": "Không thể cập nhật tên tổ chức"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "Tạo Tổ Chức Mới",
   "organization_settings": "Cài Đặt Tổ Chức",
   "organization_name": "Tên tổ chức",
-  "organization_name_description": "Tên được hiển thị trong bộ chuyển đổi tổ chức."
+  "organization_name_description": "Tên được hiển thị trong bộ chuyển đổi tổ chức.",
+  "could_not_create_organization": "Không thể tạo tổ chức"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -575,6 +575,7 @@
   "email_address": "Địa chỉ email",
   "email_already_exists": "Email đã tồn tại",
   "google": "Google",
+  "apple": "Táo",
   "farcaster": "Farcaster",
   "edit_autopost": "Chỉnh sửa tự động đăng",
   "add_autopost_title": "Thêm tự động đăng",
@@ -737,5 +738,10 @@
   "republish_the_post": "Đăng lại bài viết",
   "post_already_published_republish_warning": "Bài viết này đã được đăng. Đăng lại sẽ xuất bản bài viết một lần nữa đến",
   "republish_at": "lúc",
-  "republish_recurring_note": "Đây là bài viết định kỳ: các thay đổi của bạn sẽ áp dụng cho tất cả các lần lặp lại trong tương lai bắt đầu từ bây giờ."
+  "republish_recurring_note": "Đây là bài viết định kỳ: các thay đổi của bạn sẽ áp dụng cho tất cả các lần lặp lại trong tương lai bắt đầu từ bây giờ.",
+  "create": "Tạo",
+  "create_new_organization": "Tạo Tổ Chức Mới",
+  "organization_settings": "Cài Đặt Tổ Chức",
+  "organization_name": "Tên tổ chức",
+  "organization_name_description": "Tên được hiển thị trong bộ chuyển đổi tổ chức."
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -743,5 +743,6 @@
   "create_new_organization": "创建新组织",
   "organization_settings": "组织设置",
   "organization_name": "组织名称",
-  "organization_name_description": "在组织切换器中显示的名称。"
+  "organization_name_description": "在组织切换器中显示的名称。",
+  "could_not_create_organization": "无法创建组织"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -575,6 +575,7 @@
   "email_address": "电子邮件地址",
   "email_already_exists": "电子邮件已存在",
   "google": "Google",
+  "apple": "苹果",
   "farcaster": "Farcaster",
   "edit_autopost": "编辑自动发布",
   "add_autopost_title": "添加自动发布",
@@ -737,5 +738,10 @@
   "republish_the_post": "重新发布帖子",
   "post_already_published_republish_warning": "此帖子已发布。重新发布将再次将其发布到",
   "republish_at": "于",
-  "republish_recurring_note": "这是一个重复的帖子：你的更改将从现在开始应用于所有未来的重复内容。"
+  "republish_recurring_note": "这是一个重复的帖子：你的更改将从现在开始应用于所有未来的重复内容。",
+  "create": "创建",
+  "create_new_organization": "创建新组织",
+  "organization_settings": "组织设置",
+  "organization_name": "组织名称",
+  "organization_name_description": "在组织切换器中显示的名称。"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -744,5 +744,6 @@
   "organization_settings": "组织设置",
   "organization_name": "组织名称",
   "organization_name_description": "在组织切换器中显示的名称。",
-  "could_not_create_organization": "无法创建组织"
+  "could_not_create_organization": "无法创建组织",
+  "could_not_update_organization_name": "无法更新组织名称"
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature.

# Why was this change needed?

Some customers need more channels than our biggest plan allows (100+). Instead of adding bigger plans or reworking how channel caps / subscriptions work, this lets a user create an additional organization from inside the app and pay for it separately. Every existing mechanic stays as is: `UserOrganization` is already many-to-many, subscriptions / `paymentId` / API key / channels are already per org, and the org switcher already exists. So a second org is simply another regular org the same user is `SUPERADMIN` of, with its own Stripe customer and subscription, and no schema change or new billing logic.

What this adds:

- `POST /user/organizations`: creates a full independent org (own `apiKey`, no subscription, creator = `SUPERADMIN`). Additional orgs get `allowTrial=false` / `isTrailing=false`, so no second free trial; only signup orgs get a trial.
- Org switcher: always rendered (previously only with 2+ orgs), with a "Create New Organization +" item that opens a small name modal. After creation the user is switched to the new org; since it has no subscription, the existing first-billing plans screen appears and Stripe checkout runs against the new org's own customer.
- Rename: `GET/POST /settings/organization-name` (POST guarded by the same `@CheckPolicies([Create, ADMIN])` as shortlink) and an "Organization name" field at the top of Global Settings, so switcher entries have meaningful names instead of whatever was typed as "company" at signup.
- `CheckPayment` now strips the `?check=` param after a successful payment. Previously any reload/org switch while the param was still in the URL re-polled `/billing/check/:id` for the current org and hung on the loader; the new switcher right after checkout made that easy to hit.

# Other information:

Tested end to end locally:

- Single-org user: header shows the switcher; hover shows "Create New Organization +"; creating switches to the new org and shows the plans screen (`FirstBillingComponent`) with the new org's name. DB: `UserOrganization.role = SUPERADMIN`, `allowTrial = false`, `isTrailing = false`, own `apiKey`, no `Subscription` row.
- Completed a Stripe test checkout on the new org: `Subscription` row created for the new org only, tied to the new org's own Stripe customer; the original org's existing subscription untouched. After the webhook the app lands on the new org's (empty) dashboard with onboarding.
- Switching back to the original org via the selector works; everything as before.
- Global Settings: rename → "Settings updated" toast, name updated in DB and live in the header switcher. As a `USER`-role member the field is hidden and `POST /settings/organization-name` is rejected by the policy guard.
- Verified the `?check=` fix: loading `/launches?check=<id>` on the paid org clears the loader and drops the param; switching orgs afterwards no longer hangs.
- `tsc` clean for backend and frontend.

Notes for review:

- The `animate-bounce` on the switcher icon for FREE tier was kept as is (now visible to everyone).
- New `t()` keys added (`create_new_organization`, `organization_name`, `organization_settings`, `organization_name_description`, `create`, `save`); translations to be generated after.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
