### PR TITLE
feat: tell MCP agents to upload before scheduling and use the returned path

### DIFF
--- a/libraries/nestjs-libraries/src/chat/tools/generate.image.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/generate.image.tool.ts
@@ -19,6 +19,7 @@ export class GenerateImageTool implements AgentToolInterface {
       description: `Generate image to use in a post,
                     in case the user specified a platform that requires attachment and attachment was not provided,
                     ask if they want to generate a picture of a video.
+                    Wait for this tool to return before scheduling; pass the returned "path" verbatim as the attachment.
       `,
       mcp: {
         annotations: {

--- a/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
@@ -60,6 +60,7 @@ A single LinkedIn post with one comment
 - postsAndComments array length will be one
 
 Do not use this to update or delete existing posts.
+Attachments must be the exact "path" values returned by uploadFromUrlTool or generateImageTool (or an existing media-library item). Call those tools first and wait for their result before calling this tool; file names are random and cannot be predicted or reused from earlier uploads. A post referencing a file that was never uploaded is rejected.
 If validation fails, the result contains output.errors describing what to fix; the call can be retried with corrected parameters.
 `,
       inputSchema: z.object({
@@ -95,7 +96,9 @@ If validation fails, the result contains output.errors describing what to fix; t
                       ),
                     attachments: z
                       .array(attachmentUrl)
-                      .describe('The image of the post (URLS)'),
+                      .describe(
+                        'Attachment URLs: exact "path" values returned by uploadFromUrlTool / generateImageTool (never guessed)'
+                      ),
                   })
                 )
                 .describe(

--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -35,7 +35,8 @@ export class UploadFromUrlTool implements AgentToolInterface {
       id: 'uploadFromUrlTool',
       description: `Upload a remote image or video into the media library from a public URL.
 Use this before scheduling a post when the user provides an external media URL (not already hosted on our domain),
-so the attachment passes the upload-domain validation. Returns the hosted media { id, path } to use as an attachment, or { error } on failure.`,
+so the attachment passes the upload-domain validation. Returns the hosted media { id, path } to use as an attachment, or { error } on failure.
+Wait for this tool to return before scheduling; pass the returned "path" verbatim as the attachment.`,
       mcp: {
         annotations: {
           title: 'Upload Media From URL',


### PR DESCRIPTION
# What kind of change does this PR introduce?

MCP tool description wording (no schema or behavior change).

# Why was this change needed?

A customer's agent on the hosted MCP called `uploadFromUrlTool` and `integrationSchedulePostTool` in parallel and guessed the attachment URL (`https://uploads.postiz.com/<random>.png`) instead of using the `path` returned by the upload. Every resulting post failed at publish time on all channels with media-fetch errors. The tool descriptions never said that the upload must complete first or that file names are random.

The descriptions of `integrationSchedulePostTool` (and its `attachments` field), `uploadFromUrlTool` and `generateImageTool` now state that attachments must be the exact `path` returned by the upload/generate tools (or an existing media-library item), that the upload call must return before scheduling, and that file names cannot be predicted.

Server-side rejection of such attachments is in the companion PR (https://github.com/gitroomhq/postiz-app/pull/1948); this PR only helps agents avoid the error in the first place. Self-hosters are unaffected beyond the wording.

# Other information:

Verified the new wording is served by `tools/list` from a local backend. Type-check passes; the input schema is unchanged.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012J58EUoqJYLNWLjob1VKqa
