### PR TITLE
feat(short-linking): HikrLink provider; fix(linkedin): opt-in personal-only scopes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,7 +158,7 @@ POSTIZ_OAUTH_CLIENT_SECRET=""
 # LINK_DRIP_API_KEY="" # Your LinkDrip API key
 # HIKRLINK_API_KEY="" # HikrLink (hikrlink.com) API key — first-party, server-side link attribution
 # HIKRLINK_API_ENDPOINT="https://api.hikrl.ink/api"
-# HIKRLINK_SHORT_LINK_DOMAIN="hk.ink"
+# HIKRLINK_SHORT_LINK_DOMAIN="hikrl.ink"
 # LINK_DRIP_API_ENDPOINT="https://api.linkdrip.com/v1/" # Your self-hosted LinkDrip API endpoint
 # LINK_DRIP_SHORT_LINK_DOMAIN="dripl.ink" # Your self-hosted LinkDrip domain
 

--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,9 @@ POSTIZ_OAUTH_CLIENT_SECRET=""
 # KUTT_SHORT_LINK_DOMAIN="kutt.it" # Your self-hosted Kutt domain
 
 # LINK_DRIP_API_KEY="" # Your LinkDrip API key
+# HIKRLINK_API_KEY="" # HikrLink (hikrlink.com) API key — first-party, server-side link attribution
+# HIKRLINK_API_ENDPOINT="https://api.hikrl.ink/api"
+# HIKRLINK_SHORT_LINK_DOMAIN="hk.ink"
 # LINK_DRIP_API_ENDPOINT="https://api.linkdrip.com/v1/" # Your self-hosted LinkDrip API endpoint
 # LINK_DRIP_SHORT_LINK_DOMAIN="dripl.ink" # Your self-hosted LinkDrip domain
 

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@ X_API_KEY=""
 X_API_SECRET=""
 LINKEDIN_CLIENT_ID=""
 LINKEDIN_CLIENT_SECRET=""
+# LINKEDIN_PERSONAL_SCOPES_ONLY="true" # personal channel only needs Sign In + Share products; set until Community Management API is approved
 REDDIT_CLIENT_ID=""
 REDDIT_CLIENT_SECRET=""
 GITHUB_CLIENT_ID=""

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -61,15 +61,23 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   oneTimeToken = true;
 
   isBetweenSteps = false;
-  scopes = [
-    'openid',
-    'profile',
-    'w_member_social',
-    'r_basicprofile',
-    'rw_organization_admin',
-    'w_organization_social',
-    'r_organization_social',
-  ];
+  // LINKEDIN_PERSONAL_SCOPES_ONLY=true: request only the scopes granted by the
+  // self-serve products (Sign In with LinkedIn + Share on LinkedIn). Lets the
+  // personal channel connect on apps that have not (yet) been approved for the
+  // Community Management API; LinkedIn rejects the whole consent otherwise
+  // (unauthorized_scope_error). The page provider overrides `scopes` itself.
+  scopes =
+    process.env.LINKEDIN_PERSONAL_SCOPES_ONLY === 'true'
+      ? ['openid', 'profile', 'email', 'w_member_social']
+      : [
+          'openid',
+          'profile',
+          'w_member_social',
+          'r_basicprofile',
+          'rw_organization_admin',
+          'w_organization_social',
+          'r_organization_social',
+        ];
   override maxConcurrentJob = 2;
   refreshWait = true;
   editor = 'normal' as const;
@@ -237,13 +245,19 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       })
     ).json();
 
-    const { vanityName } = await (
-      await fetch('https://api.linkedin.com/v2/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
+    // /v2/me needs r_basicprofile (Community Management); without it fall back to the id.
+    let vanityName: string | undefined;
+    try {
+      ({ vanityName } = await (
+        await fetch('https://api.linkedin.com/v2/me', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        })
+      ).json());
+    } catch {
+      vanityName = undefined;
+    }
 
     return {
       id,
@@ -252,7 +266,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       expiresIn,
       name,
       picture,
-      username: vanityName,
+      username: vanityName || id,
     };
   }
 

