### PR TITLE
fix(backend): use canonical Etc/UTC to prevent scheduled posts shifting by 1h on minimal images

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -7,7 +7,7 @@ import { json } from 'express';
 import { Runtime } from '@temporalio/worker';
 Runtime.install({ shutdownSignals: [] });
 
-process.env.TZ = 'UTC';
+process.env.TZ = 'Etc/UTC';
 
 import cookieParser from 'cookie-parser';
 import { Logger, ValidationPipe } from '@nestjs/common';


### PR DESCRIPTION
Fixes the 1‑hour shift on scheduled posts described in #1954.

## Change

```diff
-process.env.TZ = 'UTC';
+process.env.TZ = 'Etc/UTC';
```

## Why

`apps/backend/src/main.ts` hardcodes `process.env.TZ = 'UTC'`. `UTC` is a **backward‑compatibility link** in the IANA tz database, not a canonical zone, and minimal container images (Alpine/musl, slimmed tzdata) frequently drop these links. When the link is missing the string `'UTC'` does not resolve to a zero offset, and since scheduled posts are stored/parsed as **naive wall‑clock** (`timestamp without time zone`, parsed with `dayjs(date)` — no `Z`), the phantom offset leaks into both the parse and the `node-pg` write, shifting every scheduled post.

Measured in an affected container (same Node process):

| `TZ`        | `getTimezoneOffset()` |
|-------------|-----------------------|
| `'UTC'`     | **−60** (UTC+1) ❌     |
| `'Etc/UTC'` | `0` ✅                 |
| *(unset)*   | `0` ✅                 |

`Etc/UTC` is the canonical zero‑offset zone id and resolves correctly on every platform, including images that drop the `UTC` link. On systems where `'UTC'` already resolves to 0 the behaviour is unchanged — this is a strict, zero‑risk hardening.

## Verification

Verified end‑to‑end on a self‑hosted `v2.23.0` instance: a post scheduled for `07:00` was stored/published at `06:00` before, and correctly at `07:00` after the change (confirmed with a tz‑independent `to_char("publishDate",'YYYY-MM-DD HH24:MI:SS')` read‑back).
