### PR TITLE
feat: add immutable publication attempt evidence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,9 @@ NEXT_PUBLIC_DISCORD_SUPPORT=""
 NEXT_PUBLIC_POLOTNO=""
 # NOT_SECURED=false
 API_LIMIT=30 # The limit of the public API hour limit
+# At least 32 bytes. Required before publishing a public API post carrying
+# X-Postify-Correlation-Id; signs immutable publication-attempt evidence.
+POSTIZ_PUBLICATION_EVIDENCE_HMAC_KEY=""
 
 # When connecting providers that take a self-hosted URL (WordPress, Mastodon,
 # Lemmy, Listmonk, Bluesky PDS, etc.) Postiz fetches that URL server-side and

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Headers,
   HttpException,
   Param,
   Post,
@@ -66,6 +67,7 @@ import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/us
 import { SuperAdminGuard } from '@gitroom/backend/services/auth/super.admin.guard';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
+import { canonicalSha256 } from '@gitroom/nestjs-libraries/database/prisma/publication-attempt/publication-attempt.evidence';
 
 @ApiTags('Public API')
 @Controller('/public/v1')
@@ -192,7 +194,8 @@ export class PublicIntegrationsController {
   @CheckPolicies([AuthorizationActions.Create, Sections.POSTS_PER_MONTH])
   async createPost(
     @GetOrgFromRequest() org: Organization,
-    @Body() rawBody: any
+    @Body() rawBody: any,
+    @Headers('x-postify-correlation-id') postifyCorrelationId?: string
   ) {
     Sentry.metrics.count('public_api-request', 1);
     const body = await this._postsService.mapTypeToPost(
@@ -265,7 +268,26 @@ export class PublicIntegrationsController {
       ? (rawBody.creationMethod as 'CLI' | 'API')
       : 'API';
 
-    return this._postsService.createPost(org.id, body, creationMethod);
+    const correlationId = postifyCorrelationId?.trim();
+    if (
+      correlationId &&
+      !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/.test(correlationId)
+    ) {
+      throw new HttpException({ msg: 'Invalid X-Postify-Correlation-Id' }, 400);
+    }
+
+    return this._postsService.createPost(
+      org.id,
+      body,
+      creationMethod,
+      false,
+      correlationId
+        ? {
+            correlationId,
+            requestHash: canonicalSha256({ body, creationMethod }),
+          }
+        : undefined
+    );
   }
 
   @Delete('/posts/:id')

--- a/apps/orchestrator/src/activities/post.activity.publication-attempt.spec.ts
+++ b/apps/orchestrator/src/activities/post.activity.publication-attempt.spec.ts
@@ -1,0 +1,105 @@
+import { Context } from '@temporalio/activity';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PostActivity } from './post.activity';
+
+describe('PostActivity publication evidence boundary', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does not invoke the provider when pre-provider evidence persistence fails', async () => {
+    vi.spyOn(Context, 'current').mockReturnValue({
+      info: {
+        workflowExecution: { workflowId: 'workflow-1', runId: 'run-1' },
+        activityId: 'activity-1',
+        activityType: 'postSocialPending',
+        attempt: 1,
+      },
+    } as never);
+    const providerPost = vi.fn();
+    const postService = {
+      updateTags: vi.fn().mockResolvedValue([
+        {
+          id: 'post-1',
+          content: 'approved caption',
+          settings: '{}',
+          image: '[]',
+        },
+      ]),
+      updateMedia: vi.fn().mockResolvedValue([]),
+    };
+    const integrationManager = {
+      getSocialIntegration: vi.fn().mockReturnValue({
+        editor: 'normal',
+        mentionFormat: undefined,
+        post: providerPost,
+      }),
+    };
+    const publicationAttemptService = {
+      beginPublicationAttempt: vi
+        .fn()
+        .mockRejectedValue(new Error('evidence database unavailable')),
+    };
+    const activity = new PostActivity(
+      postService as never,
+      {} as never,
+      integrationManager as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      publicationAttemptService as never
+    );
+
+    await expect(
+      (activity as any).postSocialBody(
+        {
+          id: 'integration-1',
+          internalId: 'account-1',
+          organizationId: 'org-1',
+          customerId: 'customer-1',
+          providerIdentifier: 'example',
+          token: 'provider-token',
+        },
+        [{ id: 'post-1' }],
+        false
+      )
+    ).rejects.toThrow('evidence database unavailable');
+    expect(providerPost).not.toHaveBeenCalled();
+  });
+
+  it('does not downgrade a committed success after an ambiguous activity timeout', async () => {
+    vi.spyOn(Context, 'current').mockReturnValue({
+      info: {
+        workflowExecution: { workflowId: 'workflow-1', runId: 'run-1' },
+        activityId: 'change-state-1',
+        activityType: 'changeState',
+        attempt: 1,
+      },
+    } as never);
+    const postService = { changeState: vi.fn() };
+    const publicationAttemptService = {
+      isCorrelatedPost: vi.fn().mockResolvedValue(true),
+      markOpenAttemptTerminal: vi.fn().mockResolvedValue(false),
+      hasProviderReportedSuccess: vi.fn().mockResolvedValue(true),
+    };
+    const activity = new PostActivity(
+      postService as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      publicationAttemptService as never
+    );
+
+    await activity.changeState(
+      'post-1',
+      'ERROR',
+      new Error('activity timed out')
+    );
+
+    expect(postService.changeState).not.toHaveBeenCalled();
+  });
+});

--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -29,6 +29,12 @@ import {
   BadBody,
   Disconnect,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import { ApplicationFailure, Context } from '@temporalio/activity';
+import { PublicationAttemptEventType } from '@prisma/client';
+import {
+  PublicationAttemptService,
+  TemporalAttemptIdentity,
+} from '@gitroom/nestjs-libraries/database/prisma/publication-attempt/publication-attempt.service';
 
 // Drops fields the workflow and downstream activities never read — biggest wins are `error` (grows per retry) and `childrenPost` (Prisma side-loads it on every recursive row).
 function slimPost(post: any) {
@@ -55,6 +61,17 @@ function slimPost(post: any) {
     ...rest
   } = post;
   return rest;
+}
+
+function serializedFailureType(error: unknown): string {
+  let current = error as { type?: unknown; cause?: unknown } | undefined;
+  for (let depth = 0; current && depth < 5; depth++) {
+    if (current.type) {
+      return String(current.type);
+    }
+    current = current.cause as typeof current;
+  }
+  return '';
 }
 
 // A genuinely missed occurrence (dead workflow) is only recovered by the
@@ -100,8 +117,20 @@ export class PostActivity {
     private _refreshIntegrationService: RefreshIntegrationService,
     private _webhookService: WebhooksService,
     private _temporalService: TemporalService,
-    private _subscriptionService: SubscriptionService
+    private _subscriptionService: SubscriptionService,
+    private _publicationAttemptService: PublicationAttemptService
   ) {}
+
+  private activityIdentity(): TemporalAttemptIdentity {
+    const info = Context.current().info;
+    return {
+      workflowId: info.workflowExecution.workflowId,
+      runId: info.workflowExecution.runId,
+      activityId: info.activityId,
+      activityType: info.activityType,
+      attempt: info.attempt,
+    };
+  }
 
   @ActivityMethod()
   async getIntegrationById(orgId: string, id: string) {
@@ -145,6 +174,17 @@ export class PostActivity {
 
   @ActivityMethod()
   async updatePost(id: string, postId: string, releaseURL: string) {
+    const identity = this.activityIdentity();
+    if (
+      await this._publicationAttemptService.completeFromWorkflow(
+        id,
+        postId,
+        releaseURL,
+        identity
+      )
+    ) {
+      return;
+    }
     await this._postService.updatePost(id, postId, releaseURL);
   }
 
@@ -362,20 +402,77 @@ export class PostActivity {
       }))
     );
 
-    const postNow =
-      allowPending && getIntegration.postPending
-        ? await getIntegration.postPending(
-            integration.internalId,
-            integration.token,
-            mappedPosts,
-            integration
-          )
-        : await getIntegration.post(
-            integration.internalId,
-            integration.token,
-            mappedPosts,
-            integration
-          );
+    const publicationAttempt =
+      await this._publicationAttemptService.beginPublicationAttempt({
+        integration,
+        mappedPosts,
+        identity: this.activityIdentity(),
+      });
+    if (publicationAttempt.action === 'replay-success') {
+      return publicationAttempt.result;
+    }
+    if (publicationAttempt.action === 'outcome-unknown') {
+      throw new ApplicationFailure(
+        'A previous provider call may have completed; refusing to publish again',
+        'publication_outcome_unknown',
+        true
+      );
+    }
+
+    let postNow;
+    try {
+      postNow =
+        allowPending && getIntegration.postPending
+          ? await getIntegration.postPending(
+              integration.internalId,
+              integration.token,
+              mappedPosts,
+              integration
+            )
+          : await getIntegration.post(
+              integration.internalId,
+              integration.token,
+              mappedPosts,
+              integration
+            );
+    } catch (error) {
+      if (publicationAttempt.action === 'execute') {
+        const explicit = ['bad_body', 'disconnect', 'refresh_token'].includes(
+          String((error as { type?: unknown })?.type || '')
+        );
+        await this._publicationAttemptService.recordProviderFailure(
+          publicationAttempt.attemptId,
+          explicit
+            ? PublicationAttemptEventType.EXPLICIT_FAILURE
+            : PublicationAttemptEventType.UNKNOWN,
+          explicit ? 'provider-explicitly-rejected' : 'provider-call-threw',
+          error
+        );
+      }
+      throw error;
+    }
+
+    if (publicationAttempt.action === 'execute') {
+      const outcome =
+        await this._publicationAttemptService.recordProviderResult(
+          publicationAttempt.attemptId,
+          postNow
+        );
+      if (outcome === 'explicit-failure') {
+        throw new ApplicationFailure(
+          'Provider explicitly reported publication failure',
+          'bad_body',
+          true
+        );
+      }
+      if (outcome === 'unknown') {
+        throw new ApplicationFailure(
+          'Provider returned no publication result',
+          'publication_outcome_unknown',
+          true
+        );
+      }
+    }
 
     // The post is already published at this point: the streak is best-effort,
     // failing the activity here would retry it and publish again.
@@ -408,7 +505,11 @@ export class PostActivity {
     );
 
     return this.handleDisconnect(integration, () =>
-      getIntegration.checkPostStatus(integration.token, pendingData, integration)
+      getIntegration.checkPostStatus(
+        integration.token,
+        pendingData,
+        integration
+      )
     );
   }
 
