### PR TITLE
fix(reddit): strip leading/trailing slashes from subreddit names

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -443,7 +443,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
     // finds the armed marker and asks Reddit instead of resubmitting blindly.
     const value = data.subreddits[data.cursor].value;
     data.armed = {
-      sr: value.subreddit.replace('/r/', '').toLowerCase(),
+      sr: value.subreddit.replace('/r/', '').replace(/^\/+|\/+$/g, '').toLowerCase(),
       title: value.title || '',
       armedAt: Date.now(),
       media: value.type === 'media',
@@ -502,7 +502,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
           }
         : {}),
       text: data.message,
-      sr: value.subreddit.replace('/r/', '').toLowerCase(),
+      sr: value.subreddit.replace('/r/', '').replace(/^\/+|\/+$/g, '').toLowerCase(),
     };
 
     const all = await (

--- a/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/reddit.provider.ts
@@ -443,7 +443,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
     // finds the armed marker and asks Reddit instead of resubmitting blindly.
     const value = data.subreddits[data.cursor].value;
     data.armed = {
-      sr: value.subreddit.replace('/r/', '').replace(/^\/+|\/+$/g, '').toLowerCase(),
+      sr: value.subreddit.replace(/^\/?r\//, '').replace(/^\/+|\/+$/g, '').toLowerCase(),
       title: value.title || '',
       armedAt: Date.now(),
       media: value.type === 'media',
@@ -502,7 +502,7 @@ export class RedditProvider extends SocialAbstract implements SocialProvider {
           }
         : {}),
       text: data.message,
-      sr: value.subreddit.replace('/r/', '').replace(/^\/+|\/+$/g, '').toLowerCase(),
+      sr: value.subreddit.replace(/^\/?r\//, '').replace(/^\/+|\/+$/g, '').toLowerCase(),
     };
 
     const all = await (


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Reddit provider). Both places in `RedditProvider` that derive the `sr` parameter now strip an optional leading `/r/` and any surrounding slashes before lowercasing, so a subreddit saved as `/r/foo/`, `r/foo` or `foo` all submit as `foo`. Previously only the literal substring `/r/` was removed, so a trailing slash was sent to Reddit and the submit failed. In-flight posts are unaffected: `armed.sr` is only used to query Reddit's listing, never compared against a previously stored value. Notes for the reviewer: input like `//r/foo` still resolves to `r/foo`, and the chained replace is duplicated at both call sites where a small shared helper would fit the codebase better.

# Why was this change needed?

A customer's post to an existing subreddit failed with `Reddit rejected the post to r/gameblastbr/: Hmm, that community doesn't exist`. The trailing slash comes from our own subreddit picker: `subreddits()` returns Reddit's search-result `url` field verbatim (`/r/Name/`), `restrictions()` echoes it back, and the `sr` normalization only strips the `/r/` prefix — so submits go out with `sr=name/`.

Production data shows Reddit tolerates that shape inconsistently: since June 1, 385 posts with trailing-slash subreddit settings published fine, but among errored posts the "community doesn't exist" rate is 21% (32/151) for trailing-slash names vs 3.5% (120/3465) for clean ones. Our suspicion (based on this data plus the deterministic local repro below, no official Reddit statement found) is that Reddit intermittently rejects trailing-slash subreddit names with SUBREDDIT_NOEXIST — which would also explain the "transient" NOEXIST failures behind #1886.

This strips leading and trailing slashes at both `sr` normalization sites.

# Other information:

Tested end to end against a real connected Reddit channel: pre-fix, a post configured with `/r/test/` failed with the exact `r/test/: Hmm, that community doesn't exist` error; post-fix, the same input published successfully to r/test.

# QA

1. [ ] Create a Reddit post and enter the subreddit as `/r/test/`, with both a leading and a trailing slash
2. [ ] Publish it - the post lands in r/test and the release URL is https://www.reddit.com/r/test
3. [ ] Repeat with `r/test`, `test` and `/r/test` - all four land in the same subreddit
4. [ ] Check the backend logs: the submitted `sr` parameter is `test` in every case
5. [ ] Publish a media post to the same subreddit and confirm the armed / duplicate-check path resolves to exactly one post, not two
6. [ ] Confirm a subreddit entered with mixed case, for example `/r/Test/`, still submits as `test`

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