--- a/libraries/nestjs-libraries/src/short-linking/providers/hikrlink.ts
+++ b/libraries/nestjs-libraries/src/short-linking/providers/hikrlink.ts
@@ -1,0 +1,108 @@
+import { ShortLinking } from '@gitroom/nestjs-libraries/short-linking/short-linking.interface';
+
+/**
+ * HikrLink (https://hikrlink.com) — first-party, server-side link attribution.
+ * Public API, `x-api-key` auth (API_ACCESS entitlement):
+ *   POST /public/urls                         → { url, shorturlId, ... }   (short URL on the owner's domain)
+ *   GET  /public/urls?page&pageSize           → { items: [{ shorturlId, url, redirectUrl, clicks, createdAt }], total }
+ *   GET  /public/urls/:shorturlId             → { shorturlId, url, redirectUrl, clicks, createdAt }
+ *   GET  /public/urls/:shorturlId/statistics  → { period, series, aggregates: { totalClicks, ... } }
+ * Env: HIKRLINK_API_KEY (required to activate), HIKRLINK_API_ENDPOINT (default https://api.hikrl.ink/api),
+ *      HIKRLINK_SHORT_LINK_DOMAIN (default hk.ink; only used for display — the API returns the real short URL).
+ */
+const HIKRLINK_API_ENDPOINT =
+  process.env.HIKRLINK_API_ENDPOINT || 'https://api.hikrl.ink/api';
+const HIKRLINK_SHORT_LINK_DOMAIN =
+  process.env.HIKRLINK_SHORT_LINK_DOMAIN || 'hk.ink';
+
+const getOptions = () => ({
+  headers: {
+    'x-api-key': process.env.HIKRLINK_API_KEY,
+    'Content-Type': 'application/json',
+  },
+});
+
+const slugOf = (shortLink: string) => shortLink.split('/').pop();
+
+export class HikrLink implements ShortLinking {
+  shortLinkDomain = HIKRLINK_SHORT_LINK_DOMAIN;
+
+  async convertLinkToShortLink(_id: string, link: string) {
+    const response = await fetch(`${HIKRLINK_API_ENDPOINT}/public/urls`, {
+      ...getOptions(),
+      method: 'POST',
+      body: JSON.stringify({ url: link }),
+    });
+    if (!response.ok) {
+      throw new Error(`HikrLink: failed to create short link (HTTP ${response.status})`);
+    }
+    const data = await response.json();
+    if (!data?.url) {
+      throw new Error('HikrLink: create response had no url');
+    }
+    return data.url as string;
+  }
+
+  async convertShortLinkToLink(shortLink: string) {
+    const response = await fetch(
+      `${HIKRLINK_API_ENDPOINT}/public/urls/${slugOf(shortLink)}`,
+      getOptions()
+    );
+    if (!response.ok) {
+      throw new Error(`HikrLink: failed to resolve short link (HTTP ${response.status})`);
+    }
+    const data = await response.json();
+    return (data?.redirectUrl as string) || '';
+  }
+
+  async linksStatistics(links: string[]) {
+    return Promise.all(
+      links.map(async (short) => {
+        try {
+          const response = await fetch(
+            `${HIKRLINK_API_ENDPOINT}/public/urls/${slugOf(short)}`,
+            getOptions()
+          );
+          if (!response.ok) {
+            return { short, original: '', clicks: '0' };
+          }
+          const data = await response.json();
+          return {
+            short,
+            original: data?.redirectUrl || '',
+            clicks: String(data?.clicks ?? 0),
+          };
+        } catch {
+          return { short, original: '', clicks: '0' };
+        }
+      })
+    );
+  }
+
+  async getAllLinksStatistics(
+    id: string,
+    page = 1
+  ): Promise<{ short: string; original: string; clicks: string }[]> {
+    try {
+      const response = await fetch(
+        `${HIKRLINK_API_ENDPOINT}/public/urls?page=${page}&pageSize=100`,
+        getOptions()
+      );
+      if (!response.ok) {
+        return [];
+      }
+      const data = await response.json();
+      const mapped = (data?.items || []).map((item: any) => ({
+        short: item.url,
+        original: item.redirectUrl,
+        clicks: String(item.clicks ?? 0),
+      }));
+      if (mapped.length < 100) {
+        return mapped;
+      }
+      return [...mapped, ...(await this.getAllLinksStatistics(id, page + 1))];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/libraries/nestjs-libraries/src/short-linking/providers/hikrlink.ts
+++ b/libraries/nestjs-libraries/src/short-linking/providers/hikrlink.ts
@@ -3,17 +3,17 @@ import { ShortLinking } from '@gitroom/nestjs-libraries/short-linking/short-link
 /**
  * HikrLink (https://hikrlink.com) — first-party, server-side link attribution.
  * Public API, `x-api-key` auth (API_ACCESS entitlement):
- *   POST /public/urls                         → { url, shorturlId, ... }   (short URL on the owner's domain)
+ *   POST /public/urls                         → the URL entity: { shorturlId, url (= destination), ... }
  *   GET  /public/urls?page&pageSize           → { items: [{ shorturlId, url, redirectUrl, clicks, createdAt }], total }
  *   GET  /public/urls/:shorturlId             → { shorturlId, url, redirectUrl, clicks, createdAt }
  *   GET  /public/urls/:shorturlId/statistics  → { period, series, aggregates: { totalClicks, ... } }
  * Env: HIKRLINK_API_KEY (required to activate), HIKRLINK_API_ENDPOINT (default https://api.hikrl.ink/api),
- *      HIKRLINK_SHORT_LINK_DOMAIN (default hk.ink; only used for display — the API returns the real short URL).
+ *      HIKRLINK_SHORT_LINK_DOMAIN (default hikrl.ink; the short URL is <domain>/<shorturlId>).
  */
 const HIKRLINK_API_ENDPOINT =
   process.env.HIKRLINK_API_ENDPOINT || 'https://api.hikrl.ink/api';
 const HIKRLINK_SHORT_LINK_DOMAIN =
-  process.env.HIKRLINK_SHORT_LINK_DOMAIN || 'hk.ink';
+  process.env.HIKRLINK_SHORT_LINK_DOMAIN || 'hikrl.ink';
 
 const getOptions = () => ({
   headers: {
@@ -37,10 +37,10 @@ export class HikrLink implements ShortLinking {
       throw new Error(`HikrLink: failed to create short link (HTTP ${response.status})`);
     }
     const data = await response.json();
-    if (!data?.url) {
-      throw new Error('HikrLink: create response had no url');
+    if (!data?.shorturlId) {
+      throw new Error('HikrLink: create response had no shorturlId');
     }
-    return data.url as string;
+    return `https://${this.shortLinkDomain}/${data.shorturlId}`;
   }
 
   async convertShortLinkToLink(shortLink: string) {

--- a/libraries/nestjs-libraries/src/short-linking/short.link.service.ts
+++ b/libraries/nestjs-libraries/src/short-linking/short.link.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { ShortIo } from './providers/short.io';
 import { Kutt } from './providers/kutt';
 import { LinkDrip } from './providers/linkdrip';
+import { HikrLink } from './providers/hikrlink';
 import { uniq } from 'lodash';
 import striptags from 'striptags';
 
@@ -23,6 +24,10 @@ const getProvider = (): ShortLinking => {
 
   if (process.env.LINK_DRIP_API_KEY) {
     return new LinkDrip();
+  }
+
+  if (process.env.HIKRLINK_API_KEY) {
+    return new HikrLink();
   }
 
   return new Empty();


### PR DESCRIPTION
## HikrLink short-link provider

Adds [HikrLink](https://hikrlink.com) (first-party, server-side link attribution) as a short-link provider, selected by `HIKRLINK_API_KEY` — same pattern as Dub / Short.io / Kutt / LinkDrip.

- `libraries/nestjs-libraries/src/short-linking/providers/hikrlink.ts` — implements `ShortLinking`: create (`POST /public/urls`), resolve, per-link stats, paged list.
- `short.link.service.ts` — provider selection.
- `.env.example` — `HIKRLINK_API_KEY`, `HIKRLINK_API_ENDPOINT` (default `https://api.hikrl.ink/api`), `HIKRLINK_SHORT_LINK_DOMAIN` (default `hikrl.ink`).

Tested on a self-hosted Postiz: a post containing a raw URL was stored with `https://hikrl.ink/<slug>` after creation.

## LinkedIn: `LINKEDIN_PERSONAL_SCOPES_ONLY`

`LinkedinProvider.scopes` currently requests `rw_organization_admin`, `w_organization_social`, `r_organization_social`, `r_basicprofile` unconditionally — including for the *personal* channel. Apps that have only the self-serve products (Sign In with LinkedIn + Share on LinkedIn) and have not been approved for the Community Management API get `unauthorized_scope_error` and cannot connect a personal profile at all.

Opt-in env `LINKEDIN_PERSONAL_SCOPES_ONLY=true` makes the personal provider request `openid profile email w_member_social` only; `/v2/me` (needs `r_basicprofile`) degrades to the OIDC `sub` for `username`. Default behaviour is unchanged. `LinkedinPageProvider` overrides `scopes` and is untouched.

Happy to split into two PRs if preferred.