### PR TITLE
fix(bluesky): surface the underlying error when preparation keeps failing

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -605,11 +605,12 @@ export class BlueskyProvider extends SocialAbstract implements SocialProvider {
       // this is safe and beats exhausting the check budget into a misleading
       // "check your account" warning.
       if ((pendingData.prepFailures || 0) >= 4) {
+        const reason = (err as any)?.message || String(err);
         throw new BadBody(
           'bluesky',
-          JSON.stringify({}),
+          JSON.stringify({ message: reason }),
           {} as any,
-          'Could not prepare the post for Bluesky, nothing was published, please try again'
+          `Could not prepare the post for Bluesky, nothing was published: ${reason}`
         );
       }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Bluesky provider error observability). When preparation has failed four times, `BlueskyProvider` now puts the underlying `err.message` into both the `BadBody` payload (`{ message: reason }` instead of `{}`) and the user-facing message, instead of a generic "please try again". When the post fails is deliberately unchanged - only what the user and Sentry get to see. Note for the reviewer: the raw provider message now reaches the end user, so truncating or sanitising it is worth a decision before merge.

# Why was this change needed?

A customer had 9 failed Bluesky posts this week that all surfaced only the generic "Could not prepare the post for Bluesky, nothing was published, please try again". The real cause (Bluesky's video service rejecting their 191MB–310MB videos, a usage issue on their side) was swallowed: the prep-failure catch threw a BadBody with an empty json payload and a fixed message, so neither the stored error nor the bell notification / failure email told the user (or us) what went wrong.

This includes the underlying error message in the BadBody json (`{"message": ...}`) and appends it to the user-facing failure message. Since bad_body messages already flow into the in-app notification and failure email, the user now sees the actual reason regardless of when calendar-level error surfacing (#1868) lands.

# Other information:

Retry semantics are unchanged: the first 4 preparation failures still return pending and re-poll; only the final give-up now carries the real reason.

# QA

1. [ ] Connect a Bluesky channel
2. [ ] Attach media Bluesky will reject at upload, for example an oversized video, so `uploadMediaForPost` fails repeatedly
3. [ ] Let the post run until the fifth preparation attempt
4. [ ] The ERROR notification includes the underlying Bluesky reason after "nothing was published:", rather than the old generic text
5. [ ] Check Sentry or the logs - the `BadBody` payload carries `{"message": "..."}` instead of `{}`
6. [ ] Publish a valid Bluesky post to confirm the happy path is unchanged
7. [ ] Confirm the surfaced message contains nothing you would not want shown to an end user

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
