### PR TITLE
fix(media): surface the real status when a ranged media read is not 206

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -274,11 +274,17 @@ export abstract class SocialAbstract {
       } as any);
       // Anything but 206 means the server ignored the Range header: buffering
       // response.body here would silently load the whole file into memory and
-      // upload corrupted chunks.
+      // upload corrupted chunks. Carry the real status so the failure says
+      // which answer we got - a 200 means identity encoding was not enough, a
+      // 5xx means the store was unavailable.
       if (response.status !== 206) {
         throw new BadBody(
           identifier,
-          '{}',
+          JSON.stringify({
+            status: response.status,
+            statusText: response.statusText,
+            ok: response.ok,
+          }),
           Buffer.from('{}'),
           `Media server did not honor the range request (status ${response.status})`
         );

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -704,11 +704,18 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       } as any);
 
       // A store that ignores Range (200 with the full file) or answers with an
-      // error page would corrupt the upload at this offset.
+      // error page would corrupt the upload at this offset. Carry the real
+      // status in the persisted failure details (not in the user-facing
+      // message) so the failure says which answer we got - a 200 means
+      // identity encoding was not enough, a 5xx means the store was down.
       if (response.status !== 206) {
         throw new BadBody(
           'tiktok-error-upload',
-          '{}',
+          JSON.stringify({
+            status: response.status,
+            statusText: response.statusText,
+            ok: response.ok,
+          }),
           '{}',
           'The media storage did not return the requested byte range, please try again'
         );

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -469,11 +469,18 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
       } as any);
 
       // A store that ignores Range (200 with the full file) or answers with an
-      // error page would corrupt the upload at this offset.
+      // error page would corrupt the upload at this offset. Carry the real
+      // status in the persisted failure details (not in the user-facing
+      // message) so the failure says which answer we got - a 200 means
+      // identity encoding was not enough, a 5xx means the store was down.
       if (response.status !== 206) {
         throw new BadBody(
           this.identifier,
-          '{}',
+          JSON.stringify({
+            status: response.status,
+            statusText: response.statusText,
+            ok: response.ok,
+          }),
           '{}',
           'The media storage did not return the requested byte range, please try again'
         );


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (observability, no behaviour change).

# Why was this change needed?

## What we saw in production

A post failed on 2026-08-18 in `youtubeChunkStream` with "The media storage did not return the requested byte range, please try again". That message is static, and the throw passes `'{}'` as the failure json, so the row in the database tells us nothing about what the storage actually answered. We could not tell whether the read came back as a 200 with the full body, a 5xx, or something else — and those point at completely different causes and fixes.

## Why that question matters right now

#1853 added `accept-encoding: identity` to these media reads, on the documented Cloudflare behaviour that a transformed (compressed) response [loses its `Content-Length`](https://developers.cloudflare.com/speed/optimization/content/compression/) and that a range request against an object with no `Content-Length` is [answered with the full content and an HTTP 200](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/) instead of a 206. The theory was that keeping the response untransformed would keep ranges working.

**The Aug 18 failure happened after that shipped** (#1853 merged 2026-08-07), so the identity header is not sufficient on its own to prevent non-206 answers. Before choosing a next step we need to know which status is actually coming back.

## What this PR changes

The three ranged-read helpers — `SocialAbstract.mediaChunk` and the two bespoke copies, `youtubeChunkStream` and `tiktokChunkStream` — now pass `{status, statusText, ok}` as the `BadBody` json instead of `'{}'`.

That specific argument is what reaches the database: on a `bad_body` the v1.0.6 workflow calls `changeState(postId, 'ERROR', err, postsList)`, which persists the serialized failure — `ApplicationFailure` details included — into `Post.error` and `Errors.message`. (`Errors.body` holds the posts, not the HTTP response, so the json argument is the only place response diagnostics can live.) Next time this fires, the status is readable straight from the row, with no Temporal lookup needed.

The user-facing messages are deliberately unchanged. They are also delivered to the customer through the in-app notification (`An error occurred while posting on <platform>: <message>`), so a raw HTTP status does not belong there. The one message that already contained the status (`mediaChunk`) keeps it as it was.

No classification or retry behaviour changes here — this is only meant to make the next occurrence diagnosable.

# Other information:

- **Next steps once we have data.** If the failures turn out to be 200-with-full-body, the candidate fix is to stop treating that specific answer as a permanent platform rejection: thrown as a plain `Error`, the v1.0.6 workflow re-probes the YouTube upload session and resumes from the exact committed byte offset, with a bounded consecutive-failure budget. That approach was prototyped and verified end to end against a storage server injecting Cloudflare-style 200s (five injected failures during one upload, byte-exact resumes, published in 98 s), and was held back in favour of trying the smaller in-pattern fix first. If instead we see 5xx, [R2 asks clients to retry](https://developers.cloudflare.com/r2/platform/troubleshooting/) and a narrow allowlist would be the natural shape. Either way the decision should follow the observed statuses rather than precede them.
- Still-open follow-ups from #1853, unchanged by this PR: delete `youtubeMediaSize` in favour of `SocialAbstract.mediaSize` (TikTok already uses it, and the generic helper additionally rejects a non-ok HEAD and a zero/NaN length), and consolidate the two bespoke chunk streams into a shared `mediaChunkStream` helper — ranged + streamed is the one shape `SocialAbstract` does not offer, which is why both providers hand-rolled it, and why the identity-header sweep in #1835 missed them.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
