### PR TITLE
fix: make frontend and NestJS logs reach Sentry

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -10,7 +10,7 @@ Runtime.install({ shutdownSignals: [] });
 process.env.TZ = 'UTC';
 
 import cookieParser from 'cookie-parser';
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { ConsoleLogger, Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
@@ -22,6 +22,7 @@ import { startMcp } from '@gitroom/nestjs-libraries/chat/start.mcp';
 
 async function start() {
   const app = await NestFactory.create(AppModule, {
+    logger: new ConsoleLogger({ forceConsole: true, colors: false }),
     rawBody: true,
     cors: {
       ...(!process.env.NOT_SECURED ? { credentials: true } : {}),

--- a/apps/frontend/src/app/(extension)/layout.tsx
+++ b/apps/frontend/src/app/(extension)/layout.tsx
@@ -1,3 +1,4 @@
+import { SentryComponent } from '@gitroom/frontend/components/layout/sentry.component';
 export const dynamic = 'force-dynamic';
 import '../global.scss';
 import 'react-tooltip/dist/react-tooltip.css';
@@ -64,10 +65,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               : []
           }
         >
-          <LayoutContext>
-            <UtmSaver />
-            {children}
-          </LayoutContext>
+          <SentryComponent>
+            <LayoutContext>
+              <UtmSaver />
+              {children}
+            </LayoutContext>
+          </SentryComponent>
         </VariableContextComponent>
       </body>
     </html>

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -1,3 +1,4 @@
+import { SentryComponent } from '@gitroom/frontend/components/layout/sentry.component';
 import { MantineWrapper } from '@gitroom/react/helpers/mantine.wrapper';
 
 export const dynamic = 'force-dynamic';
@@ -66,12 +67,14 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               : []
           }
         >
-          <MantineWrapper>
-            <LayoutContext>
-              <UtmSaver />
-              {children}
-            </LayoutContext>
-          </MantineWrapper>
+          <SentryComponent>
+            <MantineWrapper>
+              <LayoutContext>
+                <UtmSaver />
+                {children}
+              </LayoutContext>
+            </MantineWrapper>
+          </SentryComponent>
         </VariableContextComponent>
       </body>
     </html>

--- a/apps/frontend/src/app/(provider)/layout.tsx
+++ b/apps/frontend/src/app/(provider)/layout.tsx
@@ -1,4 +1,3 @@
-import { SentryComponent } from '@gitroom/frontend/components/layout/sentry.component';
 import { MantineWrapper } from '@gitroom/react/helpers/mantine.wrapper';
 
 export const dynamic = 'force-dynamic';
@@ -67,14 +66,12 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
               : []
           }
         >
-          <SentryComponent>
-            <MantineWrapper>
-              <LayoutContext>
-                <UtmSaver />
-                {children}
-              </LayoutContext>
-            </MantineWrapper>
-          </SentryComponent>
+          <MantineWrapper>
+            <LayoutContext>
+              <UtmSaver />
+              {children}
+            </LayoutContext>
+          </MantineWrapper>
         </VariableContextComponent>
       </body>
     </html>

--- a/apps/frontend/src/instrumentation.ts
+++ b/apps/frontend/src/instrumentation.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
 export async function register() {
   if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
     return;
@@ -9,3 +11,5 @@ export async function register() {
     await import('./sentry.edge.config');
   }
 }
+
+export const onRequestError = Sentry.captureRequestError;

--- a/apps/orchestrator/src/main.ts
+++ b/apps/orchestrator/src/main.ts
@@ -5,13 +5,16 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
 
+import { ConsoleLogger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from '@gitroom/orchestrator/app.module';
 import * as dns from 'node:dns';
 dns.setDefaultResultOrder('ipv4first');
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    logger: new ConsoleLogger({ forceConsole: true, colors: false }),
+  });
   app.enableShutdownHooks();
   const port = process.env.ORCHESTRATOR_PORT || 3002;
   await app.listen(port);

--- a/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
+++ b/libraries/react-shared-libraries/src/sentry/initialize.sentry.next.basic.ts
@@ -5,6 +5,9 @@ export const initializeSentryBasic = (environment: string, dsn: string, extensio
     return;
   }
 
+  const { integrations: extensionIntegrations = [], ...restExtension } =
+    extension || {};
+
   const ignorePatterns = [
     /^Failed to fetch$/,
     /^Failed to fetch .*/i,
@@ -31,12 +34,14 @@ export const initializeSentryBasic = (environment: string, dsn: string, extensio
       },
       integrations: [
         Sentry.consoleLoggingIntegration({ levels: ['log', 'info', 'warn', 'error', 'debug', 'assert', 'trace'] }),
+        ...extensionIntegrations,
       ],
       environment: environment || 'development',
       spotlight: process.env.SENTRY_SPOTLIGHT === '1',
       dsn,
       sendDefaultPii: true,
-      ...extension,
+      enableLogs: true,
+      ...restExtension,
       debug: environment === 'development',
       tracesSampleRate: 1.0,
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (observability).

# Why was this change needed?

Sentry is initialised on all three runtimes, but on the frontend nothing it logs actually arrives, and on the NestJS side a whole class of log lines never reaches it.

**Frontend console logs.** `consoleLoggingIntegration` is registered in `initializeSentryBasic`, but it was inert for two independent reasons:

- `enableLogs` was never set. The integration bails out at setup when logs are disabled, so every `console.*` on the browser, the Next server and the edge runtime was dropped on the floor.
- On the browser it was not even registered. `initializeSentryClient` passes its own `integrations` array, and the `...extension` spread sat below the base `integrations` key, silently overwriting it. Pulling the caller's integrations out of the spread makes them additive instead of replacing.

**Route groups without an SDK.** Only `(app)` rendered `SentryComponent`, so `(extension)` ran with no browser SDK at all - no errors, no logs, no replays - even though it already passes `sentryDsn` into the variable context. It now wraps the same way `(app)` does.

`(provider)` is deliberately left out. Those routes handle secrets: `/provider/[p]` is opened with `?loggedAuth=<jwt>` in the URL, and `/provider/add` renders custom provider credentials as text and password inputs. Replay currently runs at 100% with `maskAllText`, `maskAllInputs` and `blockAllMedia` all off, so enabling the browser SDK there would send the token and the typed credentials to Sentry. Covering those routes needs replay masking and query-parameter scrubbing first.

**Next server errors.** Without `onRequestError`, the framework swallows errors thrown in server components, server actions, `generateMetadata` and route handlers. That hook is the only way they surface.

**NestJS logger.** `ConsoleLogger` writes through `process.stdout.write` / `process.stderr.write` unless `forceConsole` is on, so nothing logged through `Logger` ever reached Sentry: startup failures and configuration warnings in the backend, and everything `nestjs-temporal-core` emits in the orchestrator. Setting the logger on `NestFactory.create` rather than per instance is what makes it apply to third-party `new Logger()` calls too - while the static ref is still the default logger, each `Logger` builds its own private `ConsoleLogger` that no per-instance option can reach. `colors: false` keeps ANSI escape codes out of the message text, since Nest's colour detection only checks `NO_COLOR` and never whether it is attached to a TTY.

# Other information:

Log levels are unchanged. The replacement `ConsoleLogger` uses Nest's default level set, which is the same one the implicit default logger already used. The visible difference on the platform side is that Nest log lines are no longer coloured.

Two open PRs also touch `initialize.sentry.next.basic.ts` - #1836 and #1365 - but both edit `beforeSend`, away from the hunks here, so they should merge independently. Worth noting that #1365's `beforeSendLog` only has an effect once logs are actually enabled, which is what this PR does.

Verified with `tsc --noEmit`: the frontend project is clean, and the backend and orchestrator projects report the same pre-existing errors before and after this change (stale Prisma client types, none in the touched files). ESLint could not be run - its config throws `Converting circular structure to JSON` on untouched files too.

Not covered here: `apps/commands` never calls `initializeSentry` and `apps/extension` has no Sentry at all, so their output is still not ingested. Those are separate changes.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
