### PR TITLE
fix: reject post attachments that were never uploaded to the media library

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/media/media.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/media/media.repository.ts
@@ -37,6 +37,22 @@ export class MediaRepository {
     });
   }
 
+  getExistingMediaPaths(org: string, paths: string[]) {
+    return this._media.model.media.findMany({
+      where: {
+        organizationId: org,
+        OR: [
+          { path: { in: paths } },
+          { name: { in: paths.map((p) => p.split('?')[0].split('/').pop()) } },
+        ],
+      },
+      select: {
+        name: true,
+        path: true,
+      },
+    });
+  }
+
   deleteMedia(org: string, id: string) {
     return this._media.model.media.update({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
@@ -33,6 +33,10 @@ export class MediaService {
     return this._mediaRepository.getMediaById(id);
   }
 
+  getExistingMediaPaths(org: string, paths: string[]) {
+    return this._mediaRepository.getExistingMediaPaths(org, paths);
+  }
+
   async generateImage(
     prompt: string,
     org: Organization,

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -815,15 +815,20 @@ export class PostsService {
         }
 
         // Provider-specific media validation (the old client `checkValidity`).
-        let errors: string | true = true;
-        try {
-          errors = await provider.checkValidity(
-            media,
-            settings,
-            additionalSettings
-          );
-        } catch (err: any) {
-          errors = err?.message || 'Invalid media';
+        let errors: string | true = await this.checkMissingAttachments(
+          orgId,
+          media.flat().map((m) => m.path)
+        );
+        if (errors === true) {
+          try {
+            errors = await provider.checkValidity(
+              media,
+              settings,
+              additionalSettings
+            );
+          } catch (err: any) {
+            errors = err?.message || 'Invalid media';
+          }
         }
 
         const maximumCharacters = provider.maxLength(additionalSettings, settings);
@@ -856,6 +861,38 @@ export class PostsService {
         };
       })
     );
+  }
+
+  // Attachments on the upload domain must exist in the org's media library:
+  // agents sometimes guess the upload path instead of using the returned one.
+  private async checkMissingAttachments(
+    orgId: string,
+    paths: string[]
+  ): Promise<string | true> {
+    const restrict = process.env.RESTRICT_UPLOAD_DOMAINS;
+    const uploaded = paths.filter(
+      (p) => restrict && p?.indexOf(restrict) > -1
+    );
+    if (!uploaded.length) {
+      return true;
+    }
+
+    const existing = await this._mediaService.getExistingMediaPaths(
+      orgId,
+      uploaded
+    );
+    const missing = uploaded.find(
+      (p) =>
+        !existing.some(
+          (m) =>
+            m.path === p || m.name === p.split('?')[0].split('/').pop()
+        )
+    );
+    if (!missing) {
+      return true;
+    }
+
+    return `Attachment ${missing} was not found in your media library. Upload it first (MCP: uploadFromUrlTool / generateImageTool, API: /public/v1/upload) and use the returned path exactly; file names are random and cannot be predicted.`;
   }
 
   /** Returns the first class-validator message (incl. nested children), or ''. */


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (server-side validation).

# Why was this change needed?

A customer's posts created through the hosted MCP failed on every channel at publish time (Facebook "Invalid file", Instagram "Media fetch failed", TikTok "Failed to pull photo from URL", Pinterest "Sorry we could not fetch the image"). Their agent had called the upload tool and the schedule tool in parallel and filled `attachments` with a predicted `https://uploads.postiz.com/<random>.png` instead of the `path` returned by the upload, so the referenced files never existed. A whole week of queued posts was doomed the same way, and nothing on our side rejected the input: attachment validation only checked the upload domain and the file extension.

This PR makes `validatePosts` reject an attachment that points at the configured upload domain (`RESTRICT_UPLOAD_DOMAINS`) but has no `Media` row in the caller's organization (matched by exact `path` or by filename). Because the check lives in `validatePosts`, the dashboard `/posts`, the public API `/public/v1/posts` and the MCP `integrationSchedulePostTool` all reject it, with a message telling the caller to upload first and use the returned path verbatim (file names are random and cannot be predicted).

Backward compatibility:
- Soft-deleted media is NOT filtered out, so editing/rescheduling old posts whose media was since deleted keeps working.
- Attachments are scoped to the organization, so another org's uploaded file cannot be referenced by URL.
- Self-hosters using local storage (`RESTRICT_UPLOAD_DOMAINS` unset) are not affected: the check is skipped entirely and external URLs keep being accepted exactly as before. Publish-time behavior for those URLs (push providers fetch them, pull providers hand them to the platform) is unchanged.
- As before, `errors` from `validatePosts` is only enforced for non-draft types on all three entry points; drafts are unchanged.

# Other information:

Tested end to end against a local backend with `RESTRICT_UPLOAD_DOMAINS` set, public API and MCP tool, on a real connected channel:
- Pre-fix: a never-uploaded path on the upload domain was accepted (201), reproducing the incident.
- Post-fix: never-uploaded path -> 400 with the new message (public API) / `output.errors` (MCP); real media by exact path and by filename -> accepted; soft-deleted media -> accepted; a file belonging to another organization -> rejected.
- With `RESTRICT_UPLOAD_DOMAINS` unset, an external URL is still accepted (check skipped).

Companion PR: MCP tool description wording telling agents to wait for the upload result and pass the returned path (https://github.com/gitroomhq/postiz-app/pull/1949).

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012J58EUoqJYLNWLjob1VKqa
