### PR TITLE
feat(oauth): add token revocation endpoint (RFC 7009)

### DIFF
--- a/apps/backend/src/api/routes/oauth.controller.ts
+++ b/apps/backend/src/api/routes/oauth.controller.ts
@@ -17,6 +17,7 @@ import { User, Organization } from '@prisma/client';
 import { AuthorizeOAuthQueryDto, ApproveOAuthDto } from '@gitroom/nestjs-libraries/dtos/oauth/authorize-oauth.dto';
 import { TokenExchangeDto } from '@gitroom/nestjs-libraries/dtos/oauth/token-exchange.dto';
 import { RegisterClientDto } from '@gitroom/nestjs-libraries/dtos/oauth/register-client.dto';
+import { RevokeTokenDto } from '@gitroom/nestjs-libraries/dtos/oauth/revoke-token.dto';
 
 @ApiTags('OAuth')
 @Controller('/oauth')
@@ -79,6 +80,12 @@ export class OAuthController {
   @Post('/userinfo')
   async userinfoPost(@Headers('authorization') authorization?: string) {
     return this._oauthService.getUserInfo(authorization);
+  }
+
+  @Post('/revoke')
+  @HttpCode(200)
+  async revokeToken(@Body() body: RevokeTokenDto) {
+    return this._oauthService.revokeToken(body.token);
   }
 }
 

--- a/libraries/nestjs-libraries/src/database/prisma/oauth/oauth.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/oauth/oauth.service.ts
@@ -393,4 +393,16 @@ export class OAuthService {
     await this._oauthRepository.revokeAuthorization(userId, authId);
     return { success: true };
   }
+
+  async revokeToken(token: string) {
+    if (!token) {
+      return { success: false };
+    }
+    const encrypted = AuthService.fixedEncryption(token);
+    const auth = await this._oauthRepository.findByAccessToken(encrypted);
+    if (auth) {
+      await this._oauthRepository.revokeAuthorization(auth.userId, auth.id);
+    }
+    return { success: true };
+  }
 }

--- a/libraries/nestjs-libraries/src/dtos/oauth/revoke-token.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/oauth/revoke-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RevokeTokenDto {
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature

# Why was this change needed?

When third-party clients or autonomous agent platforms disconnect an integration from Postiz, standard OAuth 2.0 specifications (RFC 7009) define a Token Revocation endpoint (POST /oauth/revoke).

Currently, Postiz supports OAuth application authorization, token exchange, and userinfo endpoints, but lacks an endpoint to programmatically invalidate an issued access token when a client disconnects.

This PR introduces:
- POST /oauth/revoke endpoint accepting { token: string }.
- OAuthService.revokeToken(token) method that decrypts and marks the matching authorization as revoked.

# Other information:

This change is non-breaking and maintains full backwards compatibility.

# Checklist:

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [X] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue