### PR TITLE
feat: reconcile the recycle workflow when saving a published recurring post

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -752,6 +752,153 @@ export class PostsService {
     } catch (err) {}
   }
 
+  // Recycles fire only on the post's own schedule: the first future
+  // publishDate + k*intervalInDays anniversary.
+  private nextRecycleTime(post: { publishDate: Date; intervalInDays: number }) {
+    let next = dayjs.utc(post.publishDate);
+    while (!next.isAfter(dayjs.utc())) {
+      next = next.add(post.intervalInDays, 'day');
+    }
+    return next.toISOString();
+  }
+
+  // Start a postWorkflowV110 scheduled recycle for an already published
+  // recurring post (sleeps until recycleAt, then republishes).
+  private async startRecycleWorkflow(
+    taskQueue: string,
+    postId: string,
+    orgId: string,
+    recycleAt: string
+  ) {
+    try {
+      await this._temporalService.client
+        .getRawClient()
+        ?.workflow.start('postWorkflowV110', {
+          workflowId: `post_${postId}_recycle`,
+          taskQueue: 'main',
+          workflowIdConflictPolicy: 'USE_EXISTING',
+          args: [
+            {
+              taskQueue,
+              postId,
+              organizationId: orgId,
+              recycleAt,
+            },
+          ],
+          typedSearchAttributes: new TypedSearchAttributes([
+            {
+              key: postIdSearchParam,
+              value: postId,
+            },
+            {
+              key: organizationId,
+              value: orgId,
+            },
+          ]),
+        });
+    } catch (err) {}
+  }
+
+  // Returns false when a running workflow may have survived - the caller must
+  // not arm a replacement then, or the post would have two concurrent chains.
+  private async terminatePostWorkflows(postId: string) {
+    try {
+      const workflows = this._temporalService.client
+        .getRawClient()
+        ?.workflow.list({
+          query: `postId="${postId}" AND ExecutionStatus="Running"`,
+        });
+
+      for await (const executionInfo of workflows) {
+        try {
+          const workflow = await this._temporalService.client.getWorkflowHandle(
+            executionInfo.workflowId
+          );
+          if (
+            workflow &&
+            (await workflow.describe()).status.name !== 'TERMINATED'
+          ) {
+            await workflow.terminate();
+          }
+        } catch (err) {
+          return false;
+        }
+      }
+    } catch (err) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private async hasRunningPostWorkflow(postId: string) {
+    try {
+      const workflows = this._temporalService.client
+        .getRawClient()
+        ?.workflow.list({
+          query: `postId="${postId}" AND ExecutionStatus="Running"`,
+        });
+
+      for await (const _ of workflows) {
+        return true;
+      }
+    } catch (err) {}
+    return false;
+  }
+
+  // Saving a PUBLISHED recurring post must never requeue it (that would
+  // republish immediately): reconcile the armed recycle workflow instead.
+  private async reconcileRecycleWorkflow(
+    taskQueue: string,
+    orgId: string,
+    before: { publishDate: Date; intervalInDays: number | null },
+    after: { id: string; publishDate: Date; intervalInDays: number | null }
+  ) {
+    const removed = !after.intervalInDays;
+    const scheduleChanged =
+      dayjs.utc(before.publishDate).toISOString() !==
+        dayjs.utc(after.publishDate).toISOString() ||
+      before.intervalInDays !== after.intervalInDays;
+
+    if (removed) {
+      // the armed sleeper would still fire, clearing the interval alone does
+      // not stop it (recycle runs re-read the row and stop quietly, legacy
+      // children are defused, but terminating now avoids the extra wake)
+      await this.terminatePostWorkflows(after.id);
+      return;
+    }
+
+    if (scheduleChanged) {
+      // if termination failed, keep the old chain instead of arming a second
+      // one: v1.0.10 sleepers re-read the row at wake, and a later save
+      // self-heals onto the new schedule
+      if (!(await this.terminatePostWorkflows(after.id))) {
+        return;
+      }
+      await this.startRecycleWorkflow(
+        taskQueue,
+        after.id,
+        orgId,
+        this.nextRecycleTime(
+          after as { publishDate: Date; intervalInDays: number }
+        )
+      );
+      return;
+    }
+
+    // schedule untouched: leave the armed recycle alone, self-heal if it's gone
+    if (!(await this.hasRunningPostWorkflow(after.id))) {
+      await this.startRecycleWorkflow(
+        taskQueue,
+        after.id,
+        orgId,
+        this.nextRecycleTime(
+          after as { publishDate: Date; intervalInDays: number }
+        )
+      );
+    }
+  }
+
   /**
    * Server-side validation that used to live on the client (`checkValidity` +
    * the manage modal loop). Runs the provider's settings DTO validation, the
@@ -935,8 +1082,19 @@ export class PostsService {
         content: removeLinks ? stripLinks(updateContent[i]) : updateContent[i],
       }));
 
+      // a save touching a PUBLISHED recurring post updates content/settings
+      // without requeueing it - reconcile the recycle workflow instead. The
+      // explicit republish opt-in keeps the normal requeue-and-publish path.
+      const existingPost = post.value?.[0]?.id
+        ? await this._postRepository.getPostById(post.value[0].id, orgId)
+        : null;
+      const publishedRecurring =
+        existingPost?.state === 'PUBLISHED' &&
+        !!existingPost.intervalInDays &&
+        !body.republish;
+
       const { posts } = await this._postRepository.createOrUpdatePost(
-        body.type,
+        publishedRecurring ? 'update' : body.type,
         orgId,
         body.type === 'now' ? dayjs().format('YYYY-MM-DDTHH:mm:00') : body.date,
         post,
@@ -950,7 +1108,14 @@ export class PostsService {
         return [] as any[];
       }
 
-      if (body.type !== 'update') {
+      if (publishedRecurring) {
+        await this.reconcileRecycleWorkflow(
+          post.settings.__type.split('-')[0].toLowerCase(),
+          orgId,
+          existingPost,
+          posts[0]
+        );
+      } else if (body.type !== 'update') {
         this.startWorkflow(
           post.settings.__type.split('-')[0].toLowerCase(),
           posts[0].id,
@@ -1160,6 +1325,33 @@ export class PostsService {
 
     if (action === 'schedule' && !republish) {
       this.guardAgainstRepublish(getPostById, 'changeDate');
+    }
+
+    // an update-type date change on a PUBLISHED recurring post redefines the
+    // recurrence grid: move the date and re-arm the recycle workflow on the
+    // new schedule. The explicit republish opt-in keeps the normal
+    // requeue-and-publish path.
+    if (
+      getPostById.state === 'PUBLISHED' &&
+      getPostById.intervalInDays &&
+      !republish
+    ) {
+      const newDate = await this._postRepository.changeDate(
+        orgId,
+        id,
+        date,
+        false,
+        'update'
+      );
+
+      await this.reconcileRecycleWorkflow(
+        getPostById.integration.providerIdentifier.split('-')[0].toLowerCase(),
+        orgId,
+        getPostById,
+        newDate
+      );
+
+      return newDate;
     }
 
     // schedule: Set status to QUEUE and change date (reschedule the post)


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature / bug fix. Split out of #1936 (stacked on it — base is `fix/recurring-recycle-workflow-v2`; merge #1936 first).

# Why was this change needed?

With #1936, an already published recurring post has a scheduled recycle workflow armed at its next `publishDate + k*intervalInDays` anniversary. Saving the post could silently diverge from that armed timer: removing the recurrence left the sleeper armed (it would wake later and republish invisibly), changing the date or interval left it firing on the old schedule, and a post whose chain was manually terminated had no way to get one back.

This PR makes saving a PUBLISHED recurring post reconcile the armed recycle workflow instead of requeueing the post:

- Recurrence removed → the armed sleeper is terminated.
- Schedule (date or interval) changed → terminate and re-arm on the next anniversary of the new schedule. Arming is skipped when termination may have failed, so a post can never run two concurrent chains; v1.0.10 sleepers re-read the row at wake and a later save self-heals onto the new schedule.
- Schedule unchanged → the armed recycle is left alone; if it's missing, it is re-armed (self-heal — this is also how posts whose workflows were manually terminated recover).

Saves and update-type date changes on published recurring posts are forced onto the update path so they never requeue-and-republish. The explicit `republish` opt-in (#1841) keeps the requeue-and-publish path.

# Other information:

The reconcile logic was verified on the predecessor branch of #1936 with service-layer harness assertions against a local Temporal server: terminate-on-removal, terminate-and-re-arm-on-schedule-change (including the no-double-chain guard when termination fails), and self-heal of a missing chain. Builds pass (the backend build failure on the base commit is the pre-existing apple.provider.ts typing issue, already fixed on main).

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyaUTm8jY9gRgETfVYgvMm
