### PR TITLE
fix(integrations): preserve the OAuth refresh token on reconnect

### DIFF
--- a/apps/backend/src/api/routes/no.auth.integrations.controller.ts
+++ b/apps/backend/src/api/routes/no.auth.integrations.controller.ts
@@ -136,7 +136,7 @@ export class NoAuthIntegrationsController {
               refresh,
               auth.accessToken
             );
-            return res({ ...newAuth, refreshToken: body.refresh });
+            return res({ ...newAuth, refreshToken: auth.refreshToken || body.refresh });
           } catch (err: any) {
             return res({
               error: err.message,


### PR DESCRIPTION
### What this fixes

Reconnecting an OAuth channel stores the channel id where the refresh token
should be, so the integration ends up with no usable refresh token. The next
silent refresh fails and the channel has to be reconnected by hand — over and
over. Most visible on YouTube, where the access token lives about an hour.

In `no.auth.integrations.controller.ts`, `authenticate()` has already obtained a
real refresh token from the provider by this point, and the reconnect branch then
discards it:

```ts
const newAuth = await integrationProvider.reConnect(auth.id, refresh, auth.accessToken);
return res({ ...newAuth, refreshToken: body.refresh });   // body.refresh is the channel id
```

`reConnect()` is typed `Promise<Omit<AuthTokenDetails, 'refreshToken' | 'expiresIn'>>`,
so it cannot supply one — but `auth` can, and does.

### The change

```diff
-            return res({ ...newAuth, refreshToken: body.refresh });
+            return res({ ...newAuth, refreshToken: auth.refreshToken || body.refresh });
```

Falls back to the previous value when `authenticate()` returns no refresh token, so
providers that legitimately have none (OAuth1, for example) are unaffected.

### Verification

Self-hosted, YouTube channel, Postiz image built 2026-06-18.

Before: `Integration.refreshToken` length **0**, and YouTube failed roughly an hour
after every reconnect with *"Token expired or invalid, please reconnect your YouTube
account"*. Reconnecting through the UI never changed it.

After applying this one line and reconnecting through the same UI flow:
`Integration.refreshToken` length **103**, `refreshNeeded` cleared itself, and a live
probe of the Google API with the stored credential returns 200. Facebook, Instagram
and TikTok also verified unaffected.

### Notes

Fixes #1595, open since June with several people hitting it. Two of us had
independently arrived at the same monkey patch in that thread; this is the same fix
against `main`, which still contains the line today.

Nothing else is touched — one expression, no schema change, no API change.
