### PR TITLE
fix(youtube): clarify unverified-channel thumbnail error message

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -235,7 +235,7 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
       return {
         type: 'bad-body',
         value:
-          'Your account is not verified, we have uploaded your video but we could not set the thumbnail. Please verify your account and try again.',
+          'Your video was uploaded to YouTube successfully, but we could not set the thumbnail: custom thumbnails require a phone-verified YouTube channel. Verify your channel at youtube.com/verify, and set this video\'s thumbnail manually in YouTube Studio.',
       };
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, YouTube provider error copy). Replaces the message on the `youtube.thumbnail` branch of `YoutubeProvider.handleErrors` with one that states plainly that the video did upload, that custom thumbnails require a phone-verified YouTube channel, and where to act on it (youtube.com/verify, then YouTube Studio to set the thumbnail by hand). This is copy only: the `type: 'bad-body'` classification, the branch ordering and every other branch in `handleErrors` are unchanged.

# Why was this change needed?

A customer scheduled YouTube videos with custom thumbnails on an unverified YouTube channel. In this scenario the video uploads and goes live on YouTube, but the `thumbnails.set` call is rejected (`youtube.thumbnail` 403, custom thumbnails require a phone-verified channel), so Postiz marks the whole post as ERROR.

The mapped message said "Your account is not verified... please verify your account and try again", which reads as the Postiz account or channel connection. The customer saw the video published on YouTube, concluded there was no real error, and tried to fix it by disconnecting, deleting and re-adding the YouTube channel in Postiz, which cannot help. Support also initially misread the cause.

The new text makes three things explicit: the video WAS published, the actual requirement is a phone-verified YouTube channel (youtube.com/verify), and the already-published video's thumbnail can be set manually in YouTube Studio.

# Other information:

The message reaches the in-app (bell) notification and the error email today. The calendar tooltip currently renders the raw workflow-failure JSON; #1868 is the PR that will surface curated messages like this one in the tooltip as well.

# QA

1. [ ] Connect a YouTube channel that is not phone-verified
2. [ ] Schedule a video post to that channel with a custom thumbnail attached
3. [ ] Let it publish - the post moves to ERROR and an in-app notification appears
4. [ ] The notification says the video uploaded successfully and points at youtube.com/verify and YouTube Studio, rather than the old "Your account is not verified" wording
5. [ ] Open YouTube and confirm the video really is present, matching what the message claims
6. [ ] Repeat with a phone-verified channel - the thumbnail is set and no error is raised

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla)
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
