### PR TITLE
fix(pinterest): retry Pinterest's anti-spam pin block instead of failing with "Unknown Error"

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -135,6 +135,13 @@ export class PinterestProvider
           'The board ID must be a numeric string. Please check the board ID format.',
       };
     }
+    if (body.indexOf('block (Pins) we have in place to combat spam') > -1) {
+      return {
+        type: 'retry' as const,
+        value:
+          'Pinterest temporarily blocked this pin as suspected spam. Please space out your pins and try again later.',
+      };
+    }
     if (body.indexOf('Board not found') > -1) {
       return {
         type: 'bad-body' as const,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Pinterest provider error mapping). Adds a `block (Pins) we have in place to combat spam` branch to `PinterestProvider.handleErrors`, above the "Board not found" branch, returning `type: 'retry'` with a message telling the user to space their pins out and try again later. Previously Pinterest's anti-spam block fell through `handleErrors` and reached the user as "Unknown Error". Nothing is created when Pinterest blocks a pin, so the retry cannot duplicate; the attempt count is the existing three-attempt budget in `SocialAbstract.fetch`. Open question for review: three retries five seconds apart will not clear a spam block, so `bad-body` with this same message may be the better classification.

# Why was this change needed?

A user reported pins failing with "An error occurred while posting on pinterest: Unknown Error" and no way to tell what went wrong.

The stored failure held Pinterest's real response:

```
{"code":9,"message":"Sorry! You've hit a block (Pins) we have in place to combat spam. Please try again later!"}
```

`handleErrors` in the Pinterest provider had no branch for that block, so `runInConcurrent` fell back to its generic `'Unknown Error'` value and threw `BadBody`, which is non-retryable. Two things went wrong as a result: the user saw a message that carried none of the information Pinterest gave us, and the pin was failed permanently even though Pinterest explicitly asked us to retry later.

Looking at the affected account over a week, every one of the 79 failures on that channel was this same block, and they were concentrated in a single day where a few hundred pins were pushed at once (75 failures out of 264 pins that day, 4 out of 100 the next day, 0 out of 49 the day after). Pins sent at a normal pace kept publishing to the same boards, so the block is a rate/anti-spam condition and is transient.

This maps the block to a curated, retryable message, matching the existing `'Unable to reach the URL'` branch in the same function: the pin gets retried instead of dying, and the user is told to space their pins out.

# Other information:

Scope is deliberately one error string. Two other open PRs touch the same `handleErrors` function and are independent of this one: #1907 (retry transient "Something went wrong on our end") and #1931 (map "could not fetch the image" as retryable).

Not verified end to end, since reproducing it means getting an account genuinely rate-limited by Pinterest. The mapping is driven by the exact response body captured from the failed publish.

# QA

1. [ ] Connect a Pinterest channel and select a board
2. [ ] Stub the create-pin response with a body containing "block (Pins) we have in place to combat spam"
3. [ ] Publish a pin - logs show three bounded attempts, then the post errors with the new "Pinterest temporarily blocked this pin as suspected spam" message, not "Unknown Error"
4. [ ] Open the board and confirm no pin was created
5. [ ] Remove the stub and publish a pin normally to confirm the happy path is unaffected
6. [ ] Confirm a "Board not found" error still fails immediately without retrying

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [x] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
