### PR TITLE
fix: enforce Telegram 1024-character caption limit when media is attached

### DIFF
--- a/apps/frontend/src/components/launches/information.component.tsx
+++ b/apps/frontend/src/components/launches/information.component.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { FC, Fragment, useMemo } from 'react';
+import React, { FC, Fragment, useCallback, useMemo } from 'react';
 import { useLaunchStore } from '@gitroom/frontend/components/new-launch/store';
 import { useShallow } from 'zustand/react/shallow';
 import clsx from 'clsx';
@@ -8,6 +8,7 @@ import SafeImage from '@gitroom/react/helpers/safe.image';
 import { capitalize } from 'lodash';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { hasLinks } from '@gitroom/helpers/utils/strip.links';
+import { countLength } from '@gitroom/helpers/utils/count.length';
 
 const Valid: FC = () => {
   return (
@@ -91,6 +92,13 @@ export const InformationComponent: FC<{
 
   const showStripLinkWarning = stripLinkNames.length > 0;
 
+  const countFor = useCallback(
+    (identifier?: string) => countLength(identifier || '', text || ''),
+    [text]
+  );
+
+  const currentChars = countFor(currentIntegration?.identifier);
+
   const isInternal = useMemo(() => {
     if (!isGlobal) {
       return [];
@@ -113,11 +121,11 @@ export const InformationComponent: FC<{
       return false;
     }
 
-    if (totalChars > totalAllowedChars && !isGlobal) {
+    if (currentChars > totalAllowedChars && !isGlobal) {
       return false;
     }
 
-    if (totalChars <= totalAllowedChars && !isGlobal) {
+    if (currentChars <= totalAllowedChars && !isGlobal) {
       return true;
     }
 
@@ -127,7 +135,10 @@ export const InformationComponent: FC<{
           return false;
         }
 
-        return totalChars > (chars?.[p.integration.id] || 0);
+        return (
+          countFor(p.integration.identifier) >
+          (chars?.[p.integration.id] || 0)
+        );
       })
     ) {
       return false;
@@ -137,6 +148,8 @@ export const InformationComponent: FC<{
   }, [
     totalAllowedChars,
     totalChars,
+    currentChars,
+    countFor,
     isInternal,
     isPicture,
     chars,
@@ -152,11 +165,11 @@ export const InformationComponent: FC<{
     const limits = selectedIntegrations
       .map((p, index) => ({
         limit: chars?.[p.integration.id] || 0,
+        count: countFor(p.integration.identifier),
         isInternal: isInternal[index],
       }))
       .filter((item) => !item.isInternal && item.limit > 0)
-      .map((item) => item.limit)
-      .sort((a, b) => a - b);
+      .sort((a, b) => a.limit - b.limit);
 
     if (!limits.length) {
       return null;
@@ -164,9 +177,9 @@ export const InformationComponent: FC<{
 
     // Find the smallest limit that hasn't been exceeded yet
     // If all are exceeded, show the smallest one
-    const validLimit = limits.find((limit) => totalChars <= limit);
+    const validLimit = limits.find((item) => item.count <= item.limit);
     return validLimit ?? limits[0];
-  }, [isGlobal, selectedIntegrations, chars, isInternal, totalChars]);
+  }, [isGlobal, selectedIntegrations, chars, isInternal, countFor]);
 
   return (
     <div
@@ -179,12 +192,12 @@ export const InformationComponent: FC<{
 
       {!isGlobal && (
         <div className={clsx("text-[10px] font-[600] flex justify-center items-center", !isValid && 'text-white')}>
-          {totalChars}/{totalAllowedChars}
+          {currentChars}/{totalAllowedChars}
         </div>
       )}
       {isGlobal && globalDisplayLimit !== null && (
         <div className={clsx("text-[10px] font-[600] flex justify-center items-center", !isValid && 'text-white')}>
-          {totalChars}/{globalDisplayLimit}
+          {globalDisplayLimit.count}/{globalDisplayLimit.limit}
         </div>
       )}
       {((isGlobal && selectedIntegrations.length) || !isValid) && (
@@ -237,7 +250,8 @@ export const InformationComponent: FC<{
                       'whitespace-nowrap',
                       isInternal?.[index]
                         ? ''
-                        : totalChars > (chars?.[p.integration.id] || 0)
+                        : countFor(p.integration.identifier) >
+                          (chars?.[p.integration.id] || 0)
                         ? 'text-[#FF3F3F]'
                         : ''
                     )}
@@ -250,14 +264,17 @@ export const InformationComponent: FC<{
                       'whitespace-nowrap',
                       isInternal?.[index]
                         ? ''
-                        : totalChars > (chars?.[p.integration.id] || 0)
+                        : countFor(p.integration.identifier) >
+                          (chars?.[p.integration.id] || 0)
                         ? 'text-[#FF3F3F]'
                         : ''
                     )}
                   >
                     {isInternal?.[index]
                       ? t('internal_edit', 'Internal Edit')
-                      : `${totalChars}/${chars?.[p.integration.id] || 0}`}
+                      : `${countFor(p.integration.identifier)}/${
+                          chars?.[p.integration.id] || 0
+                        }`}
                   </div>
                 </Fragment>
               ))}

--- a/apps/frontend/src/components/launches/information.component.tsx
+++ b/apps/frontend/src/components/launches/information.component.tsx
@@ -64,17 +64,31 @@ export const InformationComponent: FC<{
   text?: string;
 }> = ({ totalChars, totalAllowedChars, chars, isPicture, text }) => {
   const t = useT();
-  const { isGlobal, selectedIntegrations, internal, currentIntegration } =
-    useLaunchStore(
-      useShallow((state) => ({
-        isGlobal: state.current === 'global',
-        selectedIntegrations: state.selectedIntegrations,
-        internal: state.internal,
-        currentIntegration: state.integrations.find(
-          (p) => p.id === state.current
-        ),
-      }))
-    );
+  const {
+    isGlobal,
+    selectedIntegrations,
+    internal,
+    currentIntegration,
+    charsWithMedia,
+  } = useLaunchStore(
+    useShallow((state) => ({
+      isGlobal: state.current === 'global',
+      selectedIntegrations: state.selectedIntegrations,
+      internal: state.internal,
+      currentIntegration: state.integrations.find(
+        (p) => p.id === state.current
+      ),
+      charsWithMedia: state.charsWithMedia,
+    }))
+  );
+
+  const limitFor = (id: string) =>
+    (isPicture ? charsWithMedia?.[id] : chars?.[id]) || 0;
+
+  const allowedChars =
+    (!isGlobal && isPicture && currentIntegration
+      ? charsWithMedia?.[currentIntegration.id]
+      : undefined) || totalAllowedChars;
 
   const stripLinkNames = useMemo(() => {
     if (!hasLinks(text)) {
@@ -121,11 +135,11 @@ export const InformationComponent: FC<{
       return false;
     }
 
-    if (currentChars > totalAllowedChars && !isGlobal) {
+    if (currentChars > allowedChars && !isGlobal) {
       return false;
     }
 
-    if (currentChars <= totalAllowedChars && !isGlobal) {
+    if (currentChars <= allowedChars && !isGlobal) {
       return true;
     }
 
@@ -136,8 +150,7 @@ export const InformationComponent: FC<{
         }
 
         return (
-          countFor(p.integration.identifier) >
-          (chars?.[p.integration.id] || 0)
+          countFor(p.integration.identifier) > limitFor(p.integration.id)
         );
       })
     ) {
@@ -147,12 +160,14 @@ export const InformationComponent: FC<{
     return true;
   }, [
     totalAllowedChars,
+    allowedChars,
     totalChars,
     currentChars,
     countFor,
     isInternal,
     isPicture,
     chars,
+    charsWithMedia,
     showStripLinkWarning,
   ]);
 
@@ -164,7 +179,7 @@ export const InformationComponent: FC<{
     // Get all limits from non-internal integrations, sorted ascending
     const limits = selectedIntegrations
       .map((p, index) => ({
-        limit: chars?.[p.integration.id] || 0,
+        limit: limitFor(p.integration.id),
         count: countFor(p.integration.identifier),
         isInternal: isInternal[index],
       }))
@@ -179,7 +194,15 @@ export const InformationComponent: FC<{
     // If all are exceeded, show the smallest one
     const validLimit = limits.find((item) => item.count <= item.limit);
     return validLimit ?? limits[0];
-  }, [isGlobal, selectedIntegrations, chars, isInternal, countFor]);
+  }, [
+    isGlobal,
+    selectedIntegrations,
+    chars,
+    charsWithMedia,
+    isPicture,
+    isInternal,
+    countFor,
+  ]);
 
   return (
     <div
@@ -192,7 +215,7 @@ export const InformationComponent: FC<{
 
       {!isGlobal && (
         <div className={clsx("text-[10px] font-[600] flex justify-center items-center", !isValid && 'text-white')}>
-          {currentChars}/{totalAllowedChars}
+          {currentChars}/{allowedChars}
         </div>
       )}
       {isGlobal && globalDisplayLimit !== null && (
@@ -251,7 +274,7 @@ export const InformationComponent: FC<{
                       isInternal?.[index]
                         ? ''
                         : countFor(p.integration.identifier) >
-                          (chars?.[p.integration.id] || 0)
+                          limitFor(p.integration.id)
                         ? 'text-[#FF3F3F]'
                         : ''
                     )}
@@ -265,16 +288,16 @@ export const InformationComponent: FC<{
                       isInternal?.[index]
                         ? ''
                         : countFor(p.integration.identifier) >
-                          (chars?.[p.integration.id] || 0)
+                          limitFor(p.integration.id)
                         ? 'text-[#FF3F3F]'
                         : ''
                     )}
                   >
                     {isInternal?.[index]
                       ? t('internal_edit', 'Internal Edit')
-                      : `${countFor(p.integration.identifier)}/${
-                          chars?.[p.integration.id] || 0
-                        }`}
+                      : `${countFor(p.integration.identifier)}/${limitFor(
+                          p.integration.id
+                        )}`}
                   </div>
                 </Fragment>
               ))}

--- a/apps/frontend/src/components/new-launch/providers/high.order.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/high.order.provider.tsx
@@ -48,7 +48,7 @@ export const withProvider = function <T extends object>(params: {
     maximumCharacters?: number;
   }>;
   dto?: any;
-  maximumCharacters?: number | ((settings: any) => number);
+  maximumCharacters?: number | ((settings: any, hasMedia?: boolean) => number);
 }) {
   const {
     postComment,
@@ -117,6 +117,14 @@ export const withProvider = function <T extends object>(params: {
               JSON.parse(
                 selectedIntegration.integration.additionalSettings || '[]'
               )
+            ),
+        typeof maximumCharacters === 'number'
+          ? maximumCharacters
+          : maximumCharacters(
+              JSON.parse(
+                selectedIntegration.integration.additionalSettings || '[]'
+              ),
+              true
             )
       );
 
@@ -356,7 +364,7 @@ export const getProviderSettingsMeta = (component: unknown) => {
         CustomPreviewComponent?: FC<{ maximumCharacters?: number }>;
         dto?: any;
         postComment: PostComment;
-        maximumCharacters?: number | ((settings: any) => number);
+        maximumCharacters?: number | ((settings: any, hasMedia?: boolean) => number);
       }
     | undefined;
 };

--- a/apps/frontend/src/components/new-launch/providers/telegram/telegram.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/telegram/telegram.provider.tsx
@@ -10,5 +10,5 @@ export default withProvider({
   SettingsComponent: null,
   CustomPreviewComponent: undefined,
   dto: undefined,
-  maximumCharacters: 4096,
+  maximumCharacters: (settings, hasMedia) => (hasMedia ? 1024 : 4096),
 });

--- a/apps/frontend/src/components/new-launch/store.ts
+++ b/apps/frontend/src/components/new-launch/store.ts
@@ -130,8 +130,9 @@ interface StoreState {
   setDummy: (dummy: boolean) => void;
   setEditor: (editor: 'none' | 'normal' | 'markdown' | 'html') => void;
   setLoaded?: (loaded: boolean) => void;
-  setChars: (id: string, chars: number) => void;
+  setChars: (id: string, chars: number, charsWithMedia?: number) => void;
   chars: Record<string, number>;
+  charsWithMedia: Record<string, number>;
   setComments: (comments: boolean | 'no-media') => void;
 }
 
@@ -155,6 +156,7 @@ const initialState = {
   global: [] as Values[],
   internal: [] as Internal[],
   chars: {},
+  charsWithMedia: {},
 };
 
 export const useLaunchStore = create<StoreState>()((set) => ({
@@ -621,11 +623,15 @@ export const useLaunchStore = create<StoreState>()((set) => ({
     set((state) => ({
       loaded,
     })),
-  setChars: (id: string, chars: number) =>
+  setChars: (id: string, chars: number, charsWithMedia?: number) =>
     set((state) => ({
       chars: {
         ...state.chars,
         [id]: chars,
+      },
+      charsWithMedia: {
+        ...state.charsWithMedia,
+        [id]: charsWithMedia ?? chars,
       },
     })),
   setComments: (comments: boolean | 'no-media') =>

--- a/libraries/helpers/src/utils/count.length.ts
+++ b/libraries/helpers/src/utils/count.length.ts
@@ -37,3 +37,15 @@ export const textSlicer = (
 export const weightedLength = (text: string): number => {
   return twitter.parseTweet(text).weightedLength;
 };
+
+export const countLength = (integrationType: string, text: string): number => {
+  if (integrationType === 'x') {
+    return weightedLength(text);
+  }
+
+  if (integrationType === 'threads') {
+    return new TextEncoder().encode(text).length;
+  }
+
+  return text.length;
+};

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -826,7 +826,12 @@ export class PostsService {
           errors = err?.message || 'Invalid media';
         }
 
-        const maximumCharacters = provider.maxLength(additionalSettings, settings);
+        const maxLengthFor = (a: { image?: any[] }) =>
+          provider.maxLength(
+            additionalSettings,
+            settings,
+            (a.image || []).length > 0
+          );
 
         const emptyContent = (post.value || []).some((a) => {
           const strip = stripHtmlValidation('normal', a.content || '', true);
@@ -834,11 +839,15 @@ export class PostsService {
           return length === 0 && (a.image || []).length === 0;
         });
 
-        const tooLong = (post.value || []).some((a) => {
+        const tooLongValue = (post.value || []).find((a) => {
           const strip = stripHtmlValidation('normal', a.content || '', true);
           const counted = countLength(integration.providerIdentifier, strip);
-          return counted > (maximumCharacters || 1000000);
+          return counted > (maxLengthFor(a) || 1000000);
         });
+        const tooLong = !!tooLongValue;
+        const maximumCharacters = maxLengthFor(
+          tooLongValue || post.value?.[0] || {}
+        );
 
         return {
           id: integration.id,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -53,7 +53,7 @@ import { stripLinks } from '@gitroom/helpers/utils/strip.links';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
-import { weightedLength } from '@gitroom/helpers/utils/count.length';
+import { countLength } from '@gitroom/helpers/utils/count.length';
 
 type PostWithConditionals = Post & {
   integration?: Integration;
@@ -827,20 +827,17 @@ export class PostsService {
         }
 
         const maximumCharacters = provider.maxLength(additionalSettings, settings);
-        const isX = integration.providerIdentifier === 'x';
 
         const emptyContent = (post.value || []).some((a) => {
           const strip = stripHtmlValidation('normal', a.content || '', true);
-          const length = isX ? weightedLength(strip) : strip.length;
+          const length = countLength(integration.providerIdentifier, strip);
           return length === 0 && (a.image || []).length === 0;
         });
 
         const tooLong = (post.value || []).some((a) => {
           const strip = stripHtmlValidation('normal', a.content || '', true);
-          const weighted = isX ? weightedLength(strip) : strip.length;
-          const totalCharacters =
-            weighted > strip.length ? weighted : strip.length;
-          return totalCharacters > (maximumCharacters || 1000000);
+          const counted = countLength(integration.providerIdentifier, strip);
+          return counted > (maximumCharacters || 1000000);
         });
 
         return {

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -168,7 +168,11 @@ export interface SocialProvider
   stripLinks?: () => boolean;
   refreshCron?: boolean;
   dto?: any;
-  maxLength: (additionalSettings?: any, settings?: any) => number;
+  maxLength: (
+    additionalSettings?: any,
+    settings?: any,
+    hasMedia?: boolean
+  ) => number;
   checkValidity(
     posts: Array<{ path: string; thumbnail?: string }[]>,
     settings: any,

--- a/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
@@ -26,8 +26,8 @@ export class TelegramProvider extends SocialAbstract implements SocialProvider {
   isWeb3 = true;
   scopes = [] as string[];
   editor = 'html' as const;
-  maxLength() {
-    return 4096;
+  maxLength(additionalSettings?: any, settings?: any, hasMedia?: boolean) {
+    return hasMedia ? 1024 : 4096;
   }
 
   async refreshToken(refresh_token: string): Promise<AuthTokenDetails> {


### PR DESCRIPTION
# ⚠️ STACKED ON #1946 — DO NOT MERGE UNTIL #1946 IS MERGED

This branch is based on `fix/threads-byte-length` (#1946) and its diff includes that PR's commit. Merge #1946 first, then change this PR's base to `main` before merging.

# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

Telegram's Bot API allows up to 4096 characters for a text message, but only **1024 characters for a media caption** ("0-1024 characters after entities parsing", https://core.telegram.org/bots/api). Postiz sends the post text as the caption whenever media is attached (`sendPhoto`/`sendVideo`/`sendDocument`, or the first item of `sendMediaGroup`), yet every Telegram post was validated against the flat 4096 limit. Any post with media and 1025–4096 characters therefore passed the editor counter and the server-side `/posts/valid` check, and then failed at publish time with `ETELEGRAM: 400 Bad Request: message caption is too long`.

Production impact (Errors table, last 90 days): **781** Telegram publish failures with exactly that message, which makes it the single most frequent text-length rejection across all providers (for comparison, Threads had 175, addressed in #1946).

The limit depends on media presence, which none of the existing limit plumbing knew about. The fix:

- `SocialProvider.maxLength` gains an optional third argument `hasMedia`; the Telegram provider returns `1024` when set, `4096` otherwise. No other provider needs changes.
- `/posts/valid` evaluates each thread part against the limit for that part's own media, and the "maximum characters is N" error reports the limit of the offending part (1024, not 4096).
- Frontend mirrors it: `maximumCharacters` in the provider HOC accepts `(settings, hasMedia)`, the launch store keeps a `charsWithMedia` map next to `chars`, and the character pill/tooltip pick the with-media limit when the current value has attachments, so it flips to `/1024` the moment media is added.

# Other information:

Verified end to end against a real connected Telegram channel (bot as admin with Post Messages):

- Reproduced before the fix: 1100 characters + one image showed green `1100/4096`, scheduled fine, and the publish failed with `message caption is too long`.
- After the fix, the same 1100 characters without media stay `1100/4096` (text limit unchanged); attaching an image flips the pill to `1100/1024` in red, and Post now is refused with "(telegram) post is too long, please fix it".
- Trimmed to 1000 characters + image: `1000/1024`, scheduled and published successfully as a photo with caption.
- Other providers are unaffected: they ignore the new argument and keep their existing limits.

Telegram counts "characters after entities parsing" in UTF-16 code units, which matches our plain `.length` after HTML stripping, so no byte-counting change is needed for Telegram.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEjfd79TJocNAFULswHkXV