@@ -455,6 +556,44 @@ export class PostActivity {
 
   @ActivityMethod()
   async changeState(id: string, state: State, err?: any, body?: any) {
+    const correlated = await this._publicationAttemptService.isCorrelatedPost(
+      id
+    );
+    const identity =
+      state === State.ERROR ? this.activityIdentity() : undefined;
+    if (identity) {
+      const explicit = serializedFailureType(err) === 'bad_body';
+      await this._publicationAttemptService.markOpenAttemptTerminal(
+        id,
+        identity,
+        explicit
+          ? PublicationAttemptEventType.EXPLICIT_FAILURE
+          : PublicationAttemptEventType.UNKNOWN,
+        explicit
+          ? 'workflow-observed-explicit-provider-failure'
+          : 'workflow-could-not-confirm-provider-outcome'
+      );
+    }
+    if (correlated) {
+      if (
+        identity &&
+        (await this._publicationAttemptService.hasProviderReportedSuccess(
+          id,
+          identity
+        ))
+      ) {
+        // The provider result and PUBLISHED projection committed before the
+        // posting activity response was lost. Never downgrade that durable
+        // claim merely because Temporal observed an ambiguous timeout.
+        return;
+      }
+      await this._postService.changeState(
+        id,
+        state,
+        err ? 'Publication failed; see immutable attempt evidence' : undefined
+      );
+      return;
+    }
     await this._postService.changeState(id, state, err, body);
   }
 

--- a/libraries/nestjs-libraries/src/database/prisma/database.module.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/database.module.ts
@@ -1,5 +1,9 @@
 import { Global, Module } from '@nestjs/common';
-import { PrismaRepository, PrismaService, PrismaTransaction } from './prisma.service';
+import {
+  PrismaRepository,
+  PrismaService,
+  PrismaTransaction,
+} from './prisma.service';
 import { OrganizationRepository } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.repository';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
@@ -44,6 +48,7 @@ import { ErrorsRepository } from '@gitroom/nestjs-libraries/database/prisma/erro
 import { ErrorsService } from '@gitroom/nestjs-libraries/database/prisma/errors/errors.service';
 import { AdminStatsRepository } from '@gitroom/nestjs-libraries/database/prisma/admin-stats/admin-stats.repository';
 import { AdminStatsService } from '@gitroom/nestjs-libraries/database/prisma/admin-stats/admin-stats.service';
+import { PublicationAttemptService } from '@gitroom/nestjs-libraries/database/prisma/publication-attempt/publication-attempt.service';
 
 @Global()
 @Module({
@@ -97,6 +102,7 @@ import { AdminStatsService } from '@gitroom/nestjs-libraries/database/prisma/adm
     ErrorsService,
     AdminStatsRepository,
     AdminStatsService,
+    PublicationAttemptService,
   ],
   get exports() {
     return this.providers;

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -5,6 +5,7 @@ import {
   APPROVED_SUBMIT_FOR_ORDER,
   CreationMethod,
   Post,
+  Prisma,
   State,
 } from '@prisma/client';
 import { GetPostsDto } from '@gitroom/nestjs-libraries/dtos/posts/get.posts.dto';
@@ -516,11 +517,16 @@ export class PostsRepository {
     // Keep the existing group instead of rotating it, so open clients
     // (calendar) holding the group stay valid. Used by out-of-band updates
     // (agent / MCP / public API); the dashboard keeps the rotate-and-sweep.
-    keepGroup = false
+    keepGroup = false,
+    database?: Pick<Prisma.TransactionClient, 'post' | 'tags' | 'tagsPosts'>
   ) {
     const posts: Post[] = [];
     const uuid = uuidv4();
     const group = keepGroup && body.group ? body.group : uuid;
+    const postDatabase = database?.post || this._post.model.post;
+    const tagsDatabase = database?.tags || this._tags.model.tags;
+    const tagsPostsDatabase =
+      database?.tagsPosts || this._tagsPosts.model.tagsPosts;
 
     for (const value of body.value) {
       const updateData = (type: 'create' | 'update') => ({
@@ -568,7 +574,7 @@ export class PostsRepository {
       });
 
       posts.push(
-        await this._post.model.post.upsert({
+        await postDatabase.upsert({
           where: {
             id: value.id || uuidv4(),
           },
@@ -586,7 +592,7 @@ export class PostsRepository {
       );
 
       if (posts.length === 1) {
-        await this._tagsPosts.model.tagsPosts.deleteMany({
+        await tagsPostsDatabase.deleteMany({
           where: {
             post: {
               id: posts[0].id,
@@ -595,7 +601,7 @@ export class PostsRepository {
         });
 
         if (tags.length) {
-          const tagsList = await this._tags.model.tags.findMany({
+          const tagsList = await tagsDatabase.findMany({
             where: {
               orgId: orgId,
               name: {
@@ -605,7 +611,7 @@ export class PostsRepository {
           });
 
           if (tagsList.length) {
-            await this._post.model.post.update({
+            await postDatabase.update({
               where: {
                 id: posts[posts.length - 1].id,
               },
@@ -626,7 +632,7 @@ export class PostsRepository {
 
     const previousPost = body.group
       ? (
-          await this._post.model.post.findFirst({
+          await postDatabase.findFirst({
             where: {
               group: body.group,
               deletedAt: null,
@@ -640,7 +646,7 @@ export class PostsRepository {
       : undefined;
 
     if (body.group && !keepGroup) {
-      await this._post.model.post.updateMany({
+      await postDatabase.updateMany({
         where: {
           group: body.group,
           deletedAt: null,
@@ -655,7 +661,7 @@ export class PostsRepository {
     // keepGroup: the updated rows still carry the old group, so sweep only the
     // rows dropped from it (removed comments) by id instead of by group.
     if (body.group && keepGroup) {
-      await this._post.model.post.updateMany({
+      await postDatabase.updateMany({
         where: {
           group: body.group,
           deletedAt: null,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
   ValidationPipe,
@@ -14,6 +15,7 @@ import {
   Media,
   From,
   CreationMethod,
+  Prisma,
   State,
 } from '@prisma/client';
 import { GetPostsDto } from '@gitroom/nestjs-libraries/dtos/posts/get.posts.dto';
@@ -54,10 +56,20 @@ import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
 import { weightedLength } from '@gitroom/helpers/utils/count.length';
+import { PrismaService } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
+import {
+  isUniqueConstraintError,
+  PublicationAttemptService,
+} from '@gitroom/nestjs-libraries/database/prisma/publication-attempt/publication-attempt.service';
 
 type PostWithConditionals = Post & {
   integration?: Integration;
   childrenPost: Post[];
+};
+
+export type PublicationCorrelation = {
+  correlationId: string;
+  requestHash: string;
 };
 
 @Injectable()
@@ -71,7 +83,9 @@ export class PostsService {
     private _shortLinkService: ShortLinkService,
     private _openaiService: OpenaiService,
     private _temporalService: TemporalService,
-    private _refreshIntegrationService: RefreshIntegrationService
+    private _refreshIntegrationService: RefreshIntegrationService,
+    private _prisma: PrismaService,
+    private _publicationAttemptService: PublicationAttemptService
   ) {}
 
   searchForMissingThreeHoursPosts() {
@@ -826,7 +840,10 @@ export class PostsService {
           errors = err?.message || 'Invalid media';
         }
 
-        const maximumCharacters = provider.maxLength(additionalSettings, settings);
+        const maximumCharacters = provider.maxLength(
+          additionalSettings,
+          settings
+        );
         const isX = integration.providerIdentifier === 'x';
 
         const emptyContent = (post.value || []).some((a) => {
@@ -878,7 +895,11 @@ export class PostsService {
   // the platform: require the explicit `republish` opt-in instead. The message
   // doubles as the confirmation dialog for API/MCP automation.
   private guardAgainstRepublish(
-    post: { state: State; publishDate: Date; integration?: { providerIdentifier: string } } | null,
+    post: {
+      state: State;
+      publishDate: Date;
+      integration?: { providerIdentifier: string };
+    } | null,
     source: 'createPost' | 'changeDate'
   ) {
     if (post?.state !== 'PUBLISHED') {
@@ -891,7 +912,9 @@ export class PostsService {
     throw new BadRequestException(
       `This post was already published on ${dayjs
         .utc(post.publishDate)
-        .format('YYYY-MM-DD HH:mm')} UTC. Saving it this way would publish it again to ${
+        .format(
+          'YYYY-MM-DD HH:mm'
+        )} UTC. Saving it this way would publish it again to ${
         post.integration?.providerIdentifier || 'the channel'
       }. To edit without republishing, ${howToUpdate}. To intentionally publish again, pass republish: true.`
     );
@@ -901,9 +924,30 @@ export class PostsService {
     orgId: string,
     body: CreatePostDto,
     creationMethod: CreationMethod,
-    keepGroup = false
+    keepGroup = false,
+    publicationCorrelation?: PublicationCorrelation
   ): Promise<any[]> {
-    const postList = [];
+    if (publicationCorrelation && body.inter) {
+      throw new BadRequestException(
+        'X-Postify-Correlation-Id cannot be used with repeating posts'
+      );
+    }
+    if (publicationCorrelation) {
+      const existing =
+        await this._publicationAttemptService.resolvePublicationRequest(
+          orgId,
+          publicationCorrelation.correlationId,
+          publicationCorrelation.requestHash
+        );
+      if (existing) {
+        return existing;
+      }
+    }
+
+    // Provider-independent work stays outside the database transaction. In
+    // particular, short-link creation must not hold locks or be replayed by a
+    // serializable transaction callback.
+    const preparedPosts = [];
     for (const post of body.posts) {
       if (
         (body.type === 'schedule' || body.type === 'now') &&
@@ -935,6 +979,13 @@ export class PostsService {
         content: removeLinks ? stripLinks(updateContent[i]) : updateContent[i],
       }));
 
+      preparedPosts.push(post);
+    }
+
+    const persistPost = async (
+      post: (typeof preparedPosts)[number],
+      database?: Prisma.TransactionClient
+    ) => {
       const { posts } = await this._postRepository.createOrUpdatePost(
         body.type,
         orgId,
@@ -943,26 +994,119 @@ export class PostsService {
         body.tags,
         creationMethod,
         body.inter,
-        keepGroup
+        keepGroup,
+        database
       );
 
       if (!posts?.length) {
+        return null;
+      }
+
+      return {
+        postId: posts[0].id,
+        integration: post.integration.id,
+        state: posts[0].state,
+        taskQueue: post.settings.__type.split('-')[0].toLowerCase(),
+      };
+    };
+
+    const startPersistedWorkflow = (post: {
+      postId: string;
+      state: State;
+      taskQueue: string;
+    }) => {
+      if (body.type !== 'update') {
+        this.startWorkflow(
+          post.taskQueue,
+          post.postId,
+          orgId,
+          post.state
+        ).catch((err) => {});
+      }
+      Sentry.metrics.count('post_created', 1);
+    };
+
+    if (publicationCorrelation) {
+      try {
+        const persisted = await this._prisma.$transaction(
+          async (database) => {
+            // Close the check/create race inside the transaction. A concurrent
+            // winner is returned without creating or starting duplicate posts.
+            const existing =
+              await this._publicationAttemptService.resolvePublicationRequest(
+                orgId,
+                publicationCorrelation.correlationId,
+                publicationCorrelation.requestHash,
+                database
+              );
+            if (existing) {
+              return { created: false as const, posts: existing };
+            }
+
+            const posts = [];
+            for (const post of preparedPosts) {
+              const saved = await persistPost(post, database);
+              if (!saved) {
+                throw new Error('Failed to persist correlated post');
+              }
+              posts.push(saved);
+            }
+
+            await this._publicationAttemptService.createPublicationRequest(
+              database,
+              {
+                organizationId: orgId,
+                correlationId: publicationCorrelation.correlationId,
+                requestHash: publicationCorrelation.requestHash,
+                posts,
+              }
+            );
+            return { created: true as const, posts };
+          },
+          { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+        );
+
+        if (persisted.created) {
+          persisted.posts.forEach(startPersistedWorkflow);
+        }
+        return persisted.posts.map(({ postId, integration }) => ({
+          postId,
+          integration,
+        }));
+      } catch (error) {
+        if (!isUniqueConstraintError(error)) {
+          throw error;
+        }
+
+        // The unique organization/correlation constraint selects one winner.
+        // Its request hash still has to match before this becomes an idempotent
+        // replay rather than a conflict.
+        const existing =
+          await this._publicationAttemptService.resolvePublicationRequest(
+            orgId,
+            publicationCorrelation.correlationId,
+            publicationCorrelation.requestHash
+          );
+        if (existing) {
+          return existing;
+        }
+        throw new ConflictException(
+          'A root post in this request is already bound to another correlation identity'
+        );
+      }
+    }
+
+    const postList = [];
+    for (const post of preparedPosts) {
+      const saved = await persistPost(post);
+      if (!saved) {
         return [] as any[];
       }
 
-      if (body.type !== 'update') {
-        this.startWorkflow(
-          post.settings.__type.split('-')[0].toLowerCase(),
-          posts[0].id,
-          orgId,
-          posts[0].state
-        ).catch((err) => {});
-      }
-
-      Sentry.metrics.count('post_created', 1);
+      startPersistedWorkflow(saved);
       postList.push({
-        postId: posts[0].id,
-        integration: post.integration.id,
+        postId: saved.postId,
+        integration: saved.integration,
       });
     }
 

--- a/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.evidence.spec.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.evidence.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAttemptEvidence,
+  canonicalJson,
+  canonicalSha256,
+  normalizeProviderResult,
+  signEvidenceHash,
+} from './publication-attempt.evidence';
+
+describe('publication attempt evidence', () => {
+  it('canonicalizes object keys while preserving array order', () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, x: 3 } })).toBe(
+      canonicalJson({ a: { x: 3, y: 2 }, z: 1 })
+    );
+    expect(canonicalSha256({ items: ['a', 'b'] })).not.toBe(
+      canonicalSha256({ items: ['b', 'a'] })
+    );
+  });
+
+  it('signs the canonical evidence hash without exposing the key', () => {
+    const key = '0123456789abcdef0123456789abcdef';
+    const signature = signEvidenceHash(canonicalSha256({ id: 'attempt' }), key);
+    expect(signature).toMatch(/^hmac-sha256:[a-f0-9]{64}$/);
+    expect(signature).not.toContain(key);
+  });
+
+  it('retains content and ids but redacts credentials and every media location', () => {
+    const evidence = buildAttemptEvidence(
+      {
+        id: 'integration-1',
+        internalId: 'provider-account-1',
+        organizationId: 'org-1',
+        customerId: 'customer-1',
+        providerIdentifier: 'example',
+      },
+      [
+        {
+          id: 'post-1',
+          message: 'approved caption',
+          settings: {
+            title: 'public title',
+            accessToken: 'never-store-me',
+            headers: { Authorization: 'Bearer also-never-store-me' },
+            callback:
+              'https://example.test/callback?signature=signed-secret-value',
+            authenticatedUrl: 'https://user:password@example.test/private',
+          },
+          media: [
+            {
+              id: 'media-1',
+              type: 'image',
+              alt: 'approved alt text',
+              path: 'https://private.test/image?token=media-secret',
+              url: '/private/files/image.png',
+              thumbnail: 'https://private.test/thumb',
+            },
+          ],
+        },
+      ]
+    );
+    const serialized = JSON.stringify(evidence);
+
+    expect(serialized).toContain('approved caption');
+    expect(serialized).toContain('provider-account-1');
+    expect(serialized).toContain('media-1');
+    expect(serialized).toContain('approved alt text');
+    expect(serialized).toContain('public title');
+    expect(serialized).not.toContain('never-store-me');
+    expect(serialized).not.toContain('also-never-store-me');
+    expect(serialized).not.toContain('signed-secret-value');
+    expect(serialized).not.toContain('user:password');
+    expect(serialized).not.toContain('private.test');
+    expect(serialized).not.toContain('/private/files');
+  });
+
+  it('binds exact outgoing media paths only through the payload hash', () => {
+    const integration = {
+      id: 'integration-1',
+      internalId: 'provider-account-1',
+      organizationId: 'org-1',
+      providerIdentifier: 'example',
+    };
+    const first = buildAttemptEvidence(integration, [
+      {
+        id: 'post-1',
+        message: 'caption',
+        settings: {},
+        media: [{ id: 'media-1', path: '/first/private/path' }],
+      },
+    ]);
+    const second = buildAttemptEvidence(integration, [
+      {
+        id: 'post-1',
+        message: 'caption',
+        settings: {},
+        media: [{ id: 'media-1', path: '/second/private/path' }],
+      },
+    ]);
+
+    expect(first.outgoingPayloadHash).not.toBe(second.outgoingPayloadHash);
+    expect(JSON.stringify(first.mediaEvidence)).not.toContain(
+      '/first/private/path'
+    );
+  });
+
+  it('normalizes results without retaining opaque provider response data', () => {
+    const normalized = normalizeProviderResult([
+      {
+        id: 'post-1',
+        status: 'pending',
+        postId: 'platform-1',
+        releaseURL: 'https://platform.test/post/1',
+        pendingData: { accessToken: 'raw-provider-secret' },
+      },
+    ]);
+
+    expect(normalized).toEqual([
+      {
+        postId: 'post-1',
+        status: 'provider-accepted',
+        platformReleaseId: 'platform-1',
+        platformReleaseUrl: 'https://platform.test/post/1',
+      },
+    ]);
+    expect(JSON.stringify(normalized)).not.toContain('raw-provider-secret');
+
+    const unsafeRelease = normalizeProviderResult([
+      {
+        id: 'post-2',
+        status: 'completed',
+        postId: 'platform-2',
+        releaseURL:
+          'https://platform.test/post/2?access_token=release-url-secret',
+      },
+    ]);
+    expect(unsafeRelease[0].platformReleaseUrl).toBeNull();
+    expect(JSON.stringify(unsafeRelease)).not.toContain('release-url-secret');
+  });
+});

--- a/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.evidence.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.evidence.ts
@@ -1,0 +1,248 @@
+import { createHash, createHmac } from 'crypto';
+
+const SENSITIVE_KEY =
+  /(authorization|cookie|credential|password|secret|token|private.?key|api.?key|headers?|signature)/i;
+const SENSITIVE_URL_PARAMETER =
+  /[?&](access_token|api_key|key|password|secret|signature|sig|token|x-amz-[^=]+)=/i;
+const BEARER_TOKEN = /^bearer\s+/i;
+const URL_WITH_CREDENTIALS = /^https?:\/\/[^/?#\s]*@/i;
+
+function canonicalValue(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('Canonical JSON does not support non-finite numbers');
+    }
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      item === undefined ? null : canonicalValue(item)
+    );
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((output, key) => {
+        const item = (value as Record<string, unknown>)[key];
+        if (
+          item !== undefined &&
+          typeof item !== 'function' &&
+          typeof item !== 'symbol'
+        ) {
+          output[key] = canonicalValue(item);
+        }
+        return output;
+      }, {});
+  }
+
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
+export function canonicalSha256(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+export function signEvidenceHash(hash: string, signingKey: string): string {
+  if (!signingKey || Buffer.byteLength(signingKey) < 32) {
+    throw new Error(
+      'POSTIZ_PUBLICATION_EVIDENCE_HMAC_KEY must contain at least 32 bytes'
+    );
+  }
+
+  return `hmac-sha256:${createHmac('sha256', signingKey)
+    .update(hash)
+    .digest('hex')}`;
+}
+
+function redacted(value: unknown) {
+  return {
+    redacted: true,
+    sha256: canonicalSha256(value),
+  };
+}
+
+function sensitiveString(value: string): boolean {
+  return (
+    BEARER_TOKEN.test(value) ||
+    SENSITIVE_URL_PARAMETER.test(value) ||
+    URL_WITH_CREDENTIALS.test(value)
+  );
+}
+
+export function redactSettingsEvidence(value: unknown, key = ''): unknown {
+  if (SENSITIVE_KEY.test(key)) {
+    return redacted(value);
+  }
+
+  if (typeof value === 'string') {
+    return sensitiveString(value) ? redacted(value) : value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSettingsEvidence(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>).reduce<
+      Record<string, unknown>
+    >((output, childKey) => {
+      output[childKey] = redactSettingsEvidence(
+        (value as Record<string, unknown>)[childKey],
+        childKey
+      );
+      return output;
+    }, {});
+  }
+
+  return value;
+}
+
+function mediaIdentifier(media: Record<string, unknown>) {
+  return (
+    media.id || media.mediaId || media.providerId || media.assetId || undefined
+  );
+}
+
+export function redactMediaEvidence(media: unknown): unknown[] {
+  if (!Array.isArray(media)) {
+    return [];
+  }
+
+  return media.map((item) => {
+    const value = (item || {}) as Record<string, unknown>;
+    return {
+      ...(mediaIdentifier(value)
+        ? { mediaId: String(mediaIdentifier(value)) }
+        : {}),
+      ...(value.type ? { type: String(value.type) } : {}),
+      ...(value.alt ? { alt: String(value.alt) } : {}),
+      ...(value.path ? { pathHash: canonicalSha256(String(value.path)) } : {}),
+      ...(value.url ? { urlHash: canonicalSha256(String(value.url)) } : {}),
+      ...(value.thumbnail
+        ? { thumbnailHash: canonicalSha256(String(value.thumbnail)) }
+        : {}),
+    };
+  });
+}
+
+export type ProviderPostEvidence = {
+  id: string;
+  message: string;
+  settings: unknown;
+  media?: unknown[];
+};
+
+export function buildAttemptEvidence(
+  integration: {
+    id: string;
+    internalId: string;
+    organizationId: string;
+    customerId?: string | null;
+    providerIdentifier: string;
+  },
+  mappedPosts: ProviderPostEvidence[]
+) {
+  const captionEvidence = mappedPosts.map(({ id, message }) => ({
+    postId: id,
+    caption: message,
+  }));
+  const settingsEvidence = mappedPosts.map(({ id, settings }) => ({
+    postId: id,
+    settings: redactSettingsEvidence(settings),
+  }));
+  const mediaEvidence = mappedPosts.map(({ id, media }) => ({
+    postId: id,
+    media: redactMediaEvidence(media),
+  }));
+  const accountEvidence = {
+    integrationId: integration.id,
+    providerIdentifier: integration.providerIdentifier,
+    providerAccountId: integration.internalId,
+    customerId: integration.customerId || null,
+  };
+
+  return {
+    captionEvidence,
+    settingsEvidence,
+    mediaEvidence,
+    accountEvidence,
+    // This hash binds the exact provider input, including media locations, while
+    // the locations themselves never enter an evidence column.
+    outgoingPayloadHash: canonicalSha256({
+      account: {
+        providerIdentifier: integration.providerIdentifier,
+        providerAccountId: integration.internalId,
+      },
+      posts: mappedPosts,
+    }),
+  };
+}
+
+export type SafeProviderResult = {
+  postId: string;
+  status: 'provider-accepted' | 'provider-reported-success';
+  platformReleaseId: string | null;
+  platformReleaseUrl: string | null;
+};
+
+export function normalizeProviderResult(
+  results: Array<{
+    id?: unknown;
+    status?: unknown;
+    postId?: unknown;
+    releaseURL?: unknown;
+  }>
+): SafeProviderResult[] {
+  return results.map((result) => {
+    const releaseUrl = result.releaseURL ? String(result.releaseURL) : '';
+    return {
+      postId: String(result.id || ''),
+      status:
+        String(result.status || '').toLowerCase() === 'pending'
+          ? 'provider-accepted'
+          : 'provider-reported-success',
+      platformReleaseId: result.postId ? String(result.postId) : null,
+      platformReleaseUrl:
+        releaseUrl && !sensitiveString(releaseUrl) ? releaseUrl : null,
+    };
+  });
+}
+
+export function buildErrorEvidence(error: unknown, reason: string) {
+  const value = error as {
+    name?: unknown;
+    type?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+  const errorName = String(value?.name || 'Error');
+  const errorType = String(value?.type || '');
+  const errorCode = String(value?.code || '');
+  return {
+    reason,
+    // Provider error metadata and messages can contain response bodies or
+    // credentials. Bind them without copying any provider-controlled value.
+    errorNameHash: canonicalSha256(errorName),
+    errorTypeHash: errorType ? canonicalSha256(errorType) : null,
+    errorCodeHash: errorCode ? canonicalSha256(errorCode) : null,
+    errorMessageHash: canonicalSha256(String(value?.message || '')),
+  };
+}

--- a/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.service.spec.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.service.spec.ts
@@ -1,0 +1,555 @@
+import { ConflictException } from '@nestjs/common';
+import { PublicationAttemptEventType } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PublicationAttemptService } from './publication-attempt.service';
+
+function databaseDouble() {
+  const database = {
+    publicationRequest: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    publicationRequestBinding: {
+      findUnique: vi.fn(),
+    },
+    publicationAttempt: {
+      findFirst: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+      create: vi.fn(),
+    },
+    publicationAttemptEvent: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+    integration: {
+      findMany: vi.fn(),
+    },
+    post: {
+      update: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  };
+  database.$transaction.mockImplementation(
+    async (callback: (transaction: typeof database) => unknown) =>
+      callback(database)
+  );
+  return database;
+}
+
+const attempt = {
+  id: 'attempt-1',
+  rootPostId: 'post-1',
+  operationKey: 'operation-1',
+  evidenceHash: 'evidence-hash',
+  captionEvidence: [{ postId: 'post-1', caption: 'approved caption' }],
+};
+
+describe('PublicationAttemptService', () => {
+  beforeEach(() => {
+    process.env.POSTIZ_PUBLICATION_EVIDENCE_HMAC_KEY =
+      '0123456789abcdef0123456789abcdef';
+  });
+
+  it('rejects conflicting correlation reuse', async () => {
+    const database = databaseDouble();
+    database.publicationRequest.findUnique.mockResolvedValue({
+      requestHash: 'first-request-hash',
+      bindings: [],
+    });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.resolvePublicationRequest(
+        'org-1',
+        'correlation-1',
+        'different-request-hash'
+      )
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('returns the original roots for an idempotent correlation replay', async () => {
+    const database = databaseDouble();
+    database.publicationRequest.findUnique.mockResolvedValue({
+      requestHash: 'same-hash',
+      bindings: [
+        { rootPostId: 'post-2', integrationId: 'int-2', position: 1 },
+        { rootPostId: 'post-1', integrationId: 'int-1', position: 0 },
+      ],
+    });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.resolvePublicationRequest('org-1', 'correlation-1', 'same-hash')
+    ).resolves.toEqual([
+      { postId: 'post-1', integration: 'int-1' },
+      { postId: 'post-2', integration: 'int-2' },
+    ]);
+  });
+
+  it('binds organization, customer, root post, and integration at creation', async () => {
+    const database = databaseDouble();
+    database.integration.findMany.mockResolvedValue([
+      { id: 'integration-1', customerId: 'customer-1' },
+    ]);
+    const service = new PublicationAttemptService(database as never);
+
+    await service.createPublicationRequest(database as never, {
+      organizationId: 'org-1',
+      correlationId: 'correlation-1',
+      requestHash: 'request-hash-1',
+      posts: [{ postId: 'post-1', integration: 'integration-1' }],
+    });
+
+    expect(database.publicationRequest.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: 'org-1',
+        correlationId: 'correlation-1',
+        requestHash: 'request-hash-1',
+        bindings: {
+          create: [
+            {
+              position: 0,
+              rootPostId: 'post-1',
+              integrationId: 'integration-1',
+              customerId: 'customer-1',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('replays a recorded success instead of opening a retry attempt', async () => {
+    const database = databaseDouble();
+    database.publicationRequestBinding.findUnique.mockResolvedValue({
+      id: 'binding-1',
+      integrationId: 'integration-1',
+      customerId: null,
+      publicationRequestId: 'request-1',
+      publicationRequest: {
+        organizationId: 'org-1',
+        correlationId: 'correlation-1',
+      },
+    });
+    database.publicationAttemptEvent.findUnique.mockResolvedValue({
+      type: PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS,
+      resultEvidence: {
+        results: [
+          {
+            postId: 'post-1',
+            status: 'provider-reported-success',
+            platformReleaseId: 'platform-1',
+            platformReleaseUrl: 'https://platform.test/1',
+          },
+        ],
+      },
+    });
+    const service = new PublicationAttemptService(database as never);
+
+    const result = await service.beginPublicationAttempt({
+      integration: {
+        id: 'integration-1',
+        internalId: 'account-1',
+        organizationId: 'org-1',
+        providerIdentifier: 'example',
+      },
+      mappedPosts: [
+        { id: 'post-1', message: 'caption', settings: {}, media: [] },
+      ],
+      identity: {
+        workflowId: 'workflow-1',
+        runId: 'run-1',
+        activityId: 'activity-2',
+        activityType: 'postSocialPending',
+        attempt: 2,
+      },
+    });
+
+    expect(result).toEqual({
+      action: 'replay-success',
+      result: [
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+      ],
+    });
+    expect(database.publicationAttempt.create).not.toHaveBeenCalled();
+  });
+
+  it('opens a new durable attempt after an explicit failure retry', async () => {
+    const database = databaseDouble();
+    database.publicationRequestBinding.findUnique.mockResolvedValue({
+      id: 'binding-1',
+      integrationId: 'integration-1',
+      customerId: 'customer-1',
+      publicationRequestId: 'request-1',
+      publicationRequest: {
+        organizationId: 'org-1',
+        correlationId: 'correlation-1',
+      },
+    });
+    database.publicationAttemptEvent.findUnique.mockResolvedValue(null);
+    database.publicationAttempt.findFirst.mockResolvedValue(null);
+    database.publicationAttempt.create.mockResolvedValue({ id: 'attempt-2' });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.beginPublicationAttempt({
+        integration: {
+          id: 'integration-1',
+          internalId: 'account-1',
+          organizationId: 'org-1',
+          customerId: 'customer-1',
+          providerIdentifier: 'example',
+        },
+        mappedPosts: [
+          { id: 'post-1', message: 'caption', settings: {}, media: [] },
+        ],
+        identity: {
+          workflowId: 'workflow-1',
+          runId: 'run-1',
+          activityId: 'activity-2',
+          activityType: 'postSocialPending',
+          attempt: 2,
+        },
+      })
+    ).resolves.toEqual({ action: 'execute', attemptId: 'attempt-2' });
+
+    expect(database.publicationAttempt.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workflowId: 'workflow-1',
+        runId: 'run-1',
+        activityId: 'activity-2',
+        temporalAttempt: 2,
+      }),
+    });
+  });
+
+  it('atomically stores provider-reported success and the Postiz projection', async () => {
+    const database = databaseDouble();
+    database.publicationAttempt.findUniqueOrThrow.mockResolvedValue(attempt);
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockResolvedValue({ id: 'post-1' });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.recordProviderResult('attempt-1', [
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+      ])
+    ).resolves.toBe('success');
+
+    expect(database.$transaction).toHaveBeenCalledTimes(1);
+    expect(database.publicationAttemptEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS,
+          terminal: true,
+          operationKey: 'operation-1',
+          platformReleaseId: 'platform-1',
+          platformReleaseUrl: 'https://platform.test/1',
+        }),
+      })
+    );
+    expect(database.post.update).toHaveBeenCalledWith({
+      where: { id: 'post-1' },
+      data: {
+        state: 'PUBLISHED',
+        releaseId: 'platform-1',
+        releaseURL: 'https://platform.test/1',
+        error: null,
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: 'wrong singleton id',
+      captionEvidence: [{ postId: 'post-1' }],
+      rawResults: [
+        {
+          id: 'wrong-post',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+      ],
+    },
+    {
+      name: 'missing result',
+      captionEvidence: [{ postId: 'post-1' }, { postId: 'post-2' }],
+      rawResults: [
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+      ],
+    },
+    {
+      name: 'extra result',
+      captionEvidence: [{ postId: 'post-1' }],
+      rawResults: [
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+        {
+          id: 'post-2',
+          postId: 'platform-2',
+          releaseURL: 'https://platform.test/2',
+          status: 'success',
+        },
+      ],
+    },
+    {
+      name: 'reversed results',
+      captionEvidence: [{ postId: 'post-1' }, { postId: 'post-2' }],
+      rawResults: [
+        {
+          id: 'post-2',
+          postId: 'platform-2',
+          releaseURL: 'https://platform.test/2',
+          status: 'success',
+        },
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+      ],
+    },
+    {
+      name: 'malformed pending result',
+      captionEvidence: [{ postId: 'post-1' }],
+      rawResults: [
+        {
+          id: undefined,
+          postId: '',
+          releaseURL: '',
+          status: 'pending',
+          pendingData: { accessToken: 'never-store-me' },
+        },
+      ],
+    },
+  ])('records $name as unknown before classification', async (testCase) => {
+    const database = databaseDouble();
+    database.publicationAttempt.findUniqueOrThrow.mockResolvedValue({
+      ...attempt,
+      captionEvidence: testCase.captionEvidence,
+    });
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockResolvedValue({ id: 'post-1' });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.recordProviderResult('attempt-1', testCase.rawResults as never)
+    ).resolves.toBe('unknown');
+
+    expect(database.publicationAttemptEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: PublicationAttemptEventType.UNKNOWN,
+          reason: 'provider-result-post-binding-mismatch',
+        }),
+      })
+    );
+    expect(database.post.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ state: 'PUBLISHED' }),
+      })
+    );
+    expect(
+      JSON.stringify(
+        database.publicationAttemptEvent.create.mock.calls[0][0].data
+          .resultEvidence
+      )
+    ).not.toContain('never-store-me');
+  });
+
+  it('stores an explicit failure without raw provider response content', async () => {
+    const database = databaseDouble();
+    database.publicationAttempt.findUniqueOrThrow.mockResolvedValue(attempt);
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockResolvedValue({ id: 'post-1' });
+    const service = new PublicationAttemptService(database as never);
+    const raw = 'provider body containing access_token=do-not-store';
+    const error = Object.assign(new Error(raw), {
+      type: 'token=provider-error-secret',
+      code: 'Bearer provider-code-secret',
+    });
+
+    await service.recordProviderFailure(
+      'attempt-1',
+      PublicationAttemptEventType.EXPLICIT_FAILURE,
+      'provider-explicitly-rejected',
+      error
+    );
+
+    const event = database.publicationAttemptEvent.create.mock.calls[0][0];
+    expect(event.data.type).toBe(PublicationAttemptEventType.EXPLICIT_FAILURE);
+    expect(event.data.operationKey).toBeNull();
+    expect(JSON.stringify(event.data.resultEvidence)).not.toContain(raw);
+    expect(JSON.stringify(event.data.resultEvidence)).not.toContain(
+      'provider-error-secret'
+    );
+    expect(JSON.stringify(event.data.resultEvidence)).not.toContain(
+      'provider-code-secret'
+    );
+    expect(database.post.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ state: 'ERROR' }),
+      })
+    );
+  });
+
+  it('recognizes current provider success and explicit failure statuses', async () => {
+    const database = databaseDouble();
+    database.publicationAttempt.findUniqueOrThrow.mockResolvedValue(attempt);
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockResolvedValue({ id: 'post-1' });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.recordProviderResult('attempt-1', [
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'completed',
+        },
+      ])
+    ).resolves.toBe('success');
+
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    await expect(
+      service.recordProviderResult('attempt-2', [
+        {
+          id: 'post-1',
+          postId: '',
+          releaseURL: '',
+          status: 'error',
+        },
+      ])
+    ).resolves.toBe('explicit-failure');
+    expect(database.publicationAttemptEvent.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: PublicationAttemptEventType.EXPLICIT_FAILURE,
+        }),
+      })
+    );
+  });
+
+  it('records an incomplete provider success as unknown instead of published', async () => {
+    const database = databaseDouble();
+    database.publicationAttempt.findUniqueOrThrow.mockResolvedValue(attempt);
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockResolvedValue({ id: 'post-1' });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.recordProviderResult('attempt-1', [
+        {
+          id: 'post-1',
+          postId: '',
+          releaseURL: '',
+          status: 'success',
+        },
+      ])
+    ).resolves.toBe('unknown');
+
+    expect(database.publicationAttemptEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: PublicationAttemptEventType.UNKNOWN,
+        }),
+      })
+    );
+    expect(database.post.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ state: 'ERROR' }),
+      })
+    );
+  });
+
+  it('turns a timed-out open attempt into an unknown terminal claim', async () => {
+    const database = databaseDouble();
+    database.publicationAttempt.findFirst.mockResolvedValue(attempt);
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockResolvedValue({ id: 'post-1' });
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.markOpenAttemptTerminal(
+        'post-1',
+        { workflowId: 'workflow-1', runId: 'run-1' },
+        PublicationAttemptEventType.UNKNOWN,
+        'activity-timeout'
+      )
+    ).resolves.toBe(true);
+
+    expect(database.publicationAttemptEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: PublicationAttemptEventType.UNKNOWN,
+          terminal: true,
+          operationKey: 'operation-1',
+        }),
+      })
+    );
+  });
+
+  it('does not hide a projection failure outside the terminal transaction', async () => {
+    const database = databaseDouble();
+    database.publicationAttempt.findUniqueOrThrow.mockResolvedValue(attempt);
+    database.publicationAttemptEvent.findFirst.mockResolvedValue(null);
+    database.publicationAttemptEvent.create.mockResolvedValue({
+      id: 'event-1',
+    });
+    database.post.update.mockRejectedValue(new Error('projection failed'));
+    const service = new PublicationAttemptService(database as never);
+
+    await expect(
+      service.recordProviderResult('attempt-1', [
+        {
+          id: 'post-1',
+          postId: 'platform-1',
+          releaseURL: 'https://platform.test/1',
+          status: 'success',
+        },
+      ])
+    ).rejects.toThrow('projection failed');
+    expect(database.$transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/publication-attempt/publication-attempt.service.ts
@@ -1,0 +1,703 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { Prisma, PublicationAttemptEventType } from '@prisma/client';
+import { PrismaService } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
+import {
+  buildAttemptEvidence,
+  buildErrorEvidence,
+  canonicalSha256,
+  normalizeProviderResult,
+  ProviderPostEvidence,
+  SafeProviderResult,
+  signEvidenceHash,
+} from '@gitroom/nestjs-libraries/database/prisma/publication-attempt/publication-attempt.evidence';
+
+export type TemporalAttemptIdentity = {
+  workflowId: string;
+  runId: string;
+  activityId: string;
+  activityType: string;
+  attempt: number;
+};
+
+export type CorrelatedPost = {
+  postId: string;
+  integration: string;
+};
+
+export type PublicationAttemptStart =
+  | { action: 'untracked' }
+  | { action: 'execute'; attemptId: string }
+  | { action: 'replay-success'; result: ProviderResult[] }
+  | { action: 'outcome-unknown' };
+
+export type ProviderResult = {
+  id: string;
+  postId: string;
+  releaseURL: string;
+  status: string;
+  pendingData?: unknown;
+};
+
+type PublicationDatabase = Prisma.TransactionClient | PrismaService;
+
+const PROVIDER_REPORTED_SUCCESS = new Set([
+  'completed',
+  'posted',
+  'published',
+  'success',
+]);
+const PROVIDER_REPORTED_FAILURE = new Set(['error', 'failed', 'rejected']);
+
+function correlatedPosts(request: {
+  bindings: Array<{
+    rootPostId: string;
+    integrationId: string;
+    position: number;
+  }>;
+}): CorrelatedPost[] {
+  return [...request.bindings]
+    .sort((a, b) => a.position - b.position)
+    .map((binding) => ({
+      postId: binding.rootPostId,
+      integration: binding.integrationId,
+    }));
+}
+
+export function isUniqueConstraintError(error: unknown): boolean {
+  return (error as { code?: string })?.code === 'P2002';
+}
+
+@Injectable()
+export class PublicationAttemptService {
+  constructor(private readonly _prisma: PrismaService) {}
+
+  private signingKey(): string {
+    return process.env.POSTIZ_PUBLICATION_EVIDENCE_HMAC_KEY || '';
+  }
+
+  async resolvePublicationRequest(
+    organizationId: string,
+    correlationId: string,
+    requestHash: string,
+    database: PublicationDatabase = this._prisma
+  ): Promise<CorrelatedPost[] | null> {
+    const existing = await database.publicationRequest.findUnique({
+      where: {
+        organizationId_correlationId: { organizationId, correlationId },
+      },
+      include: { bindings: true },
+    });
+
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.requestHash !== requestHash) {
+      throw new ConflictException(
+        'X-Postify-Correlation-Id was already used for a different request'
+      );
+    }
+
+    return correlatedPosts(existing);
+  }
+
+  async createPublicationRequest(
+    database: Prisma.TransactionClient,
+    input: {
+      organizationId: string;
+      correlationId: string;
+      requestHash: string;
+      posts: CorrelatedPost[];
+    }
+  ): Promise<void> {
+    const integrations = await database.integration.findMany({
+      where: {
+        id: { in: input.posts.map((post) => post.integration) },
+        organizationId: input.organizationId,
+      },
+      select: { id: true, customerId: true },
+    });
+    const integrationById = new Map(
+      integrations.map((integration) => [integration.id, integration])
+    );
+
+    if (input.posts.some((post) => !integrationById.has(post.integration))) {
+      throw new ConflictException(
+        'A correlated post references an integration outside the organization'
+      );
+    }
+
+    await database.publicationRequest.create({
+      data: {
+        organizationId: input.organizationId,
+        correlationId: input.correlationId,
+        requestHash: input.requestHash,
+        bindings: {
+          create: input.posts.map((post, position) => ({
+            position,
+            rootPostId: post.postId,
+            integrationId: post.integration,
+            customerId:
+              integrationById.get(post.integration)?.customerId || null,
+          })),
+        },
+      },
+    });
+  }
+
+  private operationKey(
+    publicationRequestBindingId: string,
+    rootPostId: string,
+    integrationId: string
+  ) {
+    return canonicalSha256({
+      operation: 'provider-post',
+      publicationRequestBindingId,
+      rootPostId,
+      integrationId,
+    });
+  }
+
+  private eventData(
+    attempt: {
+      id: string;
+      operationKey: string;
+      evidenceHash: string;
+    },
+    input: {
+      type: PublicationAttemptEventType;
+      terminal: boolean;
+      reason?: string;
+      resultEvidence: unknown;
+      platformReleaseId?: string | null;
+      platformReleaseUrl?: string | null;
+      blockRetry?: boolean;
+    }
+  ) {
+    const createdAt = new Date();
+    const resultHash = canonicalSha256(input.resultEvidence);
+    const evidenceHash = canonicalSha256({
+      attemptEvidenceHash: attempt.evidenceHash,
+      createdAt: createdAt.toISOString(),
+      type: input.type,
+      terminal: input.terminal,
+      reason: input.reason || null,
+      platformReleaseId: input.platformReleaseId || null,
+      platformReleaseUrl: input.platformReleaseUrl || null,
+      resultHash,
+    });
+
+    return {
+      publicationAttemptId: attempt.id,
+      type: input.type,
+      terminal: input.terminal,
+      terminalAttemptId: input.terminal ? attempt.id : null,
+      operationKey: input.blockRetry ? attempt.operationKey : null,
+      reason: input.reason || null,
+      platformReleaseId: input.platformReleaseId || null,
+      platformReleaseUrl: input.platformReleaseUrl || null,
+      resultEvidence: input.resultEvidence as Prisma.InputJsonValue,
+      resultHash,
+      evidenceHash,
+      evidenceSignature: signEvidenceHash(evidenceHash, this.signingKey()),
+      createdAt,
+    };
+  }
+
+  private async createTerminalEvent(
+    database: Prisma.TransactionClient,
+    attempt: {
+      id: string;
+      rootPostId: string;
+      operationKey: string;
+      evidenceHash: string;
+    },
+    input: {
+      type:
+        | typeof PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS
+        | typeof PublicationAttemptEventType.EXPLICIT_FAILURE
+        | typeof PublicationAttemptEventType.UNKNOWN;
+      reason?: string;
+      resultEvidence: unknown;
+      platformReleaseId?: string | null;
+      platformReleaseUrl?: string | null;
+    }
+  ) {
+    const existing = await database.publicationAttemptEvent.findFirst({
+      where: { terminalAttemptId: attempt.id },
+    });
+    const event = this.eventData(attempt, {
+      ...input,
+      terminal: true,
+      blockRetry: input.type !== PublicationAttemptEventType.EXPLICIT_FAILURE,
+    });
+
+    if (existing) {
+      if (
+        existing.type !== input.type ||
+        existing.resultHash !== event.resultHash
+      ) {
+        throw new ConflictException(
+          'Publication attempt already has a conflicting terminal claim'
+        );
+      }
+      return existing;
+    }
+
+    const created = await database.publicationAttemptEvent.create({
+      data: event,
+    });
+    if (input.type === PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS) {
+      await database.post.update({
+        where: { id: attempt.rootPostId },
+        data: {
+          state: 'PUBLISHED',
+          releaseId: input.platformReleaseId || '',
+          releaseURL: input.platformReleaseUrl || '',
+          error: null,
+        },
+      });
+    } else {
+      await database.post.update({
+        where: { id: attempt.rootPostId },
+        data: {
+          state: 'ERROR',
+          error:
+            input.type === PublicationAttemptEventType.UNKNOWN
+              ? 'Provider outcome unknown; check the platform before retrying'
+              : 'Provider explicitly rejected this publication attempt',
+        },
+      });
+    }
+
+    return created;
+  }
+
+  private replayResult(resultEvidence: Prisma.JsonValue): ProviderResult[] {
+    const evidence = resultEvidence as {
+      results?: SafeProviderResult[];
+    };
+    return (evidence.results || []).map((result) => ({
+      id: result.postId,
+      postId: result.platformReleaseId || '',
+      releaseURL: result.platformReleaseUrl || '',
+      status: 'success',
+    }));
+  }
+
+  async beginPublicationAttempt(input: {
+    integration: {
+      id: string;
+      internalId: string;
+      organizationId: string;
+      customerId?: string | null;
+      providerIdentifier: string;
+    };
+    mappedPosts: ProviderPostEvidence[];
+    identity: TemporalAttemptIdentity;
+  }): Promise<PublicationAttemptStart> {
+    const rootPostId = input.mappedPosts[0]?.id;
+    if (!rootPostId) {
+      return { action: 'untracked' };
+    }
+
+    const binding = await this._prisma.publicationRequestBinding.findUnique({
+      where: { rootPostId },
+      include: { publicationRequest: true },
+    });
+    if (!binding) {
+      return { action: 'untracked' };
+    }
+    if (
+      binding.integrationId !== input.integration.id ||
+      binding.publicationRequest.organizationId !==
+        input.integration.organizationId ||
+      binding.customerId !== (input.integration.customerId || null)
+    ) {
+      throw new ConflictException(
+        'Publication request binding does not match the provider activity'
+      );
+    }
+
+    // Validate the key before opening the transaction. A correlated post must
+    // never reach the provider without signed durable evidence.
+    signEvidenceHash('preflight', this.signingKey());
+    const operationKey = this.operationKey(
+      binding.id,
+      rootPostId,
+      input.integration.id
+    );
+
+    return this._prisma.$transaction(
+      async (database) => {
+        const blocking = await database.publicationAttemptEvent.findUnique({
+          where: { operationKey },
+        });
+        if (blocking) {
+          if (
+            blocking.type ===
+            PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS
+          ) {
+            return {
+              action: 'replay-success' as const,
+              result: this.replayResult(blocking.resultEvidence),
+            };
+          }
+          return { action: 'outcome-unknown' as const };
+        }
+
+        const openAttempt = await database.publicationAttempt.findFirst({
+          where: {
+            operationKey,
+            events: { none: { terminal: true } },
+          },
+          orderBy: { createdAt: 'desc' },
+        });
+        if (openAttempt) {
+          const evidence = {
+            claim: 'outcome-unknown',
+            reason: 'previous-activity-attempt-did-not-record-a-terminal-claim',
+          };
+          await this.createTerminalEvent(database, openAttempt, {
+            type: PublicationAttemptEventType.UNKNOWN,
+            reason: 'previous-attempt-not-terminal',
+            resultEvidence: evidence,
+          });
+          return { action: 'outcome-unknown' as const };
+        }
+
+        const payloadEvidence = buildAttemptEvidence(
+          input.integration,
+          input.mappedPosts
+        );
+        const createdAt = new Date();
+        const immutableEvidence = {
+          publicationRequestId: binding.publicationRequestId,
+          correlationId: binding.publicationRequest.correlationId,
+          organizationId: input.integration.organizationId,
+          customerId: binding.customerId || null,
+          rootPostId,
+          integrationId: input.integration.id,
+          providerIdentifier: input.integration.providerIdentifier,
+          operationKey,
+          workflowId: input.identity.workflowId,
+          runId: input.identity.runId,
+          activityId: input.identity.activityId,
+          activityType: input.identity.activityType,
+          temporalAttempt: input.identity.attempt,
+          createdAt: createdAt.toISOString(),
+          ...payloadEvidence,
+        };
+        const evidenceHash = canonicalSha256(immutableEvidence);
+        const attempt = await database.publicationAttempt.create({
+          data: {
+            publicationRequestBindingId: binding.id,
+            organizationId: input.integration.organizationId,
+            customerId: binding.customerId || null,
+            rootPostId,
+            integrationId: input.integration.id,
+            providerIdentifier: input.integration.providerIdentifier,
+            operationKey,
+            workflowId: input.identity.workflowId,
+            runId: input.identity.runId,
+            activityId: input.identity.activityId,
+            activityType: input.identity.activityType,
+            temporalAttempt: input.identity.attempt,
+            captionEvidence:
+              payloadEvidence.captionEvidence as Prisma.InputJsonValue,
+            settingsEvidence:
+              payloadEvidence.settingsEvidence as Prisma.InputJsonValue,
+            mediaEvidence:
+              payloadEvidence.mediaEvidence as Prisma.InputJsonValue,
+            accountEvidence:
+              payloadEvidence.accountEvidence as Prisma.InputJsonValue,
+            outgoingPayloadHash: payloadEvidence.outgoingPayloadHash,
+            evidenceHash,
+            evidenceSignature: signEvidenceHash(
+              evidenceHash,
+              this.signingKey()
+            ),
+            createdAt,
+          },
+        });
+
+        return { action: 'execute' as const, attemptId: attempt.id };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
+  }
+
+  async recordProviderResult(
+    attemptId: string,
+    rawResults: ProviderResult[]
+  ): Promise<'accepted' | 'success' | 'explicit-failure' | 'unknown'> {
+    const attemptEvidence =
+      await this._prisma.publicationAttempt.findUniqueOrThrow({
+        where: { id: attemptId },
+        select: { captionEvidence: true },
+      });
+    const expectedPostIds = Array.isArray(attemptEvidence.captionEvidence)
+      ? attemptEvidence.captionEvidence.map((item) => {
+          if (
+            !item ||
+            typeof item !== 'object' ||
+            Array.isArray(item) ||
+            typeof (item as Record<string, unknown>).postId !== 'string' ||
+            !(item as Record<string, unknown>).postId
+          ) {
+            return null;
+          }
+          return (item as Record<string, string>).postId;
+        })
+      : null;
+    const resultPostIds = Array.isArray(rawResults)
+      ? rawResults.map((result) =>
+          result && typeof result.id === 'string' && result.id
+            ? result.id
+            : null
+        )
+      : null;
+    const resultBindingMatches =
+      expectedPostIds &&
+      resultPostIds &&
+      expectedPostIds.length > 0 &&
+      expectedPostIds.length === resultPostIds.length &&
+      new Set(expectedPostIds).size === expectedPostIds.length &&
+      new Set(resultPostIds).size === resultPostIds.length &&
+      expectedPostIds.every(
+        (expectedPostId, position) =>
+          expectedPostId !== null && expectedPostId === resultPostIds[position]
+      );
+    if (!resultBindingMatches) {
+      await this.recordProviderFailure(
+        attemptId,
+        PublicationAttemptEventType.UNKNOWN,
+        'provider-result-post-binding-mismatch',
+        new Error(
+          'Provider result post IDs did not match immutable attempt evidence'
+        )
+      );
+      return 'unknown';
+    }
+
+    const statuses = rawResults.map((result) =>
+      String(result.status || '').toLowerCase()
+    );
+    if (statuses.every((status) => PROVIDER_REPORTED_FAILURE.has(status))) {
+      await this.recordProviderFailure(
+        attemptId,
+        PublicationAttemptEventType.EXPLICIT_FAILURE,
+        'provider-returned-explicit-failure',
+        new Error('Provider explicitly reported failure')
+      );
+      return 'explicit-failure';
+    }
+    if (
+      statuses.some(
+        (status) =>
+          status !== 'pending' && !PROVIDER_REPORTED_SUCCESS.has(status)
+      )
+    ) {
+      await this.recordProviderFailure(
+        attemptId,
+        PublicationAttemptEventType.UNKNOWN,
+        'unrecognized-or-mixed-provider-result',
+        new Error('Provider returned an unrecognized or mixed result status')
+      );
+      return 'unknown';
+    }
+
+    const results = normalizeProviderResult(rawResults);
+    if (
+      results.every(
+        (result) => result.status === 'provider-reported-success'
+      ) &&
+      results.some(
+        (result) =>
+          !result.platformReleaseId ||
+          !result.platformReleaseUrl ||
+          !result.postId
+      )
+    ) {
+      await this.recordProviderFailure(
+        attemptId,
+        PublicationAttemptEventType.UNKNOWN,
+        'incomplete-provider-success-result',
+        new Error('Provider success omitted a release id or URL')
+      );
+      return 'unknown';
+    }
+
+    const resultEvidence = {
+      claim: results.some((result) => result.status === 'provider-accepted')
+        ? 'provider-accepted'
+        : 'provider-reported-success',
+      independentlyPlatformVerified: false,
+      results,
+    };
+
+    if (results.some((result) => result.status === 'provider-accepted')) {
+      return this._prisma.$transaction(async (database) => {
+        const attempt = await database.publicationAttempt.findUniqueOrThrow({
+          where: { id: attemptId },
+        });
+        const existing = await database.publicationAttemptEvent.findUnique({
+          where: {
+            publicationAttemptId_type: {
+              publicationAttemptId: attemptId,
+              type: PublicationAttemptEventType.PROVIDER_ACCEPTED,
+            },
+          },
+        });
+        const event = this.eventData(attempt, {
+          type: PublicationAttemptEventType.PROVIDER_ACCEPTED,
+          terminal: false,
+          resultEvidence,
+        });
+        if (existing) {
+          if (existing.resultHash !== event.resultHash) {
+            throw new ConflictException(
+              'Publication attempt has conflicting provider acceptance evidence'
+            );
+          }
+          return 'accepted' as const;
+        }
+        await database.publicationAttemptEvent.create({ data: event });
+        return 'accepted' as const;
+      });
+    }
+
+    const first = results[0];
+    return this._prisma.$transaction(async (database) => {
+      const attempt = await database.publicationAttempt.findUniqueOrThrow({
+        where: { id: attemptId },
+      });
+      await this.createTerminalEvent(database, attempt, {
+        type: PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS,
+        resultEvidence,
+        platformReleaseId: first.platformReleaseId,
+        platformReleaseUrl: first.platformReleaseUrl,
+      });
+      return 'success' as const;
+    });
+  }
+
+  async recordProviderFailure(
+    attemptId: string,
+    type:
+      | typeof PublicationAttemptEventType.EXPLICIT_FAILURE
+      | typeof PublicationAttemptEventType.UNKNOWN,
+    reason: string,
+    error: unknown
+  ): Promise<void> {
+    const resultEvidence = {
+      claim:
+        type === PublicationAttemptEventType.EXPLICIT_FAILURE
+          ? 'explicit-provider-failure'
+          : 'outcome-unknown',
+      independentlyPlatformVerified: false,
+      error: buildErrorEvidence(error, reason),
+    };
+    await this._prisma.$transaction(async (database) => {
+      const attempt = await database.publicationAttempt.findUniqueOrThrow({
+        where: { id: attemptId },
+      });
+      await this.createTerminalEvent(database, attempt, {
+        type,
+        reason,
+        resultEvidence,
+      });
+    });
+  }
+
+  async completeFromWorkflow(
+    postId: string,
+    platformReleaseId: string,
+    platformReleaseUrl: string,
+    identity: Pick<TemporalAttemptIdentity, 'workflowId' | 'runId'>
+  ): Promise<boolean> {
+    const attempt = await this._prisma.publicationAttempt.findFirst({
+      where: {
+        rootPostId: postId,
+        workflowId: identity.workflowId,
+        runId: identity.runId,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!attempt) {
+      return false;
+    }
+
+    await this.recordProviderResult(attempt.id, [
+      {
+        id: postId,
+        postId: platformReleaseId,
+        releaseURL: platformReleaseUrl,
+        status: 'success',
+      },
+    ]);
+    return true;
+  }
+
+  async markOpenAttemptTerminal(
+    postId: string,
+    identity: Pick<TemporalAttemptIdentity, 'workflowId' | 'runId'>,
+    type:
+      | typeof PublicationAttemptEventType.EXPLICIT_FAILURE
+      | typeof PublicationAttemptEventType.UNKNOWN,
+    reason: string
+  ): Promise<boolean> {
+    return this._prisma.$transaction(async (database) => {
+      const attempt = await database.publicationAttempt.findFirst({
+        where: {
+          rootPostId: postId,
+          workflowId: identity.workflowId,
+          runId: identity.runId,
+          events: { none: { terminal: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+      if (!attempt) {
+        return false;
+      }
+
+      await this.createTerminalEvent(database, attempt, {
+        type,
+        reason,
+        resultEvidence: {
+          claim:
+            type === PublicationAttemptEventType.EXPLICIT_FAILURE
+              ? 'explicit-provider-failure'
+              : 'outcome-unknown',
+          independentlyPlatformVerified: false,
+          reason,
+        },
+      });
+      return true;
+    });
+  }
+
+  async isCorrelatedPost(rootPostId: string): Promise<boolean> {
+    return !!(await this._prisma.publicationRequestBinding.findUnique({
+      where: { rootPostId },
+      select: { id: true },
+    }));
+  }
+
+  async hasProviderReportedSuccess(
+    rootPostId: string,
+    identity: Pick<TemporalAttemptIdentity, 'workflowId' | 'runId'>
+  ): Promise<boolean> {
+    return !!(await this._prisma.publicationAttemptEvent.findFirst({
+      where: {
+        type: PublicationAttemptEventType.PROVIDER_REPORTED_SUCCESS,
+        publicationAttempt: {
+          rootPostId,
+          workflowId: identity.workflowId,
+          runId: identity.runId,
+        },
+      },
+      select: { id: true },
+    }));
+  }
+}

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -44,6 +44,8 @@ model Organization {
   webhooks            Webhooks[]
   oauthApp            OAuthApp[]
   oauthAuthorizations OAuthAuthorization[]
+  publicationRequests PublicationRequest[]
+  publicationAttempts PublicationAttempt[]
 
   @@index([apiKey])
   @@index([streakSince])
@@ -303,48 +305,52 @@ model Subscription {
 }
 
 model Customer {
-  id           String        @id @default(uuid())
-  name         String
-  orgId        String
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  deletedAt    DateTime?
-  organization Organization  @relation(fields: [orgId], references: [id])
-  integrations Integration[]
+  id                         String                      @id @default(uuid())
+  name                       String
+  orgId                      String
+  createdAt                  DateTime                    @default(now())
+  updatedAt                  DateTime                    @updatedAt
+  deletedAt                  DateTime?
+  organization               Organization                @relation(fields: [orgId], references: [id])
+  integrations               Integration[]
+  publicationRequestBindings PublicationRequestBinding[]
+  publicationAttempts        PublicationAttempt[]
 
   @@unique([orgId, name, deletedAt])
 }
 
 model Integration {
-  id                    String                 @id @default(cuid())
-  internalId            String
-  organizationId        String
-  name                  String
-  picture               String?
-  providerIdentifier    String
-  type                  String
-  token                 String
-  disabled              Boolean                @default(false)
-  tokenExpiration       DateTime?
-  refreshToken          String?
-  profile               String?
-  deletedAt             DateTime?
-  createdAt             DateTime               @default(now())
-  updatedAt             DateTime?              @updatedAt
-  inBetweenSteps        Boolean                @default(false)
-  refreshNeeded         Boolean                @default(false)
-  postingTimes          String                 @default("[{\"time\":120}, {\"time\":400}, {\"time\":700}]")
-  customInstanceDetails String?
-  customerId            String?
-  rootInternalId        String?
-  additionalSettings    String?                @default("[]")
-  exisingPlugData       ExisingPlugData[]
-  customer              Customer?              @relation(fields: [customerId], references: [id])
-  organization          Organization           @relation(fields: [organizationId], references: [id])
-  webhooks              IntegrationsWebhooks[]
-  orderItems            OrderItems[]
-  plugs                 Plugs[]
-  posts                 Post[]
+  id                         String                      @id @default(cuid())
+  internalId                 String
+  organizationId             String
+  name                       String
+  picture                    String?
+  providerIdentifier         String
+  type                       String
+  token                      String
+  disabled                   Boolean                     @default(false)
+  tokenExpiration            DateTime?
+  refreshToken               String?
+  profile                    String?
+  deletedAt                  DateTime?
+  createdAt                  DateTime                    @default(now())
+  updatedAt                  DateTime?                   @updatedAt
+  inBetweenSteps             Boolean                     @default(false)
+  refreshNeeded              Boolean                     @default(false)
+  postingTimes               String                      @default("[{\"time\":120}, {\"time\":400}, {\"time\":700}]")
+  customInstanceDetails      String?
+  customerId                 String?
+  rootInternalId             String?
+  additionalSettings         String?                     @default("[]")
+  exisingPlugData            ExisingPlugData[]
+  customer                   Customer?                   @relation(fields: [customerId], references: [id])
+  organization               Organization                @relation(fields: [organizationId], references: [id])
+  webhooks                   IntegrationsWebhooks[]
+  orderItems                 OrderItems[]
+  plugs                      Plugs[]
+  posts                      Post[]
+  publicationRequestBindings PublicationRequestBinding[]
+  publicationAttempts        PublicationAttempt[]
 
   @@unique([organizationId, internalId])
   @@index([rootInternalId])
@@ -395,13 +401,13 @@ model Comments {
 }
 
 model Post {
-  id                         String                    @id @default(cuid())
-  state                      State                     @default(QUEUE)
+  id                         String                     @id @default(cuid())
+  state                      State                      @default(QUEUE)
   publishDate                DateTime
   organizationId             String
   integrationId              String
   content                    String
-  delay                      Int                       @default(0)
+  delay                      Int                        @default(0)
   group                      String
   title                      String?
   description                String?
@@ -412,25 +418,27 @@ model Post {
   image                      String?
   submittedForOrderId        String?
   submittedForOrganizationId String?
-  approvedSubmitForOrder     APPROVED_SUBMIT_FOR_ORDER @default(NO)
-  creationMethod             CreationMethod            @default(UNKNOWN)
+  approvedSubmitForOrder     APPROVED_SUBMIT_FOR_ORDER  @default(NO)
+  creationMethod             CreationMethod             @default(UNKNOWN)
   lastMessageId              String?
   intervalInDays             Int?
   error                      String?
-  createdAt                  DateTime                  @default(now())
-  updatedAt                  DateTime                  @updatedAt
+  createdAt                  DateTime                   @default(now())
+  updatedAt                  DateTime                   @updatedAt
   deletedAt                  DateTime?
   comments                   Comments[]
   errors                     Errors[]
   payoutProblems             PayoutProblems[]
-  integration                Integration               @relation(fields: [integrationId], references: [id])
-  lastMessage                Messages?                 @relation(fields: [lastMessageId], references: [id])
-  organization               Organization              @relation("organization", fields: [organizationId], references: [id])
-  parentPost                 Post?                     @relation("parentPostId", fields: [parentPostId], references: [id])
-  childrenPost               Post[]                    @relation("parentPostId")
-  submittedForOrder          Orders?                   @relation(fields: [submittedForOrderId], references: [id])
-  submittedForOrganization   Organization?             @relation("submittedForOrg", fields: [submittedForOrganizationId], references: [id])
+  integration                Integration                @relation(fields: [integrationId], references: [id])
+  lastMessage                Messages?                  @relation(fields: [lastMessageId], references: [id])
+  organization               Organization               @relation("organization", fields: [organizationId], references: [id])
+  parentPost                 Post?                      @relation("parentPostId", fields: [parentPostId], references: [id])
+  childrenPost               Post[]                     @relation("parentPostId")
+  submittedForOrder          Orders?                    @relation(fields: [submittedForOrderId], references: [id])
+  submittedForOrganization   Organization?              @relation("submittedForOrg", fields: [submittedForOrganizationId], references: [id])
   tags                       TagsPosts[]
+  publicationRequestBinding  PublicationRequestBinding?
+  publicationAttempts        PublicationAttempt[]
 
   @@index([group])
   @@index([deletedAt])
@@ -447,6 +455,112 @@ model Post {
   @@index([updatedAt])
   @@index([releaseURL])
   @@index([integrationId])
+}
+
+// One public API request identity and its exact immutable root-post bindings.
+// Rows are append-only: application code exposes create/read operations only.
+model PublicationRequest {
+  id             String                      @id @default(uuid())
+  organizationId String
+  correlationId  String
+  requestHash    String
+  createdAt      DateTime                    @default(now())
+  organization   Organization                @relation(fields: [organizationId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  bindings       PublicationRequestBinding[]
+
+  @@unique([organizationId, correlationId])
+  @@index([createdAt])
+}
+
+model PublicationRequestBinding {
+  id                   String               @id @default(uuid())
+  publicationRequestId String
+  position             Int
+  rootPostId           String               @unique
+  integrationId        String
+  customerId           String?
+  createdAt            DateTime             @default(now())
+  publicationRequest   PublicationRequest   @relation(fields: [publicationRequestId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  rootPost             Post                 @relation(fields: [rootPostId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  integration          Integration          @relation(fields: [integrationId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  customer             Customer?            @relation(fields: [customerId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  attempts             PublicationAttempt[]
+
+  @@unique([publicationRequestId, position])
+  @@index([publicationRequestId])
+  @@index([integrationId])
+  @@index([customerId])
+}
+
+// The immutable evidence captured before one real provider mutation attempt.
+// It deliberately contains no provider token, headers, or raw media location.
+model PublicationAttempt {
+  id                          String                    @id @default(uuid())
+  publicationRequestBindingId String
+  organizationId              String
+  customerId                  String?
+  rootPostId                  String
+  integrationId               String
+  providerIdentifier          String
+  operationKey                String
+  workflowId                  String
+  runId                       String
+  activityId                  String
+  activityType                String
+  temporalAttempt             Int
+  captionEvidence             Json
+  settingsEvidence            Json
+  mediaEvidence               Json
+  accountEvidence             Json
+  outgoingPayloadHash         String
+  evidenceHash                String
+  evidenceSignature           String
+  createdAt                   DateTime                  @default(now())
+  publicationRequestBinding   PublicationRequestBinding @relation(fields: [publicationRequestBindingId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  organization                Organization              @relation(fields: [organizationId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  customer                    Customer?                 @relation(fields: [customerId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  rootPost                    Post                      @relation(fields: [rootPostId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  integration                 Integration               @relation(fields: [integrationId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+  events                      PublicationAttemptEvent[]
+
+  @@unique([workflowId, runId, activityId, temporalAttempt])
+  @@index([operationKey])
+  @@index([rootPostId])
+  @@index([integrationId])
+  @@index([publicationRequestBindingId])
+  @@index([createdAt])
+}
+
+// Immutable append-only claims. terminalAttemptId permits only one terminal
+// claim per attempt; operationKey permits only one success/unknown effect per
+// correlated root mutation while explicit failures remain retryable.
+model PublicationAttemptEvent {
+  id                   String                      @id @default(uuid())
+  publicationAttemptId String
+  type                 PublicationAttemptEventType
+  terminal             Boolean
+  terminalAttemptId    String?                     @unique
+  operationKey         String?                     @unique
+  reason               String?
+  platformReleaseId    String?
+  platformReleaseUrl   String?
+  resultEvidence       Json
+  resultHash           String
+  evidenceHash         String
+  evidenceSignature    String
+  createdAt            DateTime                    @default(now())
+  publicationAttempt   PublicationAttempt          @relation(fields: [publicationAttemptId], references: [id], onDelete: Restrict, onUpdate: Restrict)
+
+  @@unique([publicationAttemptId, type])
+  @@index([publicationAttemptId])
+  @@index([createdAt])
+}
+
+enum PublicationAttemptEventType {
+  PROVIDER_ACCEPTED
+  PROVIDER_REPORTED_SUCCESS
+  EXPLICIT_FAILURE
+  UNKNOWN
 }
 
 model Notifications {

--- a/vitest.publication-attempt.config.ts
+++ b/vitest.publication-attempt.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: [
+      'libraries/nestjs-libraries/src/database/prisma/publication-attempt/*.spec.ts',
+      'apps/orchestrator/src/activities/post.activity.publication-attempt.spec.ts',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

Add fail-closed, immutable publication evidence for idempotent public API requests so retries cannot silently create duplicate provider actions and provider acceptance is not confused with independent publication verification.

- accepts and validates the standard `Idempotency-Key` header on `POST /public/v1/posts`
- atomically binds the idempotency key/request hash to organization, customer, root posts, and integrations
- replays an identical request and returns `409` for conflicting key reuse
- retries the complete serializable transaction on bounded Prisma `P2034` write conflicts so concurrent first use resolves to the durable winner
- persists a signed `PublicationAttempt` before invoking `post()` / `postPending()`
- binds workflow/run/activity/attempt identity plus normalized caption, settings, media, account, and outgoing-payload hashes
- records provider acceptance, provider-reported success, explicit rejection, and unknown outcomes as distinct append-only claims
- requires exact ordered one-to-one provider result IDs before accepting or signing any provider result
- accepts only homogeneous result sets: all explicit failures, all pending, or all recognized successes
- rejects malformed/non-string success metadata and non-HTTP(S) release URLs as `UNKNOWN`
- commits terminal evidence and the root Post projection atomically
- blocks retries after success or an ambiguous outcome while allowing a later attempt after explicit rejection
- hashes/redacts credentials, headers, media locations, opaque provider errors, and unsafe release URLs
- never claims independent platform verification

## Safety properties

- Failure to persist or sign pre-provider evidence prevents provider invocation.
- Wrong, missing, extra, duplicate, reordered, mixed, or malformed results become `UNKNOWN`; they cannot mark a Post `PUBLISHED`.
- Pending acceptance remains nonterminal. Later polling/finalization records the terminal provider claim.
- Workflow completion cannot report success without valid durable provider-success evidence.
- Request-bound posts cannot enter `PUBLISHED` through an evidence-free state transition.
- A lost activity response cannot downgrade an already committed provider-reported success.
- Exhausted database write-conflict retries fail without starting a provider workflow; successful retry starts at most one workflow after commit.
- Idempotent repeating posts are rejected because one stable operation key cannot truthfully describe recurring mutations.

## Deployment

Set `POSTIZ_PUBLICATION_EVIDENCE_HMAC_KEY` to at least 32 bytes before sending idempotent publication requests. This repository deploys Prisma changes through its existing `prisma db push` convention; this PR does not introduce a separate migration framework.

## Verification

Run with Node 22.14.0 and pnpm 10.6.1:

- focused Vitest: 5 files, 35 tests passed
- backend production build passed
- orchestrator production build passed
- Prisma 6.5 validation and client generation passed
- Prettier and `git diff --check` passed

No social credentials, live provider calls, deployment, or database mutation outside test doubles were used. Targeted ESLint could not start because the existing ESLint 8 configuration serializes a circular React plugin config; it failed before source linting.

## Deliberate limits

`PROVIDER_REPORTED_SUCCESS` is only Postiz's authenticated provider-path claim; `independentlyPlatformVerified` remains false. Signed/retrying delivery of these claims to external consumers and direct social-platform verification are follow-up capabilities, not claims made by this PR.

