### PR TITLE
feat(db): add directUrl support in schema.prisma for connection poolers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 # === Required Settings
 DATABASE_URL="postgresql://postiz-user:postiz-password@localhost:5432/postiz-db-local"
+# DATABASE_DIRECT_URL="" # Optional: Direct connection string for Prisma migrations when using transaction connection poolers (e.g., Supavisor, PgBouncer)
 REDIS_URL="redis://localhost:6379"
 JWT_SECRET="random string for your JWT secret, make it long"
 

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -4,8 +4,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DATABASE_DIRECT_URL")
 }
 
 model Organization {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature

# Why was this change needed?

When deploying Postiz with managed PostgreSQL database providers that utilize transaction connection pooling (such as Supabase Supavisor, AWS RDS Proxy, or PgBouncer), DATABASE_URL connects through a pooler port where session-level DDL locks and migrations are restricted.

Prisma natively provides the directUrl configuration property for PostgreSQL datasources. This allows Prisma CLI migration workflows (prisma db push, prisma migrate deploy) to use a direct connection via DATABASE_DIRECT_URL while the runtime application connects through connection poolers via DATABASE_URL.

# Other information:

This change is fully backwards-compatible: if DATABASE_DIRECT_URL is not defined in the environment, Prisma defaults to using DATABASE_URL.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue