### PR TITLE
fix: anchor recycles to the publish schedule with post.workflow.v1.0.10

### DIFF
--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -25,6 +25,11 @@ import {
 } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
 import { withHeartbeat } from '@gitroom/nestjs-libraries/temporal/temporal.heartbeat';
+import { Context } from '@temporalio/activity';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 import {
   BadBody,
   Disconnect,
@@ -114,7 +119,7 @@ export class PostActivity {
     for (const post of list) {
       await this._temporalService.client
         .getRawClient()
-        .workflow.signalWithStart('postWorkflowV109', {
+        .workflow.signalWithStart('postWorkflowV110', {
           workflowId: `post_${post.id}`,
           taskQueue: 'main',
           signal: 'poke',
@@ -148,6 +153,90 @@ export class PostActivity {
     await this._postService.updatePost(id, postId, releaseURL);
   }
 
+  // Legacy (v1.0.5-v1.0.9) recycle children have a random-suffix workflowId
+  // (post_<id>_<suffix>); the plain post_<id> execution is a pending first
+  // publish and must be left alone.
+  private isLegacyRecycleChild(postId: string) {
+    try {
+      const { workflowType, workflowExecution } = Context.current().info;
+      return (
+        [
+          'postWorkflowV105',
+          'postWorkflowV106',
+          'postWorkflowV107',
+          'postWorkflowV108',
+          'postWorkflowV109',
+        ].includes(workflowType) &&
+        workflowExecution.workflowId.startsWith(`post_${postId}_`)
+      );
+    } catch (err) {
+      return false;
+    }
+  }
+
+  // Hand a legacy recycle chain over to postWorkflowV110: start a scheduled
+  // recycle on the post's own anniversary grid, so the legacy child can
+  // complete without publishing.
+  private async handoffLegacyRecycle(post: any) {
+    if (
+      !post ||
+      post.deletedAt ||
+      post.state !== 'PUBLISHED' ||
+      !post.intervalInDays
+    ) {
+      return;
+    }
+
+    const client = this._temporalService.client.getRawClient();
+
+    // a v1.0.10 chain already owns this post's recycles
+    const running = client.workflow.list({
+      query: `postId="${post.id}" AND ExecutionStatus="Running" AND WorkflowType="postWorkflowV110"`,
+    });
+    for await (const _ of running) {
+      return;
+    }
+
+    // recycle only at publishDate + k*intervalInDays: if the legacy chain was
+    // phase-correct (fired within 2 hours after an anniversary) continue
+    // seamlessly now, otherwise wait for the next anniversary (dissolves batch
+    // bursts). Firing early when the next anniversary is close would publish
+    // twice: the recycle run arms that same anniversary as its successor.
+    const now = dayjs.utc();
+    let next = dayjs.utc(post.publishDate);
+    while (!next.isAfter(now)) {
+      next = next.add(post.intervalInDays, 'day');
+    }
+    const previous = next.subtract(post.intervalInDays, 'day');
+    const nearAnniversary = now.diff(previous, 'hour', true) <= 2;
+
+    await client.workflow.start('postWorkflowV110', {
+      workflowId: `post_${post.id}_recycle`,
+      taskQueue: 'main',
+      workflowIdConflictPolicy: 'USE_EXISTING',
+      args: [
+        {
+          taskQueue: post.integration.providerIdentifier
+            .split('-')[0]
+            .toLowerCase(),
+          postId: post.id,
+          organizationId: post.organizationId,
+          recycleAt: (nearAnniversary ? now : next).toISOString(),
+        },
+      ],
+      typedSearchAttributes: new TypedSearchAttributes([
+        {
+          key: postIdSearchParam,
+          value: post.id,
+        },
+        {
+          key: organizationId,
+          value: post.organizationId,
+        },
+      ]),
+    });
+  }
+
   @ActivityMethod()
   async getPost(orgId: string, postId: string) {
     if (process.env.STRIPE_SECRET_KEY) {
@@ -159,7 +248,16 @@ export class PostActivity {
       }
     }
     const post = await this._postService.getPostById(postId, orgId);
-    if (post.deletedAt) {
+
+    // defuse legacy creation-anchored recycle children at fire time: hand the
+    // chain to postWorkflowV110 first, then let the legacy child take its
+    // "no post -> stop" path without publishing
+    if (this.isLegacyRecycleChild(postId)) {
+      await this.handoffLegacyRecycle(post);
+      return false;
+    }
+
+    if (!post || post.deletedAt) {
       return false;
     }
 
@@ -455,6 +553,13 @@ export class PostActivity {
 
   @ActivityMethod()
   async changeState(id: string, state: State, err?: any, body?: any) {
+    // a legacy recycle child failing (e.g. after the handoff returned "no
+    // post") must never mark the row as ERROR - the row belongs to the
+    // already-completed original publication
+    if (state === 'ERROR' && this.isLegacyRecycleChild(id)) {
+      return;
+    }
+
     await this._postService.changeState(id, state, err, body);
   }
 

--- a/apps/orchestrator/src/workflows/index.ts
+++ b/apps/orchestrator/src/workflows/index.ts
@@ -7,6 +7,7 @@ export * from './post-workflows/post.workflow.v1.0.6';
 export * from './post-workflows/post.workflow.v1.0.7';
 export * from './post-workflows/post.workflow.v1.0.8';
 export * from './post-workflows/post.workflow.v1.0.9';
+export * from './post-workflows/post.workflow.v1.0.10';
 export * from './autopost.workflow';
 export * from './digest.email.workflow';
 export * from './missing.post.workflow';

--- a/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.10.ts
+++ b/apps/orchestrator/src/workflows/post-workflows/post.workflow.v1.0.10.ts
@@ -1,0 +1,731 @@
+import { PostActivity } from '@gitroom/orchestrator/activities/post.activity';
+import {
+  ActivityFailure,
+  ApplicationFailure,
+  startChild,
+  proxyActivities,
+  sleep,
+  defineSignal,
+  setHandler,
+} from '@temporalio/workflow';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { Integration } from '@prisma/client';
+
+dayjs.extend(utc);
+import { capitalize, sortBy } from 'lodash';
+import { PostResponse } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
+import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
+import { TimeoutFailure, TypedSearchAttributes } from '@temporalio/common';
+import { postId as postIdSearchParam } from '@gitroom/nestjs-libraries/temporal/temporal.search.attribute';
+
+const proxyTaskQueue = (taskQueue: string) => {
+  return proxyActivities<PostActivity>({
+    startToCloseTimeout: '10 minute',
+    taskQueue,
+    retry: {
+      maximumAttempts: 3,
+      backoffCoefficient: 1,
+      initialInterval: '2 minutes',
+    },
+  });
+};
+
+// postComment publishes through providers that can legitimately run long
+// (media conversion + upload), so it gets a large time budget. No
+// heartbeatTimeout: heartbeat reporting proved unreliable in production and
+// false heartbeat timeouts retried the activity, which can duplicate a
+// comment. A dead worker is detected by startToCloseTimeout instead.
+const proxyCommentTaskQueue = (taskQueue: string) => {
+  return proxyActivities<PostActivity>({
+    startToCloseTimeout: '30 minute',
+    taskQueue,
+    retry: {
+      maximumAttempts: 3,
+      backoffCoefficient: 1,
+      initialInterval: '2 minutes',
+    },
+  });
+};
+
+// checkPostStatus is a single read-only status call, so it gets a short timeout
+// and fast retries - retrying it can never duplicate a post.
+const proxyCheckTaskQueue = (taskQueue: string) => {
+  return proxyActivities<PostActivity>({
+    startToCloseTimeout: '2 minute',
+    taskQueue,
+    retry: {
+      maximumAttempts: 3,
+      backoffCoefficient: 1,
+      initialInterval: '10 seconds',
+    },
+  });
+};
+
+// postSocialPending / finalizePost run irreversible publishing mutations, so no
+// automatic retries - a retried activity whose previous (timed-out) attempt
+// still completed in the background would publish twice. The workflow retries
+// deliberately, and treats timeouts as "outcome unknown".
+// No heartbeatTimeout: heartbeat reporting proved unreliable in production and
+// a false timeout marks a possibly-live post as unconfirmed, which is far
+// worse than a slow failure. A dead worker is detected by startToCloseTimeout
+// instead.
+const proxyMutationTaskQueue = (taskQueue: string) => {
+  return proxyActivities<PostActivity>({
+    startToCloseTimeout: '30 minute',
+    taskQueue,
+    retry: {
+      maximumAttempts: 1,
+    },
+  });
+};
+
+const {
+  getPostsList,
+  getPost,
+  inAppNotification,
+  changeState,
+  updatePost,
+  sendWebhooks,
+  isCommentable,
+} = proxyActivities<PostActivity>({
+  startToCloseTimeout: '10 minute',
+  retry: {
+    maximumAttempts: 3,
+    backoffCoefficient: 1,
+    initialInterval: '2 minutes',
+  },
+});
+
+const poke = defineSignal('poke');
+
+const iterate = Array.from({ length: 5 });
+
+// ~30 minutes at 20s interval (longer than the old in-activity loop, timers are
+// free). Multi-item flows (stories, chunked uploads) consume several checks per
+// item, so the budget must cover the largest realistic post, not one poll cycle.
+const maxPendingChecks = 90;
+
+export async function postWorkflowV110({
+  taskQueue,
+  postId,
+  organizationId,
+  postNow = false,
+  recycleAt,
+}: {
+  taskQueue: string;
+  postId: string;
+  organizationId: string;
+  postNow?: boolean;
+  // scheduled-recycle mode: republish an already-PUBLISHED interval post at
+  // this time
+  recycleAt?: string;
+}) {
+  // Dynamic task queue, for concurrency
+  const {
+    getIntegrationById,
+    refreshTokenWithCause,
+    internalPlugs,
+    globalPlugs,
+    processInternalPlug,
+    processPlug,
+  } = proxyTaskQueue(taskQueue);
+
+  const { checkPostStatus } = proxyCheckTaskQueue(taskQueue);
+
+  const { postComment } = proxyCommentTaskQueue(taskQueue);
+
+  const { postSocialPending, finalizePost } = proxyMutationTaskQueue(taskQueue);
+
+  let poked = false;
+  setHandler(poke, () => {
+    poked = true;
+  });
+
+  const isRecycle = !!recycleAt;
+
+  // scheduled-recycle mode: wait for the target time before reading the post,
+  // the sleep can span days and the content/settings may change meanwhile
+  if (isRecycle) {
+    await sleep(Math.max(0, dayjs(recycleAt).diff(dayjs(), 'millisecond')));
+  }
+
+  // get all the posts and comments to post
+  const firstPost = await getPost(organizationId, postId);
+
+  // in case doesn't exists for some reason, fail it
+  if (!firstPost) {
+    if (!isRecycle) {
+      await changeState(postId, 'ERROR', 'No Post');
+    }
+    return;
+  }
+
+  // the recurrence was removed, or the row left PUBLISHED (requeued, errored,
+  // drafted), while this recycle was sleeping
+  if (
+    isRecycle &&
+    (!firstPost.intervalInDays || firstPost.state !== 'PUBLISHED')
+  ) {
+    return;
+  }
+
+  // Recycles fire only on the post's own schedule: the first future
+  // publishDate + k*intervalInDays anniversary (k >= 1). UTC mode keeps the
+  // day-stepping identical to the service layer regardless of the server's
+  // timezone/DST.
+  const nextRecycleTime = () => {
+    let next = dayjs.utc(firstPost.publishDate);
+    while (!next.isAfter(dayjs.utc())) {
+      next = next.add(firstPost.intervalInDays, 'day');
+    }
+    return next.toISOString();
+  };
+
+  const armNextRecycle = async () => {
+    await startChild(postWorkflowV110, {
+      parentClosePolicy: 'ABANDON',
+      args: [
+        {
+          taskQueue,
+          postId,
+          organizationId,
+          recycleAt: nextRecycleTime(),
+        },
+      ],
+      workflowId: `post_${postId}_${makeId(10)}`,
+      typedSearchAttributes: new TypedSearchAttributes([
+        {
+          key: postIdSearchParam,
+          value: postId,
+        },
+      ]),
+    });
+  };
+
+  if (!postNow && !isRecycle && firstPost.state !== 'QUEUE') {
+    await changeState(firstPost.id, 'ERROR', 'Already posted', [firstPost]);
+    return;
+  }
+
+  // if it's a repeatable post, we should ignore this.
+  if (!postNow && !isRecycle) {
+    await sleep(
+      dayjs(firstPost.publishDate).isBefore(dayjs())
+        ? 0
+        : dayjs(firstPost.publishDate).diff(dayjs(), 'millisecond')
+    );
+  }
+
+  const postsListBefore = await getPostsList(organizationId, postId);
+  const [post] = postsListBefore;
+
+  if (!post) {
+    if (!isRecycle) {
+      await changeState(postId, 'ERROR', 'No Post');
+    }
+    return;
+  }
+
+  // arm the next occurrence before publishing: a failed recycle must complete
+  // quietly without breaking the chain (the post is confirmed alive above)
+  if (isRecycle) {
+    await armNextRecycle();
+  }
+
+  // if refresh is needed from last time, let's inform the user
+  if (post.integration?.refreshNeeded) {
+    await inAppNotification(
+      post.organizationId,
+      `We couldn't post to ${post.integration?.providerIdentifier} for ${post?.integration?.name}`,
+      `We couldn't post to ${post.integration?.providerIdentifier} for ${post?.integration?.name} because you need to reconnect it. Please enable it and try again.`,
+      true,
+      false,
+      'info'
+    );
+
+    if (!isRecycle) {
+      await changeState(
+        postsListBefore[0].id,
+        'ERROR',
+        'Refresh channel needed',
+        postsListBefore
+      );
+    }
+    return;
+  }
+
+  // if it's disabled, inform the user
+  if (post.integration?.disabled) {
+    await inAppNotification(
+      post.organizationId,
+      `We couldn't post to ${post.integration?.providerIdentifier} for ${post?.integration?.name}`,
+      `We couldn't post to ${post.integration?.providerIdentifier} for ${post?.integration?.name} because it's disabled. Please enable it and try again.`,
+      true,
+      false,
+      'info'
+    );
+
+    if (!isRecycle) {
+      await changeState(
+        postsListBefore[0].id,
+        'ERROR',
+        'Channel disabled',
+        postsListBefore
+      );
+    }
+    return;
+  }
+
+  // Do we need to post comment for this social?
+  const toComment: boolean =
+    postsListBefore.length === 1
+      ? false
+      : await isCommentable(post.integration);
+
+  const postsList = toComment ? postsListBefore : [postsListBefore[0]];
+
+  // list of all the saved results
+  const postsResults: PostResponse[] = [];
+
+  // Every catch block below used to repeat the same failure classification, so
+  // it is centralized here: detect the failure type, refresh the token when
+  // needed, and tell the caller what to do.
+  // 'retry' - the token was refreshed, run the action again
+  // 'stop' - the token could not be refreshed
+  // 'bad-body' - the platform rejected the action
+  // 'timeout' - the activity timed out, its outcome is unknown
+  // 'unknown' - anything else (transient errors)
+  const handleActivityError = async (
+    err: unknown,
+    getIntegration?: () => Promise<any>
+  ): Promise<{
+    type: 'retry' | 'stop' | 'bad-body' | 'timeout' | 'unknown';
+    message: string;
+  }> => {
+    if (
+      err instanceof ActivityFailure &&
+      err.cause instanceof TimeoutFailure
+    ) {
+      return { type: 'timeout', message: '' };
+    }
+
+    const cause =
+      err instanceof ActivityFailure && err.cause instanceof ApplicationFailure
+        ? err.cause
+        : undefined;
+
+    if (cause?.type === 'refresh_token') {
+      const refresh = await refreshTokenWithCause(
+        getIntegration ? await getIntegration() : post.integration,
+        cause.message || ''
+      );
+      if (!refresh || !refresh.accessToken) {
+        return { type: 'stop', message: cause.message || '' };
+      }
+
+      if (!getIntegration) {
+        post.integration.token = refresh.accessToken;
+      }
+
+      return { type: 'retry', message: cause.message || '' };
+    }
+
+    if (cause?.type === 'bad_body') {
+      return { type: 'bad-body', message: cause.message || '' };
+    }
+
+    return { type: 'unknown', message: '' };
+  };
+
+  // The platform may have accepted the post but we can't confirm it was
+  // published - mark the error with a distinct message so the user checks the
+  // account before reposting manually and duplicating it.
+  const markUnconfirmed = async (err: any) => {
+    if (!isRecycle) {
+      await changeState(postsList[0].id, 'ERROR', err, postsList);
+    }
+    await inAppNotification(
+      post.organizationId,
+      `We couldn't confirm your post on ${capitalize(
+        post.integration?.providerIdentifier
+      )}`,
+      `Your post was sent to ${capitalize(
+        post.integration?.providerIdentifier
+      )}, but we couldn't confirm it was published. Please check your ${
+        post?.integration?.name
+      } account before posting again to avoid duplicates.`,
+      true,
+      false,
+      'fail'
+    );
+  };
+
+  // The post/comment was already accepted by the platform but returned as
+  // "pending": poll the read-only status check with durable timers until it
+  // completes. Errors are fully handled here (never rethrown), otherwise they
+  // would bubble to the posting retry loop and re-run the publish.
+  const resolvePending = async (
+    pending: PostResponse
+  ): Promise<PostResponse | false> => {
+    let pendingData = pending.pendingData;
+    let errorAttempts = 0;
+
+    for (let check = 0; check < maxPendingChecks; check++) {
+      try {
+        let result = await checkPostStatus(post.integration, pendingData);
+
+        // commit the check's state BEFORE finalizePost runs: if finalize dies
+        // mid-mutation, the next check must see what it had already authorized,
+        // so providers can detect the interrupted attempt instead of running
+        // the mutation again
+        if (result.status !== 'completed') {
+          pendingData = result.pendingData;
+        }
+
+        // polling is done, run the remaining provider mutations
+        if (result.status === 'ready') {
+          result = await finalizePost(post.integration, result.pendingData);
+        }
+
+        if (result.status === 'completed') {
+          return {
+            id: pending.id,
+            postId: result.postId,
+            releaseURL: result.releaseURL,
+            status: 'success',
+          };
+        }
+
+        pendingData = result.pendingData;
+
+        // a fully successful iteration proves the platform is reachable: the
+        // error budget bounds consecutive failures, not blips accumulated over
+        // a long upload
+        errorAttempts = 0;
+      } catch (err) {
+        const handle = await handleActivityError(err);
+
+        // token refreshed, check again right away
+        if (handle.type === 'retry') {
+          continue;
+        }
+
+        // the token could not be refreshed while checking, but the platform
+        // already accepted the post - warn about a possible live post
+        if (handle.type === 'stop') {
+          await markUnconfirmed(err);
+          return false;
+        }
+
+        // the platform explicitly failed the post, it was not published
+        if (handle.type === 'bad-body') {
+          if (!isRecycle) {
+            await changeState(postsList[0].id, 'ERROR', err, postsList);
+          }
+          await inAppNotification(
+            post.organizationId,
+            `Error posting on ${post.integration?.providerIdentifier} for ${post?.integration?.name}`,
+            `An error occurred while posting on ${
+              post.integration?.providerIdentifier
+            }${handle.message ? `: ${handle.message}` : ``}`,
+            true,
+            false,
+            'fail'
+          );
+          return false;
+        }
+
+        // unknown error on a read-only check, retry a few more times
+        errorAttempts++;
+        if (errorAttempts >= iterate.length) {
+          break;
+        }
+      }
+
+      // the platform is still processing, wait before the next check
+      await sleep('20 seconds');
+    }
+
+    // no verdict from the platform after all the checks
+    await markUnconfirmed('Could not confirm the post status');
+    return false;
+  };
+
+  // iterate over the posts
+  for (let i = 0; i < postsList.length; i++) {
+    const before = postsResults.length;
+    // once the platform accepted the post, the catch below must never retry
+    // the publish - retrying after updatePost / notification errors would
+    // duplicate the post
+    let posted = false;
+    let updated = false;
+    // this is a small trick to repeat an action in case of token refresh
+    for (const _ of iterate) {
+      try {
+        // first post the main post
+        if (i === 0) {
+          postsResults.push(
+            ...(await postSocialPending(post.integration as Integration, [
+              postsList[i],
+            ]))
+          );
+
+          // then post the comments if any
+        } else {
+          if (postsList[i].delay) {
+            await sleep(60000 * Math.max(0, Number(postsList[i].delay ?? 0)));
+          }
+
+          postsResults.push(
+            ...(await postComment(
+              postsResults[0].postId,
+              postsResults.length === 1
+                ? undefined
+                : postsResults[i - 1].postId,
+              post.integration,
+              [postsList[i]]
+            ))
+          );
+        }
+
+        posted = true;
+
+        // the platform accepted the post but is still processing it: resolve
+        // it here before marking anything, resolvePending handles its own
+        // errors so a failed status check can never re-run the publish above
+        if (postsResults[i].status === 'pending') {
+          let resolved: PostResponse | false = false;
+          try {
+            resolved = await resolvePending(postsResults[i]);
+          } catch (err) {
+            // never let a pending-resolution error reach the outer catch, it
+            // would retry the post and duplicate it. Best-effort error state,
+            // otherwise the post stays in QUEUE and the missing-posts sweep
+            // would re-publish it.
+            try {
+              await markUnconfirmed(err);
+            } catch (e) {
+              /**empty**/
+            }
+            resolved = false;
+          }
+          if (!resolved) {
+            return false;
+          }
+          postsResults[i] = resolved;
+        }
+
+        // mark post as successful
+        await updatePost(
+          postsList[i].id,
+          postsResults[i].postId,
+          postsResults[i].releaseURL
+        );
+        updated = true;
+
+        if (i === 0) {
+          // send notification on a sucessful post
+          await inAppNotification(
+            post.integration.organizationId,
+            `Your post has been published on ${capitalize(
+              post.integration.providerIdentifier
+            )}`,
+            `Your post has been published on ${capitalize(
+              post.integration.providerIdentifier
+            )} at ${postsResults[0].releaseURL}`,
+            true,
+            true
+          );
+        }
+
+        // break the current while to move to the next post
+        break;
+      } catch (err) {
+        // the post is already live: never re-run the publish
+        if (posted) {
+          if (!updated) {
+            // still marked QUEUE, record the error so the missing-posts sweep
+            // doesn't re-publish it
+            try {
+              await markUnconfirmed(err);
+            } catch (e) {
+              /**empty**/
+            }
+            return false;
+          }
+
+          // already marked published, a failed notification shouldn't abort
+          // the rest of the flow
+          break;
+        }
+
+        const handle = await handleActivityError(err);
+
+        // token refreshed, repeat the action
+        if (handle.type === 'retry') {
+          continue;
+        }
+
+        // the activity timed out: the platform may still complete the publish
+        // in the background, so never retry it
+        if (handle.type === 'timeout') {
+          try {
+            await markUnconfirmed(err);
+          } catch (e) {
+            /**empty**/
+          }
+          return false;
+        }
+
+        // for other errors, change state and inform the user if needed
+        if (!isRecycle) {
+          await changeState(postsList[0].id, 'ERROR', err, postsList);
+        }
+
+        if (handle.type === 'stop') {
+          return false;
+        }
+
+        // specific case for bad body errors
+        if (handle.type === 'bad-body') {
+          await inAppNotification(
+            post.organizationId,
+            `Error posting${i === 0 ? ' ' : ' comments '}on ${
+              post.integration?.providerIdentifier
+            } for ${post?.integration?.name}`,
+            `An error occurred while posting${i === 0 ? ' ' : ' comments '}on ${
+              post.integration?.providerIdentifier
+            }${handle.message ? `: ${handle.message}` : ``}`,
+            true,
+            false,
+            'fail'
+          );
+          return false;
+        }
+      }
+    }
+
+    if (postsResults.length === before) {
+      // all retries exhausted without success
+      return false;
+    }
+  }
+
+  // send webhooks for the post
+  await sendWebhooks(
+    postsResults[0].postId,
+    post.organizationId,
+    post.integration.id
+  );
+
+  // load internal plugs like repost by other users
+  const internalPlugsList = await internalPlugs(
+    post.integration,
+    JSON.parse(post.settings)
+  );
+
+  // load global plugs, like repost a post if it gets to a certain number of likes
+  const globalPlugsList = (await globalPlugs(post.integration)).reduce(
+    (all, current) => {
+      for (let i = 1; i <= current.totalRuns; i++) {
+        all.push({
+          ...current,
+          delay: current.delay * i,
+        });
+      }
+
+      return all;
+    },
+    []
+  );
+
+  // Check if the post is repeatable. A recycle run already armed the next
+  // occurrence before publishing.
+  const repeatPost =
+    isRecycle || !post.intervalInDays
+      ? []
+      : [
+          {
+            type: 'repeat-post',
+            delay: 0,
+          },
+        ];
+
+  // Sort all the actions by delay, so we can process them in order
+  const list = sortBy(
+    [...internalPlugsList, ...globalPlugsList, ...repeatPost],
+    'delay'
+  );
+
+  // process all the plugs in order, we are using while because in some cases we need to remove items from the list
+  while (list.length > 0) {
+    // get the next to process
+    const todo = list.shift();
+
+    // wait for the delay
+    await sleep(Math.max(0, Number(todo.delay ?? 0)));
+
+    // process internal plug
+    if (todo.type === 'internal-plug') {
+      for (const _ of iterate) {
+        try {
+          await processInternalPlug({ ...todo, post: postsResults[0].postId });
+        } catch (err) {
+          const handle = await handleActivityError(err, () =>
+            getIntegrationById(organizationId, todo.integration)
+          );
+
+          if (handle.type === 'stop' || handle.type === 'bad-body') {
+            break;
+          }
+
+          continue;
+        }
+        break;
+      }
+    }
+
+    // process global plug
+    if (todo.type === 'global') {
+      for (const _ of iterate) {
+        try {
+          const process = await processPlug({
+            ...todo,
+            postId: postsResults[0].postId,
+          });
+          if (process) {
+            const toDelete = list
+              .reduce((all, current, index) => {
+                if (current.plugId === todo.plugId) {
+                  all.push(index);
+                }
+
+                return all;
+              }, [])
+              .reverse();
+
+            for (const index of toDelete) {
+              list.splice(index, 1);
+            }
+          }
+        } catch (err) {
+          const handle = await handleActivityError(err);
+
+          if (handle.type === 'stop' || handle.type === 'bad-body') {
+            break;
+          }
+
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    // process repeat post in a new workflow, this is important so the other plugs can keep running
+    if (todo.type === 'repeat-post') {
+      await armNextRecycle();
+    }
+  }
+}

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -727,7 +727,7 @@ export class PostsService {
     try {
       await this._temporalService.client
         .getRawClient()
-        ?.workflow.start('postWorkflowV109', {
+        ?.workflow.start('postWorkflowV110', {
           workflowId: `post_${postId}`,
           taskQueue: 'main',
           workflowIdConflictPolicy: 'TERMINATE_EXISTING',
@@ -750,6 +750,153 @@ export class PostsService {
           ]),
         });
     } catch (err) {}
+  }
+
+  // Recycles fire only on the post's own schedule: the first future
+  // publishDate + k*intervalInDays anniversary.
+  private nextRecycleTime(post: { publishDate: Date; intervalInDays: number }) {
+    let next = dayjs.utc(post.publishDate);
+    while (!next.isAfter(dayjs.utc())) {
+      next = next.add(post.intervalInDays, 'day');
+    }
+    return next.toISOString();
+  }
+
+  // Start a postWorkflowV110 scheduled recycle for an already published
+  // recurring post (sleeps until recycleAt, then republishes).
+  private async startRecycleWorkflow(
+    taskQueue: string,
+    postId: string,
+    orgId: string,
+    recycleAt: string
+  ) {
+    try {
+      await this._temporalService.client
+        .getRawClient()
+        ?.workflow.start('postWorkflowV110', {
+          workflowId: `post_${postId}_recycle`,
+          taskQueue: 'main',
+          workflowIdConflictPolicy: 'USE_EXISTING',
+          args: [
+            {
+              taskQueue,
+              postId,
+              organizationId: orgId,
+              recycleAt,
+            },
+          ],
+          typedSearchAttributes: new TypedSearchAttributes([
+            {
+              key: postIdSearchParam,
+              value: postId,
+            },
+            {
+              key: organizationId,
+              value: orgId,
+            },
+          ]),
+        });
+    } catch (err) {}
+  }
+
+  // Returns false when a running workflow may have survived - the caller must
+  // not arm a replacement then, or the post would have two concurrent chains.
+  private async terminatePostWorkflows(postId: string) {
+    try {
+      const workflows = this._temporalService.client
+        .getRawClient()
+        ?.workflow.list({
+          query: `postId="${postId}" AND ExecutionStatus="Running"`,
+        });
+
+      for await (const executionInfo of workflows) {
+        try {
+          const workflow = await this._temporalService.client.getWorkflowHandle(
+            executionInfo.workflowId
+          );
+          if (
+            workflow &&
+            (await workflow.describe()).status.name !== 'TERMINATED'
+          ) {
+            await workflow.terminate();
+          }
+        } catch (err) {
+          return false;
+        }
+      }
+    } catch (err) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private async hasRunningPostWorkflow(postId: string) {
+    try {
+      const workflows = this._temporalService.client
+        .getRawClient()
+        ?.workflow.list({
+          query: `postId="${postId}" AND ExecutionStatus="Running"`,
+        });
+
+      for await (const _ of workflows) {
+        return true;
+      }
+    } catch (err) {}
+    return false;
+  }
+
+  // Saving a PUBLISHED recurring post must never requeue it (that would
+  // republish immediately): reconcile the armed recycle workflow instead.
+  private async reconcileRecycleWorkflow(
+    taskQueue: string,
+    orgId: string,
+    before: { publishDate: Date; intervalInDays: number | null },
+    after: { id: string; publishDate: Date; intervalInDays: number | null }
+  ) {
+    const removed = !after.intervalInDays;
+    const scheduleChanged =
+      dayjs.utc(before.publishDate).toISOString() !==
+        dayjs.utc(after.publishDate).toISOString() ||
+      before.intervalInDays !== after.intervalInDays;
+
+    if (removed) {
+      // the armed sleeper would still fire, clearing the interval alone does
+      // not stop it (recycle runs re-read the row and stop quietly, legacy
+      // children are defused, but terminating now avoids the extra wake)
+      await this.terminatePostWorkflows(after.id);
+      return;
+    }
+
+    if (scheduleChanged) {
+      // if termination failed, keep the old chain instead of arming a second
+      // one: v1.0.10 sleepers re-read the row at wake, and a later save
+      // self-heals onto the new schedule
+      if (!(await this.terminatePostWorkflows(after.id))) {
+        return;
+      }
+      await this.startRecycleWorkflow(
+        taskQueue,
+        after.id,
+        orgId,
+        this.nextRecycleTime(
+          after as { publishDate: Date; intervalInDays: number }
+        )
+      );
+      return;
+    }
+
+    // schedule untouched: leave the armed recycle alone, self-heal if it's gone
+    if (!(await this.hasRunningPostWorkflow(after.id))) {
+      await this.startRecycleWorkflow(
+        taskQueue,
+        after.id,
+        orgId,
+        this.nextRecycleTime(
+          after as { publishDate: Date; intervalInDays: number }
+        )
+      );
+    }
   }
 
   /**
@@ -935,8 +1082,19 @@ export class PostsService {
         content: removeLinks ? stripLinks(updateContent[i]) : updateContent[i],
       }));
 
+      // a save touching a PUBLISHED recurring post updates content/settings
+      // without requeueing it - reconcile the recycle workflow instead. The
+      // explicit republish opt-in keeps the normal requeue-and-publish path.
+      const existingPost = post.value?.[0]?.id
+        ? await this._postRepository.getPostById(post.value[0].id, orgId)
+        : null;
+      const publishedRecurring =
+        existingPost?.state === 'PUBLISHED' &&
+        !!existingPost.intervalInDays &&
+        !body.republish;
+
       const { posts } = await this._postRepository.createOrUpdatePost(
-        body.type,
+        publishedRecurring ? 'update' : body.type,
         orgId,
         body.type === 'now' ? dayjs().format('YYYY-MM-DDTHH:mm:00') : body.date,
         post,
@@ -950,7 +1108,14 @@ export class PostsService {
         return [] as any[];
       }
 
-      if (body.type !== 'update') {
+      if (publishedRecurring) {
+        await this.reconcileRecycleWorkflow(
+          post.settings.__type.split('-')[0].toLowerCase(),
+          orgId,
+          existingPost,
+          posts[0]
+        );
+      } else if (body.type !== 'update') {
         this.startWorkflow(
           post.settings.__type.split('-')[0].toLowerCase(),
           posts[0].id,
@@ -1160,6 +1325,33 @@ export class PostsService {
 
     if (action === 'schedule' && !republish) {
       this.guardAgainstRepublish(getPostById, 'changeDate');
+    }
+
+    // an update-type date change on a PUBLISHED recurring post redefines the
+    // recurrence grid: move the date and re-arm the recycle workflow on the
+    // new schedule. The explicit republish opt-in keeps the normal
+    // requeue-and-publish path.
+    if (
+      getPostById.state === 'PUBLISHED' &&
+      getPostById.intervalInDays &&
+      !republish
+    ) {
+      const newDate = await this._postRepository.changeDate(
+        orgId,
+        id,
+        date,
+        false,
+        'update'
+      );
+
+      await this.reconcileRecycleWorkflow(
+        getPostById.integration.providerIdentifier.split('-')[0].toLowerCase(),
+        orgId,
+        getPostById,
+        newDate
+      );
+
+      return newDate;
     }
 
     // schedule: Set status to QUEUE and change date (reschedule the post)

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -752,153 +752,6 @@ export class PostsService {
     } catch (err) {}
   }
 
-  // Recycles fire only on the post's own schedule: the first future
-  // publishDate + k*intervalInDays anniversary.
-  private nextRecycleTime(post: { publishDate: Date; intervalInDays: number }) {
-    let next = dayjs.utc(post.publishDate);
-    while (!next.isAfter(dayjs.utc())) {
-      next = next.add(post.intervalInDays, 'day');
-    }
-    return next.toISOString();
-  }
-
-  // Start a postWorkflowV110 scheduled recycle for an already published
-  // recurring post (sleeps until recycleAt, then republishes).
-  private async startRecycleWorkflow(
-    taskQueue: string,
-    postId: string,
-    orgId: string,
-    recycleAt: string
-  ) {
-    try {
-      await this._temporalService.client
-        .getRawClient()
-        ?.workflow.start('postWorkflowV110', {
-          workflowId: `post_${postId}_recycle`,
-          taskQueue: 'main',
-          workflowIdConflictPolicy: 'USE_EXISTING',
-          args: [
-            {
-              taskQueue,
-              postId,
-              organizationId: orgId,
-              recycleAt,
-            },
-          ],
-          typedSearchAttributes: new TypedSearchAttributes([
-            {
-              key: postIdSearchParam,
-              value: postId,
-            },
-            {
-              key: organizationId,
-              value: orgId,
-            },
-          ]),
-        });
-    } catch (err) {}
-  }
-
-  // Returns false when a running workflow may have survived - the caller must
-  // not arm a replacement then, or the post would have two concurrent chains.
-  private async terminatePostWorkflows(postId: string) {
-    try {
-      const workflows = this._temporalService.client
-        .getRawClient()
-        ?.workflow.list({
-          query: `postId="${postId}" AND ExecutionStatus="Running"`,
-        });
-
-      for await (const executionInfo of workflows) {
-        try {
-          const workflow = await this._temporalService.client.getWorkflowHandle(
-            executionInfo.workflowId
-          );
-          if (
-            workflow &&
-            (await workflow.describe()).status.name !== 'TERMINATED'
-          ) {
-            await workflow.terminate();
-          }
-        } catch (err) {
-          return false;
-        }
-      }
-    } catch (err) {
-      return false;
-    }
-
-    return true;
-  }
-
-  private async hasRunningPostWorkflow(postId: string) {
-    try {
-      const workflows = this._temporalService.client
-        .getRawClient()
-        ?.workflow.list({
-          query: `postId="${postId}" AND ExecutionStatus="Running"`,
-        });
-
-      for await (const _ of workflows) {
-        return true;
-      }
-    } catch (err) {}
-    return false;
-  }
-
-  // Saving a PUBLISHED recurring post must never requeue it (that would
-  // republish immediately): reconcile the armed recycle workflow instead.
-  private async reconcileRecycleWorkflow(
-    taskQueue: string,
-    orgId: string,
-    before: { publishDate: Date; intervalInDays: number | null },
-    after: { id: string; publishDate: Date; intervalInDays: number | null }
-  ) {
-    const removed = !after.intervalInDays;
-    const scheduleChanged =
-      dayjs.utc(before.publishDate).toISOString() !==
-        dayjs.utc(after.publishDate).toISOString() ||
-      before.intervalInDays !== after.intervalInDays;
-
-    if (removed) {
-      // the armed sleeper would still fire, clearing the interval alone does
-      // not stop it (recycle runs re-read the row and stop quietly, legacy
-      // children are defused, but terminating now avoids the extra wake)
-      await this.terminatePostWorkflows(after.id);
-      return;
-    }
-
-    if (scheduleChanged) {
-      // if termination failed, keep the old chain instead of arming a second
-      // one: v1.0.10 sleepers re-read the row at wake, and a later save
-      // self-heals onto the new schedule
-      if (!(await this.terminatePostWorkflows(after.id))) {
-        return;
-      }
-      await this.startRecycleWorkflow(
-        taskQueue,
-        after.id,
-        orgId,
-        this.nextRecycleTime(
-          after as { publishDate: Date; intervalInDays: number }
-        )
-      );
-      return;
-    }
-
-    // schedule untouched: leave the armed recycle alone, self-heal if it's gone
-    if (!(await this.hasRunningPostWorkflow(after.id))) {
-      await this.startRecycleWorkflow(
-        taskQueue,
-        after.id,
-        orgId,
-        this.nextRecycleTime(
-          after as { publishDate: Date; intervalInDays: number }
-        )
-      );
-    }
-  }
-
   /**
    * Server-side validation that used to live on the client (`checkValidity` +
    * the manage modal loop). Runs the provider's settings DTO validation, the
@@ -1082,19 +935,8 @@ export class PostsService {
         content: removeLinks ? stripLinks(updateContent[i]) : updateContent[i],
       }));
 
-      // a save touching a PUBLISHED recurring post updates content/settings
-      // without requeueing it - reconcile the recycle workflow instead. The
-      // explicit republish opt-in keeps the normal requeue-and-publish path.
-      const existingPost = post.value?.[0]?.id
-        ? await this._postRepository.getPostById(post.value[0].id, orgId)
-        : null;
-      const publishedRecurring =
-        existingPost?.state === 'PUBLISHED' &&
-        !!existingPost.intervalInDays &&
-        !body.republish;
-
       const { posts } = await this._postRepository.createOrUpdatePost(
-        publishedRecurring ? 'update' : body.type,
+        body.type,
         orgId,
         body.type === 'now' ? dayjs().format('YYYY-MM-DDTHH:mm:00') : body.date,
         post,
@@ -1108,14 +950,7 @@ export class PostsService {
         return [] as any[];
       }
 
-      if (publishedRecurring) {
-        await this.reconcileRecycleWorkflow(
-          post.settings.__type.split('-')[0].toLowerCase(),
-          orgId,
-          existingPost,
-          posts[0]
-        );
-      } else if (body.type !== 'update') {
+      if (body.type !== 'update') {
         this.startWorkflow(
           post.settings.__type.split('-')[0].toLowerCase(),
           posts[0].id,
@@ -1325,33 +1160,6 @@ export class PostsService {
 
     if (action === 'schedule' && !republish) {
       this.guardAgainstRepublish(getPostById, 'changeDate');
-    }
-
-    // an update-type date change on a PUBLISHED recurring post redefines the
-    // recurrence grid: move the date and re-arm the recycle workflow on the
-    // new schedule. The explicit republish opt-in keeps the normal
-    // requeue-and-publish path.
-    if (
-      getPostById.state === 'PUBLISHED' &&
-      getPostById.intervalInDays &&
-      !republish
-    ) {
-      const newDate = await this._postRepository.changeDate(
-        orgId,
-        id,
-        date,
-        false,
-        'update'
-      );
-
-      await this.reconcileRecycleWorkflow(
-        getPostById.integration.providerIdentifier.split('-')[0].toLowerCase(),
-        orgId,
-        getPostById,
-        newDate
-      );
-
-      return newDate;
     }
 
     // schedule: Set status to QUEUE and change date (reschedule the post)


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix. Replaces PR #1840 (see below).

# Why was this change needed?

Recurring (intervalInDays) posts recycle at workflowStart + interval instead of publishDate + k*interval. Every post created in one session re-fires at that session's anniversary: batches created together burst together, at the wrong time of day. Two production customer incidents in July 2026 were traced to this — one customer (Instagram/Facebook via API) had two batches of recurring posts burst-republish simultaneously on their creation anniversaries; another (Reddit, 18 weekly posts created in one sitting) had the whole batch re-fire together weekly, which got their Reddit account history deleted.

This PR:

- Adds `postWorkflowV110` (built on v1.0.9's content): after the first publish it arms a scheduled-recycle child carrying an absolute `recycleAt` = the next `publishDate + k*intervalInDays` anniversary (UTC day-stepping, DST-safe). A recycle run sleeps until `recycleAt`, re-reads the row (stops quietly if the recurrence was removed or the row left PUBLISHED), arms the next anniversary before publishing so a failed recycle never breaks the chain, then publishes. Failed recycles complete quietly and never flip the already-published row to ERROR.
- Lazily defuses in-flight legacy sleepers (v1.0.5 through v1.0.9 all recycle from workflow start — no migration script needed): at fire time, `getPost` detects a legacy recycle child, hands the chain to a v1.0.10 scheduled recycle on the post's own anniversary grid (continuing immediately only within 2h after an anniversary, otherwise waiting for the next one — this dissolves existing batch bursts), and the legacy child completes without publishing. `changeState` refuses ERROR from legacy recycle children so the defusal never marks published rows as failed.
Saving-a-published-recurring-post reconciliation (terminate/re-arm/self-heal of the armed recycle on save) was split into #1940, stacked on this PR, to keep this one focused on the anchoring fix and the legacy handoff.

## Replaces #1840

Main gained v1.0.7–v1.0.9 since #1840 was opened, colliding with its workflow file, and the scope changed: this PR intentionally does NOT preserve the first publication's releaseURL/releaseId on recycles (each recycle updates the row as today) — which publication the row should represent is a separate product question. See #1840 for the original review history and incident forensics.

# Other information:

Tested with a 31-assertion harness against a local Temporal server running the real workflow bundle and the real activity handoff code. The bug was reproduced on v1.0.9 (repeat timer measured at ~24h from workflow start instead of the 22.5h-away publishDate anniversary) and verified fixed on v1.0.10: exact-anniversary arming, quiet failure with chain survival, legacy v1.0.6 and v1.0.9 children defused and handed off on the exact anniversary, phase-correct chains continuing seamlessly, near-next-anniversary handoffs waiting (double-publish guard), and no handoff for non-PUBLISHED rows or removed recurrences. The predecessor branch was additionally verified end to end with a real recycle publish to a connected Instagram channel.

The handoff code becomes dead one interval-cycle after deploy (every legacy chain is defused at its next fire) and can be removed in a follow-up.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyaUTm8jY9gRgETfVYgvMm
