### PR TITLE
feat: migrate Veo3 video provider from kie.ai to EvoLink

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,7 @@ EXTENSION_ID=""
 
 # Misc Settings
 OPENAI_API_KEY=""
+# EVOLINK_API_KEY="" # EvoLink API key for Veo3 AI video generation (https://evolink.ai)
 NEXT_PUBLIC_DISCORD_SUPPORT=""
 NEXT_PUBLIC_POLOTNO=""
 # NOT_SECURED=false

--- a/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
+++ b/libraries/nestjs-libraries/src/videos/veo3/veo3.ts
@@ -33,7 +33,7 @@ class Veo3Params {
   dto: Veo3Params,
   tools: [],
   trial: false,
-  available: !!process.env.KIEAI_API_KEY,
+  available: !!process.env.EVOLINK_API_KEY,
 })
 export class Veo3 extends VideoAbstract<Veo3Params> {
   override dto = Veo3Params;
@@ -42,27 +42,33 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
     customParams: Veo3Params
   ): Promise<URL> {
     const value = await (
-      await fetch('https://api.kie.ai/api/v1/veo/generate', {
+      await fetch('https://api.evolink.ai/v1/videos/generations', {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.KIEAI_API_KEY}`,
+          Authorization: `Bearer ${process.env.EVOLINK_API_KEY}`,
         },
         method: 'POST',
         signal: AbortSignal.timeout(30000),
         body: JSON.stringify({
+          model: 'veo3.1-fast',
           prompt: customParams.prompt,
-          imageUrls: customParams?.images?.map((p) => p.path) || [],
-          model: 'veo3_fast',
-          aspectRatio: output === 'horizontal' ? '16:9' : '9:16',
+          image_urls: customParams?.images?.map((p) => p.path) || [],
+          aspect_ratio: output === 'horizontal' ? '16:9' : '9:16',
+          duration: 8,
+          generate_audio: true,
         }),
       })
     ).json();
 
-    if (value.code !== 200 && value.code !== 201) {
-      throw new Error(value?.msg || `Failed to generate video`);
+    const taskId = value?.id;
+    if (!taskId) {
+      throw new Error(
+        value?.error
+          ? `${value.error.code}: ${value.error.message}`
+          : `Failed to generate video`
+      );
     }
 
-    const taskId = value.data.taskId;
     console.log('veo3 taskId', taskId);
     let attempts = 0;
     const maxAttempts = 180; // ~30 minutes at 10s interval
@@ -73,38 +79,29 @@ export class Veo3 extends VideoAbstract<Veo3Params> {
 
       console.log('waiting for video to be ready');
       const data = await (
-        await fetch(
-          'https://api.kie.ai/api/v1/veo/record-info?taskId=' + taskId,
-          {
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${process.env.KIEAI_API_KEY}`,
-            },
-            signal: AbortSignal.timeout(30000),
-          }
-        )
+        await fetch('https://api.evolink.ai/v1/tasks/' + taskId, {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.EVOLINK_API_KEY}`,
+          },
+          signal: AbortSignal.timeout(30000),
+        })
       ).json();
 
-      if (data.code !== 200) {
-        throw new Error(data?.msg || `Failed to get video info`);
-      }
-
-      // successFlag: 0 = generating, 1 = success, anything else = failed
-      const successFlag = data?.data?.successFlag;
-      if (successFlag !== 0 && successFlag !== 1) {
-        throw new Error(
-          data?.data?.errorMessage ||
-            `Video generation failed (status ${successFlag})`
-        );
-      }
-
-      const videoUrl = data?.data?.response?.resultUrls || [];
-      if (videoUrl.length > 0) {
-        return videoUrl[0];
-      }
-
-      if (successFlag === 1) {
+      if (data?.status === 'completed') {
+        const videoUrl = data?.results || [];
+        if (videoUrl.length > 0) {
+          return videoUrl[0];
+        }
         throw new Error('Video generation succeeded but no video URL returned');
+      }
+
+      if (data?.status !== 'pending' && data?.status !== 'processing') {
+        throw new Error(
+          data?.error
+            ? `${data.error.code}: ${data.error.message}`
+            : `Video generation failed (status ${data?.status})`
+        );
       }
 
       await timer(10000);


### PR DESCRIPTION
# ⚠️ New env var required: `EVOLINK_API_KEY`

## The Veo3 video provider now needs `EVOLINK_API_KEY` in `.env` (an EvoLink API key with a funded credit balance). `KIEAI_API_KEY` is no longer used. Without the new key the Veo3 option silently disappears from the video generation list. Requires a backend restart after setting it.

# What kind of change does this PR introduce?

Feature / provider migration.

# Why was this change needed?

Moves the `veo3` AI video provider from kie.ai to EvoLink. Same upstream model (Veo 3.1 Fast, 8s, 720p, audio on) — kie's `veo3_fast` is already Veo 3.1 Fast per their docs — so no quality change, at a lower per-video price and with failed generations not charged.

Changes (single file, `libraries/nestjs-libraries/src/videos/veo3/veo3.ts`):
- `available` gated on `EVOLINK_API_KEY` instead of `KIEAI_API_KEY`
- Submit via `POST https://api.evolink.ai/v1/videos/generations` (`model: veo3.1-fast`, `image_urls`, `aspect_ratio` 16:9/9:16, `duration: 8`, `generate_audio: true`), poll `GET /v1/tasks/{id}` every 10s (same 30-min cap), return `results[0]`
- Failures (submit `{error}` or task `status: failed`) throw `"<code>: <message>"`. Including the code matters: EvoLink's `content_policy_violation` message text does not match `generationError`'s safety regex, but the code does, so users get the existing 422 "rejected by the AI safety system" response instead of a generic 500
- Identifier, title, DTO (prompt + up to 3 images), placement and the frontend are untouched. EvoLink result URLs expire after 24h, which is fine because `MediaService.generateVideo` immediately uploads the result to our storage

## Pricing (8s, 720p, with audio)

| Model | kie.ai (published) | EvoLink (measured from account debits) |
|---|---|---|
| Veo 3.1 Fast (this PR) | $0.40 (80 credits) | **$0.318** (21.6 credits) |
| Veo 3.1 Quality / Pro | $2.00 | $2.38 (162 credits) |

Failed tasks are not charged (balance verified unchanged after an image-processing failure and two content-policy failures).

## Testing

All via the real EvoLink API through `POST /public/v1/generate-video` on a paid, non-trial org; outputs verified with ffprobe and saved to the media library:

- Text only, horizontal → 1280×720, 8.0s, audio track ✅
- Text only, vertical → 720×1280, 8.0s, audio ✅
- 2 reference images, vertical → 720×1280, 8.0s, audio, first frame matches the reference ✅
- 3 reference images, vertical → 720×1280, 8.0s, audio ✅ (EvoLink docs say 3-image REFERENCE mode is 16:9-only; in practice 9:16 worked)
- Error: non-image URL as reference → task `failed` with `image_processing_error` → generic 500 to the user, local `ai_videos` credit rolled back ✅
- Error: insufficient EvoLink balance → submit returns `insufficient_quota` → generic 500, credit rolled back ✅
- Error: celebrity-likeness prompt → `content_policy_violation` → HTTP 422 safety message to the user ✅ (before the error-code change this surfaced as the generic 500)
- One `veo3.1-pro` generation to measure the Pro price; the shipped code uses `veo3.1-fast`

# Other information:

- Docs follow-up: `self-host/configuration/reference.mdx` in postiz-docs lists `KIEAI_API_KEY`; it should become `EVOLINK_API_KEY`
- No retry logic was added: no video/image provider has one today, and the previous kie code threw on every error too
- EvoLink's failure responses carry a `suggestion` field recommending `veo-3.1-fast-generate-preview` as a more stable channel than `veo3.1-fast`; all successful runs here used `veo3.1-fast` without issues, but the model is a single string literal if we want to switch

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNtigh3UmZMbvyPsqrjxfn
