### PR TITLE
fix(posts): reject post creation on soft-deleted channels

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
@@ -203,7 +203,7 @@ If the tools return errors, you would need to rerun it with the right parameters
         for (const post of inputData.socialPost) {
           const integration = integrations[post.integrationId];
 
-          if (!integration) {
+          if (!integration || integration.deletedAt) {
             throw new Error('Integration not found');
           }
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -263,7 +263,7 @@ export class PostsService {
             post.integration.id
           );
 
-          if (!integration) {
+          if (!integration || integration.deletedAt) {
             throw new BadRequestException(
               `Integration with id ${post.integration.id} not found`
             );

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -777,7 +777,7 @@ export class PostsService {
           post?.integration?.id
         );
 
-        if (!integration) {
+        if (!integration || integration.deletedAt) {
           throw new BadRequestException(
             `Integration with id ${post?.integration?.id} not found`
           );


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, post creation on deleted channels). Both creation paths that resolve a channel through `getIntegrationById` - the public API's `mapTypeToPost` and the MCP `integrationSchedulePostTool` - now treat a soft-deleted integration (`deletedAt` set) as not found, so a deleted channel can no longer receive newly created posts and keep publishing with its retained token. Autopost resolves channels through `getIntegrationsList` and is unaffected.

# Why was this change needed?

A customer deleted their X channel in Postiz but posts kept being published to it for three more days. Deleting a channel soft-deletes it and its already-scheduled posts, but new posts could still be created for it: the public API (`mapTypeToPost`) and the MCP schedule tool both resolve the integration with `getIntegrationById`, which does not filter `deletedAt`. The token is retained on the soft-deleted row, so the orchestrator published normally. In this case an external automation kept calling the public API daily with the old integration id.

Both creation paths now treat a soft-deleted integration as not found (`400 Integration with id … not found` on the API, `Integration not found` from the MCP tool). Autopost is unaffected: it resolves channels through `getIntegrationsList`, which already excludes deleted ones.

# Other information:

Testing (local backend, real org with a soft-deleted channel and a live X channel):
- Public API `POST /public/v1/posts` with the deleted channel id: before the fix it passed the integration lookup and reached DTO validation (i.e. would be created with a valid payload); after the fix it returns 400 not found. Live channel still creates a draft.
- MCP `integrationSchedulePostTool` with the deleted channel id: before the fix it created a draft; after the fix it fails with "Integration not found". Live channel still creates a draft.

Follow-ups considered separately: applying the same guard to disabled channels, and a mid-flight orchestrator guard for workflows that survive channel deletion.

# QA

1. [ ] Start the stack (`pnpm run dev:docker`, then `pnpm run dev`) and log in to a test org with at least two connected channels.
2. [ ] Copy the org's public API key from Settings, and list the channels: `curl -H "Authorization: <api key>" http://localhost:3000/public/v1/integrations`. Note the id of one channel to delete and the id of one to keep.
3. [ ] Delete the first channel from the UI (Preview/settings menu -> Delete). This soft-deletes it: the row stays with `deletedAt` set, and its already-scheduled posts are soft-deleted too.
4. [ ] Public API, deleted channel: `curl -i -X POST http://localhost:3000/public/v1/posts -H "Authorization: <api key>" -H "Content-Type: application/json" -d '{"type":"schedule","posts":[{"integration":{"id":"<deleted channel id>"},"value":[{"content":"qa"}]}]}'`. Expected: `400` with `Integration with id <deleted channel id> not found`. Before the fix the lookup passed and the request fell through to DTO validation.
5. [ ] Public API, live channel: the same call with the kept channel id. Expected: it gets past the integration lookup - either the post is created, or you get DTO validation errors about missing fields, but never `Integration with id ... not found`.
6. [ ] MCP path, deleted channel: run `integrationSchedulePostTool` (via the in-app chat, e.g. "schedule a post to <deleted channel name>") targeting the deleted channel id. Expected: it fails with `Integration not found` and no draft is created. Before the fix it created a draft.
7. [ ] MCP path, live channel: same tool against the kept channel. Expected: the draft is created as before.
8. [ ] Dashboard regression: create and schedule a post from the calendar on the kept channel. Expected: unchanged - it saves and publishes.
9. [ ] Autopost regression: confirm an autopost configured on the org still resolves its channels (it goes through `getIntegrationsList`, which already excludes deleted rows) and is unaffected by the deleted channel.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
