### PR TITLE
fix(upload): local uploader must follow the app's auth mode

### DIFF
--- a/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
+++ b/libraries/react-shared-libraries/src/helpers/uppy.upload.ts
@@ -19,6 +19,18 @@ const fetchUploadApiEndpoint = async (
 };
 
 // Define the factory to return appropriate Uppy configuration
+/**
+ * The `auth` token, when it is readable from JavaScript.
+ *
+ * Only NOT_SECURED (header auth) mode sets this cookie client-side; the default
+ * cookie-auth mode sets it httpOnly, so this returns undefined there. That
+ * difference is what lets the local uploader pick the right auth mechanism.
+ */
+const readAuthCookie = (): string | undefined => {
+  if (typeof document === 'undefined') return undefined;
+  return document.cookie.match(/(?:^|;\s*)auth=([^;]+)/)?.[1];
+};
+
 export const getUppyUploadPlugin = (
   provider: string,
   fetch: any,
@@ -92,14 +104,33 @@ export const getUppyUploadPlugin = (
             }),
         },
       };
-    case 'local':
+    case 'local': {
+      // NOT_SECURED switches the app from cookie auth to header auth, and
+      // main.ts drops `credentials: true` from the CORS config along with it.
+      // Asking for cookie credentials there sends a cookie the server is not
+      // using against a policy that forbids them, so the browser blocks the
+      // response and Uppy reports a bare "network error".
+      //
+      // The two modes are distinguishable without extra configuration: in
+      // cookie-auth mode the `auth` cookie is set httpOnly (see
+      // users.controller.ts) and cannot be read here, while NOT_SECURED sets it
+      // client-side and it can. A readable cookie therefore means header auth.
+      const usesHeaderAuth = Boolean(readAuthCookie());
       return {
         plugin: XHRUpload,
         options: {
           endpoint: `${backendUrl}/media/upload-server`,
-          withCredentials: true,
+          withCredentials: !usesHeaderAuth,
+          // Read per request rather than once, so a token refreshed mid-session
+          // is picked up. Empty in cookie-auth mode, which leaves the request
+          // exactly as it is today.
+          headers: () => {
+            const token = readAuthCookie();
+            return token ? { auth: decodeURIComponent(token) } : {};
+          },
         },
       };
+    }
 
     // Add more cases for other cloud providers
     default:


### PR DESCRIPTION
Fixes #1958.

## What was wrong

`NOT_SECURED=true` switches the app to header auth, and `apps/backend/src/main.ts` drops `credentials: true` from the CORS config along with it. The `local` branch of `getUppyUploadPlugin` kept asking for cookie credentials:

```ts
case 'local':
  return {
    plugin: XHRUpload,
    options: {
      endpoint: `${backendUrl}/media/upload-server`,
      withCredentials: true,
    },
  };
```

So it sent a cookie the server was not using, against a CORS policy that forbids credentials. The browser blocked the response and Uppy reported a bare `network error` with nothing pointing at auth or CORS — which is what made it slow to place.

It is also the only uploader that ignores the authenticated `fetch` the factory already receives; the `cloudflare` branch uses it in five places.

## The fix

The two modes are distinguishable without new configuration. In cookie-auth mode `users.controller.ts` sets the `auth` cookie `httpOnly: true`, so it cannot be read from JavaScript. Under `NOT_SECURED` the frontend sets it client-side and it can. A readable `auth` cookie therefore means header auth.

```ts
const usesHeaderAuth = Boolean(readAuthCookie());
return {
  plugin: XHRUpload,
  options: {
    endpoint: `${backendUrl}/media/upload-server`,
    withCredentials: !usesHeaderAuth,
    headers: () => {
      const token = readAuthCookie();
      return token ? { auth: decodeURIComponent(token) } : {};
    },
  },
};
```

`headers` is a function rather than a fixed object so a token refreshed mid-session is picked up.

## Risk

**None on the default path.** With `NOT_SECURED` unset, `readAuthCookie()` returns `undefined` (the cookie is httpOnly), so `withCredentials` stays `true` and `headers()` returns `{}` — byte-for-byte the current request. The behaviour only changes in the mode that is broken today.

## Testing

- **`NOT_SECURED=true`:** upload previously failed every time with the Uppy network error; with this change the file uploads and appears in the Media library. Verified in a browser.
- **Default (cookie auth):** upload works, unchanged. Also verified in a browser — this is the configuration the repo defaults to.
- Frontend compiles clean in the workspace.

I have not run the full test suite, only the upload paths above.

## How I hit it

Using postiz as an independent conformance client against a local API emulator, with frontend and backend on separate `localhost` ports. `NOT_SECURED=true` seemed the natural choice for a local fixture, which is how I landed in the broken combination.