### PR TITLE
fix(analytics): log swallowed provider errors instead of silent empty arrays

### DIFF
--- a/COMMIT_MSG.txt
+++ b/COMMIT_MSG.txt
@@ -1,0 +1,12 @@
+fix(analytics): log provider errors instead of silently returning empty
+
+checkAnalytics swallows every non-RefreshToken provider error and
+falls through to an empty array, making failing analytics look like
+"no data" (expired scopes, depleted API credits, malformed tokens).
+
+Log the error with provider + integration context so the failure is
+visible in server logs.
+
+Verified against a live instance: X (credits depleted) and other
+providers silently returned [] while the Integration table showed
+healthy, unexpired tokens and 315 published posts existed.

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -511,6 +511,10 @@ export class IntegrationService {
         if (e instanceof RefreshToken) {
           return this.checkAnalytics(org, integration, date, true);
         }
+        console.log(
+          `Failed to load analytics for ${getIntegration.providerIdentifier} (${integration}):`,
+          e
+        );
       }
     }
 


### PR DESCRIPTION
## Problem

`checkAnalytics` swallows **every** provider error that isn't a `RefreshToken` and falls through to `return []`. Result: failing analytics looks identical to "no data" — operators cannot tell an expired scope, depleted API credits, or a malformed token from a quiet day.

## Evidence (live instance)

- Integration table: all 9 providers connected, unexpired tokens, no `refreshNeeded`.
- 315 posts in state `PUBLISHED` (286 created this month).
- `GET /public/v1/analytics/:integration?date=7` returns `[]` for **every** provider.
- Root cause found in the provider implementations: e.g. X fails on depleted API credits; the error is caught here and discarded.

## Fix

Log the error with provider + integration context before falling through. One `console.log` (matches the file's existing convention at line 120), no API contract change, no behavior change for healthy providers.

## Impact

- Operators see `Failed to load analytics for x (…)` in server logs instead of silent empties.
- Frontend and API behavior unchanged.
- Zero risk to the happy path — only the previously-silent catch branch gains a log line.
