### PR TITLE
feat: user timezone setting via a display-lens conversion

### DIFF
--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -25,6 +25,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
 import { UserDetailDto } from '@gitroom/nestjs-libraries/dtos/users/user.details.dto';
 import { EmailNotificationsDto } from '@gitroom/nestjs-libraries/dtos/users/email-notifications.dto';
+import { TimezoneDto } from '@gitroom/nestjs-libraries/dtos/users/timezone.dto';
 import { HttpForbiddenException } from '@gitroom/nestjs-libraries/services/exception.filter';
 import { RealIP } from 'nestjs-real-ip';
 import { UserAgent } from '@gitroom/nestjs-libraries/user/user.agent';
@@ -235,6 +236,14 @@ export class UsersController {
     @Body() body: UserDetailDto
   ) {
     return this._userService.changePersonal(user.id, body);
+  }
+
+  @Post('/timezone')
+  async updateTimezone(
+    @GetUserFromRequest() user: User,
+    @Body() body: TimezoneDto
+  ) {
+    return this._userService.updateTimezone(user.id, body);
   }
 
   @Get('/email-notifications')

--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -63,9 +63,16 @@ import { RefreshIntegrationService } from '@gitroom/nestjs-libraries/integration
 import { RefreshToken } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { PostValidationException } from '@gitroom/backend/api/routes/posts.validation.exception';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
+import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import { SuperAdminGuard } from '@gitroom/backend/services/auth/super.admin.guard';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 @ApiTags('Public API')
 @Controller('/public/v1')
@@ -79,7 +86,8 @@ export class PublicIntegrationsController {
     private _notificationService: NotificationService,
     private _integrationManager: IntegrationManager,
     private _refreshIntegrationService: RefreshIntegrationService,
-    private _usersService: UsersService
+    private _usersService: UsersService,
+    private _organizationService: OrganizationService
   ) {}
 
   @Post('/upload')
@@ -195,6 +203,25 @@ export class PublicIntegrationsController {
     @Body() rawBody: any
   ) {
     Sentry.metrics.count('public_api-request', 1);
+
+    // Dates without an explicit offset / Z are interpreted in the API key
+    // owner's timezone (when set); dates with an offset stay absolute.
+    if (
+      typeof rawBody?.date === 'string' &&
+      !/(Z|[+-]\d{2}:?\d{2})$/i.test(rawBody.date)
+    ) {
+      const timezoneName = await this._organizationService.getOrgOwnerTimezone(
+        org.id
+      );
+      if (timezoneName) {
+        const shifted = dayjs.tz(rawBody.date, timezoneName);
+        // an unparsable date is left alone so the DTO reports it as sent
+        if (shifted.isValid()) {
+          rawBody.date = shifted.utc().format('YYYY-MM-DDTHH:mm:ss');
+        }
+      }
+    }
+
     const body = await this._postsService.mapTypeToPost(
       rawBody,
       org.id,

--- a/apps/frontend/src/app/(app)/layout.tsx
+++ b/apps/frontend/src/app/(app)/layout.tsx
@@ -97,7 +97,6 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           }
         >
           <SentryComponent>
-            {/*<SetTimezone />*/}
             <HtmlComponent />
             <DubAnalytics />
             <FacebookComponent />

--- a/apps/frontend/src/components/agents/agent.chat.tsx
+++ b/apps/frontend/src/components/agents/agent.chat.tsx
@@ -34,6 +34,7 @@ import {
 } from '@copilotkit/runtime-client-gql';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
 import dayjs from 'dayjs';
+import { fromUtc } from '@gitroom/frontend/components/layout/set.timezone';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { ExistingDataContextProvider } from '@gitroom/frontend/components/launches/helpers/use.existing.data';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
@@ -358,7 +359,7 @@ const OpenModal: FC<{
               }}
             >
               <AddEditModal
-                date={dayjs.utc(integration.date)}
+                date={fromUtc(integration.date)}
                 allIntegrations={properties}
                 integrations={properties.filter(
                   (p) => p.id === integration.integrationId

--- a/apps/frontend/src/components/analytics/stars.table.component.tsx
+++ b/apps/frontend/src/components/analytics/stars.table.component.tsx
@@ -18,6 +18,7 @@ import clsx from 'clsx';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import ReactLoading from '@gitroom/frontend/components/layout/loading';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { fromUtc } from '@gitroom/frontend/components/layout/set.timezone';
 
 export const UpDown: FC<{
   name: string;
@@ -138,7 +139,7 @@ export const StarsTableComponent = () => {
     mutate();
   }, [searchParams]);
   const renderMediaLink = useCallback((date: string) => {
-    const local = dayjs.utc(date).local();
+    const local = fromUtc(date);
     const weekNumber = local.isoWeek();
     const year = local.year();
     return `/launches?week=${weekNumber}&year=${year}`;

--- a/apps/frontend/src/components/billing/main.billing.component.tsx
+++ b/apps/frontend/src/components/billing/main.billing.component.tsx
@@ -24,7 +24,7 @@ import { useTrack } from '@gitroom/react/helpers/use.track';
 import { TrackEnum } from '@gitroom/nestjs-libraries/user/track.enum';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { FinishTrial } from '@gitroom/frontend/components/billing/finish.trial';
-import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
+import { fromUtc, newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { useDubClickId } from '@gitroom/frontend/components/layout/dubAnalytics';
 import { LogoutComponent } from '@gitroom/frontend/components/layout/logout.component';
 
@@ -453,10 +453,9 @@ export const MainBillingComponent: FC<{
                       ? 'Current Plan'
                       : name.toUpperCase() === 'FREE'
                       ? subscription?.cancelAt
-                        ? `Downgrade on ${dayjs
-                            .utc(subscription?.cancelAt)
-                            .local()
-                            .format('D MMM, YYYY')}`
+                        ? `Downgrade on ${fromUtc(
+                            subscription?.cancelAt
+                          ).format('D MMM, YYYY')}`
                         : 'Cancel subscription'
                       : // @ts-ignore
                       (user?.tier === 'FREE' ||
@@ -507,7 +506,7 @@ export const MainBillingComponent: FC<{
             'your_subscription_will_be_canceled_at',
             'Your subscription will be canceled at'
           )}{' '}
-          {newDayjs(subscription.cancelAt).local().format('D MMM, YYYY')}
+          {fromUtc(subscription.cancelAt).format('D MMM, YYYY')}
           <br />
           {t(
             'you_will_never_be_charged_again',

--- a/apps/frontend/src/components/launches/calendar.context.tsx
+++ b/apps/frontend/src/components/launches/calendar.context.tsx
@@ -20,7 +20,7 @@ import isoWeek from 'dayjs/plugin/isoWeek';
 import weekOfYear from 'dayjs/plugin/weekOfYear';
 import { extend } from 'dayjs';
 import useCookie from 'react-use-cookie';
-import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
+import { newDayjs, toUtc } from '@gitroom/frontend/components/layout/set.timezone';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { expandPostsList, expandPosts } from '@gitroom/helpers/utils/posts.list.minify';
 extend(isoWeek);
@@ -187,8 +187,8 @@ export const CalendarWeekProvider: FC<{
     const modifiedParams = new URLSearchParams({
       display: filters.display,
       customer: filters?.customer?.toString() || '',
-      startDate: newDayjs(filters.startDate).startOf('day').utc().format(),
-      endDate: newDayjs(filters.endDate).endOf('day').utc().format(),
+      startDate: toUtc(newDayjs(filters.startDate).startOf('day')).format(),
+      endDate: toUtc(newDayjs(filters.endDate).endOf('day')).format(),
     }).toString();
 
     const data = await (await fetch(`/posts?${modifiedParams}`)).json();
@@ -309,7 +309,7 @@ export const CalendarWeekProvider: FC<{
           if (post.id === id) {
             return {
               ...post,
-              publishDate: date.utc().format('YYYY-MM-DDTHH:mm:ss'),
+              publishDate: toUtc(date).format('YYYY-MM-DDTHH:mm:ss'),
             };
           }
           return post;

--- a/apps/frontend/src/components/launches/calendar.tsx
+++ b/apps/frontend/src/components/launches/calendar.tsx
@@ -56,7 +56,11 @@ import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import copy from 'copy-to-clipboard';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
-import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
+import {
+  fromUtc,
+  newDayjs,
+  toUtc,
+} from '@gitroom/frontend/components/layout/set.timezone';
 import { Button } from '@gitroom/react/form/button';
 
 // Extend dayjs with necessary plugins
@@ -117,9 +121,7 @@ const usePostActions = (onMutate?: () => void) => {
       const date = !isDuplicate
         ? null
         : (await (await fetch('/posts/find-slot')).json()).date;
-      const publishDate = dayjs
-        .utc(date || data.posts[0].publishDate)
-        .local();
+      const publishDate = fromUtc(date || data.posts[0].publishDate);
       const ExistingData = !isDuplicate
         ? ExistingDataContextProvider
         : Fragment;
@@ -305,12 +307,9 @@ export const DayView = () => {
         {options.map((option) => (
           <Fragment key={option[0].time}>
             <div className="text-center text-[14px] min-h-[21px]">
-              {newDayjs()
-                .utc()
-                .startOf('day')
-                .add(option[0].time, 'minute')
-                .local()
-                .format(isUSCitizen() ? 'hh:mm A' : 'LT')}
+              {fromUtc(
+                dayjs.utc().startOf('day').add(option[0].time, 'minute')
+              ).format(isUSCitizen() ? 'hh:mm A' : 'LT')}
             </div>
             <div
               key={option[0].time}
@@ -323,10 +322,9 @@ export const DayView = () => {
                 }}
               >
                 <CalendarColumn
-                  getDate={currentDay
-                    .startOf('day')
-                    .add(option[0].time, 'minute')
-                    .local()}
+                  getDate={fromUtc(
+                    currentDay.startOf('day').add(option[0].time, 'minute')
+                  )}
                 />
               </CalendarContext.Provider>
             </div>
@@ -505,7 +503,7 @@ export const ListView = () => {
   const groupedPosts = useMemo(() => {
     const groups: { [key: string]: any[] } = {};
     listPosts.forEach((post) => {
-      const dateKey = newDayjs(post.publishDate).local().format('YYYY-MM-DD');
+      const dateKey = fromUtc(post.publishDate).format('YYYY-MM-DD');
       if (!groups[dateKey]) {
         groups[dateKey] = [];
       }
@@ -544,7 +542,7 @@ export const ListView = () => {
                   key={post.id}
                   display="day"
                   isBeforeNow={false}
-                  date={newDayjs(post.publishDate)}
+                  date={fromUtc(post.publishDate)}
                   state={post.state}
                   statistics={openStatistics(post.id)}
                   missingRelease={openMissingRelease(post.id)}
@@ -607,7 +605,7 @@ export const CalendarColumn: FC<{
   const { editPost, deletePost, copyDebugJson, openStatistics, openMissingRelease } = usePostActions();
   const postList = useMemo(() => {
     return posts.filter((post) => {
-      const pList = dayjs.utc(post.publishDate).local();
+      const pList = fromUtc(post.publishDate);
       const check =
         display === 'day'
           ? pList.format('YYYY-MM-DD HH:mm') ===
@@ -634,10 +632,8 @@ export const CalendarColumn: FC<{
   }, [postList, showAll]);
 
   const isBeforeNow = useMemo(() => {
-    const originalUtc = getDate.startOf('hour');
-    return originalUtc
-      .startOf('hour')
-      .isBefore(newDayjs().startOf('hour').utc());
+    // both sides carry the user timezone wall clock
+    return getDate.startOf('hour').isBefore(newDayjs().startOf('hour'));
   }, [getDate, num]);
 
   const { start, stop } = useInterval(
@@ -738,7 +734,7 @@ export const CalendarColumn: FC<{
       const { status } = await fetch(`/posts/${item.id}/date`, {
         method: 'PUT',
         body: JSON.stringify({
-          date: getDate.utc().format('YYYY-MM-DDTHH:mm:ss'),
+          date: toUtc(getDate).format('YYYY-MM-DDTHH:mm:ss'),
           action,
           // published posts always confirm via the modal before reaching here;
           // for QUEUE posts the flag is a no-op on the server
@@ -1183,7 +1179,7 @@ const CalendarItem: FC<{
         </div>
         {showTime && (
           <div className="text-textColor/50 text-[12px] whitespace-nowrap flex items-center">
-            {newDayjs(post.publishDate).local().format(isUSCitizen() ? 'hh:mm A' : 'HH:mm')}
+            {fromUtc(post.publishDate).format(isUSCitizen() ? 'hh:mm A' : 'HH:mm')}
           </div>
         )}
       </div>

--- a/apps/frontend/src/components/launches/comments/comment.component.tsx
+++ b/apps/frontend/src/components/launches/comments/comment.component.tsx
@@ -9,6 +9,7 @@ import { useUser } from '@gitroom/frontend/components/layout/user.context';
 import { Input } from '@gitroom/react/form/input';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
+import { toUtc } from '@gitroom/frontend/components/layout/set.timezone';
 export const CommentBox: FC<{
   value?: string;
   type: 'textarea' | 'input';
@@ -149,7 +150,7 @@ export const CommentComponent: FC<{
   const fetch = useFetch();
   const load = useCallback(async () => {
     const data = await (
-      await fetch(`/comments/${date.utc().format('YYYY-MM-DDTHH:mm:00')}`)
+      await fetch(`/comments/${toUtc(date).format('YYYY-MM-DDTHH:mm:00')}`)
     ).json();
     setCommentsList(data);
   }, []);
@@ -162,7 +163,7 @@ export const CommentComponent: FC<{
         method: 'PUT',
         body: JSON.stringify({
           content,
-          date: date.utc().format('YYYY-MM-DDTHH:mm:00'),
+          date: toUtc(date).format('YYYY-MM-DDTHH:mm:00'),
         }),
       });
     },
@@ -175,7 +176,7 @@ export const CommentComponent: FC<{
           method: 'POST',
           body: JSON.stringify({
             content,
-            date: date.utc().format('YYYY-MM-DDTHH:mm:00'),
+            date: toUtc(date).format('YYYY-MM-DDTHH:mm:00'),
           }),
         })
       ).json();
@@ -231,7 +232,7 @@ export const CommentComponent: FC<{
           method: 'POST',
           body: JSON.stringify({
             content,
-            date: date.utc().format('YYYY-MM-DDTHH:mm:00'),
+            date: toUtc(date).format('YYYY-MM-DDTHH:mm:00'),
           }),
         })
       ).json();

--- a/apps/frontend/src/components/launches/generator/generator.tsx
+++ b/apps/frontend/src/components/launches/generator/generator.tsx
@@ -22,6 +22,7 @@ import { Select } from '@gitroom/react/form/select';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
 import { useToaster } from '@gitroom/react/toaster/toaster';
+import { fromUtc } from '@gitroom/frontend/components/layout/set.timezone';
 
 const FirstStep: FC = (props) => {
   const { integrations, reloadCalendarView } = useCalendar();
@@ -194,7 +195,7 @@ const FirstStep: FC = (props) => {
                 ...p,
               }))}
               mutate={reloadCalendarView}
-              date={dayjs.utc(load.date).local()}
+              date={fromUtc(load.date)}
               reopenModal={() => ({})}
               onlyValues={messages}
             />

--- a/apps/frontend/src/components/launches/menu/menu.tsx
+++ b/apps/frontend/src/components/launches/menu/menu.tsx
@@ -31,6 +31,7 @@ import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.m
 import dayjs from 'dayjs';
 import { ModalWrapperComponent } from '@gitroom/frontend/components/new-launch/modal.wrapper.component';
 import copy from 'copy-to-clipboard';
+import { fromUtc } from '@gitroom/frontend/components/layout/set.timezone';
 
 export const Menu: FC<{
   canEnable: boolean;
@@ -235,7 +236,7 @@ export const Menu: FC<{
             integrations={integrations}
             selectedChannels={[integration.id]}
             // focusedChannel={integration.id}
-            date={dayjs.utc(date).local()}
+            date={fromUtc(date)}
           />
         ),
         size: '80%',

--- a/apps/frontend/src/components/launches/new.post.tsx
+++ b/apps/frontend/src/components/launches/new.post.tsx
@@ -7,6 +7,7 @@ import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { SetSelectionModal } from '@gitroom/frontend/components/launches/calendar';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
 import { ModalWrapperComponent } from '@gitroom/frontend/components/new-launch/modal.wrapper.component';
+import { fromUtc } from '@gitroom/frontend/components/layout/set.timezone';
 
 export const NewPost = () => {
   const fetch = useFetch();
@@ -67,7 +68,7 @@ export const NewPost = () => {
           reopenModal={createAPost}
           mutate={reloadCalendarView}
           integrations={integrations}
-          date={dayjs.utc(date).local()}
+          date={fromUtc(date)}
         />
       ),
       size: '80%',

--- a/apps/frontend/src/components/launches/time.table.tsx
+++ b/apps/frontend/src/components/launches/time.table.tsx
@@ -15,7 +15,10 @@ import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 import { sortBy } from 'lodash';
 import { usePreventWindowUnload } from '@gitroom/react/helpers/use.prevent.window.unload';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
-import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
+import {
+  fromUtc,
+  getTimezone,
+} from '@gitroom/frontend/components/layout/set.timezone';
 import clsx from 'clsx';
 import {
   TrashIcon,
@@ -85,14 +88,10 @@ export const TimeTable: FC<{
   );
 
   const addHour = useCallback(() => {
+    // slots stay stored as UTC minutes; the picked hour is a wall clock in the
+    // user timezone, so it is offset by that timezone rather than the browser's
     const calculateMinutes =
-      newDayjs()
-        .utc()
-        .startOf('day')
-        .add(hour, 'hours')
-        .add(minute, 'minutes')
-        .diff(newDayjs().utc().startOf('day'), 'minutes') -
-      dayjs.tz().utcOffset();
+      hour * 60 + minute - dayjs().tz(getTimezone()).utcOffset();
     setCurrentTimes((prev) => [
       ...prev,
       {
@@ -105,12 +104,9 @@ export const TimeTable: FC<{
     return sortBy(
       currentTimes.map(({ time }) => ({
         value: time,
-        formatted: dayjs
-          .utc()
-          .startOf('day')
-          .add(time, 'minutes')
-          .local()
-          .format('HH:mm'),
+        formatted: fromUtc(
+          dayjs.utc().startOf('day').add(time, 'minutes')
+        ).format('HH:mm'),
       })),
       (p) => p.value
     );

--- a/apps/frontend/src/components/layout/set.timezone.tsx
+++ b/apps/frontend/src/components/layout/set.timezone.tsx
@@ -1,6 +1,5 @@
 'use client';
-import dayjs, { ConfigType } from 'dayjs';
-import { FC, useEffect } from 'react';
+import dayjs, { ConfigType, Dayjs } from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -8,36 +7,78 @@ dayjs.extend(timezone);
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
 
-const { utc: originalUtc } = dayjs;
+const WALL_CLOCK = 'YYYY-MM-DDTHH:mm:ss';
 
-export const getTimezone = () => {
-  if (typeof window === 'undefined') {
-    return dayjs.tz.guess();
+// The user timezone is a display lens: it is never persisted into a datetime.
+// Every datetime is converted once when it crosses the API boundary
+// (`fromUtc` / `toUtc`), and the rest of the app keeps working on plain
+// machine-local dayjs objects carrying the user timezone wall clock, so render
+// loops never pay the `Intl` cost of a timezone-aware dayjs.
+// `null` means "auto" - every helper degenerates to plain machine-local dayjs.
+let userTimezone: string | null = null;
+
+// The same publish dates are converted once per calendar cell, so keep the
+// conversions O(number of API datetimes) instead of O(rendered cells).
+const displayCache = new Map<string, Dayjs>();
+let now: { at: number; value: Dayjs } | null = null;
+
+export const setUserTimezone = (timezoneName: string | null) => {
+  if (timezoneName === userTimezone) {
+    return;
   }
-  return localStorage.getItem('timezone') || dayjs.tz.guess();
+  userTimezone = timezoneName;
+  displayCache.clear();
+  now = null;
+};
+
+export const getTimezone = () => userTimezone || dayjs.tz.guess();
+
+// Read boundary: a UTC instant from the API becomes a plain machine-local
+// dayjs carrying the user timezone wall clock.
+export const fromUtc = (value: ConfigType) => {
+  if (!userTimezone) {
+    return dayjs.utc(value).local();
+  }
+
+  if (typeof value !== 'string') {
+    return dayjs(dayjs.utc(value).tz(userTimezone).format(WALL_CLOCK));
+  }
+
+  const cached = displayCache.get(value);
+  if (cached) {
+    return cached;
+  }
+
+  if (displayCache.size > 5000) {
+    displayCache.clear();
+  }
+
+  const display = dayjs(dayjs.utc(value).tz(userTimezone).format(WALL_CLOCK));
+  displayCache.set(value, display);
+  return display;
+};
+
+// Write boundary: the exact inverse of `fromUtc` - a wall clock the user typed
+// (or dragged to) becomes the real instant, in UTC mode.
+export const toUtc = (value: Dayjs) => {
+  if (!userTimezone) {
+    return value.utc();
+  }
+
+  return dayjs.tz(value.format(WALL_CLOCK), userTimezone).utc();
 };
 
 export const newDayjs = (config?: ConfigType) => {
-  return dayjs(config);
+  if (config !== undefined || !userTimezone) {
+    return dayjs(config);
+  }
+
+  // "now" is compared against shifted datetimes, so it has to be shifted too.
+  // It is read once per calendar cell, hence the one second window.
+  const at = Date.now();
+  if (!now || at - now.at > 1000) {
+    now = { at, value: dayjs(dayjs().tz(userTimezone).format(WALL_CLOCK)) };
+  }
+
+  return now.value;
 };
-
-const SetTimezone: FC = () => {
-  useEffect(() => {
-    dayjs.utc = (config?: ConfigType, format?: string, strict?: boolean) => {
-      const result = originalUtc(config, format, strict);
-
-      // Attach `.local()` method to the returned Dayjs object
-      result.local = function () {
-        return result.tz(getTimezone());
-      };
-
-      return result;
-    };
-    if (localStorage.getItem('timezone')) {
-      dayjs.tz.setDefault(getTimezone());
-    }
-  }, []);
-  return null;
-};
-
-export default SetTimezone;

--- a/apps/frontend/src/components/new-launch/manage.modal.tsx
+++ b/apps/frontend/src/components/new-launch/manage.modal.tsx
@@ -43,6 +43,7 @@ import { useHasScroll } from '@gitroom/frontend/components/ui/is.scroll.hook';
 import { useShortlinkPreference } from '@gitroom/frontend/components/settings/shortlink-preference.component';
 import dayjs from 'dayjs';
 import { Button } from '@gitroom/react/form/button';
+import { toUtc } from '@gitroom/frontend/components/layout/set.timezone';
 
 export const ManageModal: FC<AddEditModalProps> = (props) => {
   const t = useT();
@@ -197,7 +198,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
         (type === 'now' || type === 'schedule') &&
         (existingData?.posts?.[0]?.state === 'PUBLISHED' ||
           (existingData?.posts?.[0]?.state === 'QUEUE' &&
-            dayjs().isAfter(date.utc())))
+            dayjs().isAfter(toUtc(date))))
       ) {
         const channels = selectedIntegrations
           .map((p) => p.integration.name)
@@ -416,7 +417,7 @@ export const ManageModal: FC<AddEditModalProps> = (props) => {
         ...(repeater ? { inter: repeater } : {}),
         tags,
         shortLink,
-        date: date.utc().format('YYYY-MM-DDTHH:mm:ss'),
+        date: toUtc(date).format('YYYY-MM-DDTHH:mm:ss'),
         posts,
       };
 

--- a/apps/frontend/src/components/new-layout/layout.component.tsx
+++ b/apps/frontend/src/components/new-layout/layout.component.tsx
@@ -43,6 +43,7 @@ import { AttachToFeedbackIcon } from '@gitroom/frontend/components/new-layout/se
 import { FirstBillingComponent } from '@gitroom/frontend/components/billing/first.billing.component';
 import { TrialTracker } from '@gitroom/frontend/components/layout/gtm.component';
 import { setSentryUser } from '@gitroom/react/sentry/initialize.sentry.client';
+import { setUserTimezone } from '@gitroom/frontend/components/layout/set.timezone';
 
 const jakartaSans = Plus_Jakarta_Sans({
   weight: ['600', '500', '700'],
@@ -61,6 +62,8 @@ export const LayoutComponent = ({ children }: { children: ReactNode }) => {
     return await (await fetch(path)).json();
   }, []);
   const { data: user, mutate } = useSWR('/user/self', load, {
+    // hydrate the display lens before anything renders a datetime
+    onSuccess: (data) => setUserTimezone(data?.timezoneName || null),
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     revalidateIfStale: false,

--- a/apps/frontend/src/components/post-url-selector/post.url.selector.tsx
+++ b/apps/frontend/src/components/post-url-selector/post.url.selector.tsx
@@ -9,7 +9,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import removeMd from 'remove-markdown';
 import clsx from 'clsx';
 import { useT } from '@gitroom/react/translation/get.transation.service.client';
-import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
+import { newDayjs, toUtc } from '@gitroom/frontend/components/layout/set.timezone';
 const postUrlEmitter = new EventEmitter();
 export const ShowPostSelector = () => {
   const [showPostSelector, setShowPostSelector] = useState(false);
@@ -78,7 +78,7 @@ export const PostSelector: FC<{
   const fetch = useFetch();
   const fetchOldPosts = useCallback(() => {
     return fetch(
-      '/posts/old?date=' + date.utc().format('YYYY-MM-DDTHH:mm:00'),
+      '/posts/old?date=' + toUtc(date).format('YYYY-MM-DDTHH:mm:00'),
       {
         method: 'GET',
         headers: {

--- a/apps/frontend/src/components/preview/render.preview.date.tsx
+++ b/apps/frontend/src/components/preview/render.preview.date.tsx
@@ -3,9 +3,10 @@
 import { FC } from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import { fromUtc } from '@gitroom/frontend/components/layout/set.timezone';
 dayjs.extend(utc);
 
 export const RenderPreviewDate: FC<{ date: string }> = ({ date }) => {
   console.log(date);
-  return <>{dayjs.utc(date).local().format('MMMM D, YYYY h:mm A')}</>;
+  return <>{fromUtc(date).format('MMMM D, YYYY h:mm A')}</>;
 };

--- a/apps/frontend/src/components/settings/metric.component.tsx
+++ b/apps/frontend/src/components/settings/metric.component.tsx
@@ -1,36 +1,50 @@
 'use client';
 
 import { Select } from '@gitroom/react/form/select';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { isUSCitizen } from '@gitroom/frontend/components/launches/helpers/isuscitizen.utils';
 import timezones from 'timezones-list';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import { useToaster } from '@gitroom/react/toaster/toaster';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useUser } from '@gitroom/frontend/components/layout/user.context';
+import { setUserTimezone } from '@gitroom/frontend/components/layout/set.timezone';
+
 const dateMetrics = [
   { label: 'AM:PM', value: 'US' },
   { label: '24 hours', value: 'GLOBAL' },
 ];
 
-import dayjs from 'dayjs';
-import timezone from 'dayjs/plugin/timezone';
-dayjs.extend(timezone);
-
 const MetricComponent = () => {
+  const t = useT();
+  const fetch = useFetch();
+  const toaster = useToaster();
+  const user = useUser();
   const [currentMetric, setCurrentMetric] = useState(isUSCitizen());
-  const [timezone, setTimezone] = useState(
-    localStorage.getItem('timezone') || dayjs.tz.guess()
-  );
+  const [timezone, setTimezone] = useState(user?.timezoneName || '');
+
   const changeMetric = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value;
     setCurrentMetric(value === 'US');
     localStorage.setItem('isUS', value);
   };
 
-  const changeTimezone = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = event.target.value;
-    console.log(value);
-    setTimezone(value);
-    localStorage.setItem('timezone', value);
-    dayjs.tz.setDefault(value);
-  };
+  const changeTimezone = useCallback(
+    async (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value;
+      setTimezone(value);
+      setUserTimezone(value || null);
+
+      await fetch('/user/timezone', {
+        method: 'POST',
+        body: JSON.stringify({ timezoneName: value || null }),
+      });
+
+      toaster.show(t('settings_updated', 'Settings updated'), 'success');
+    },
+    []
+  );
+
   return (
     <div className="my-[16px] mt-[16px] bg-sixth border-fifth border rounded-[4px] p-[24px] flex flex-col gap-[24px]">
       <div className="mt-[4px]">Date Metrics</div>
@@ -45,23 +59,23 @@ const MetricComponent = () => {
         ))}
       </Select>
 
-      {/*<div className="mt-[4px]">Current Timezone</div>*/}
-      {/*<Select*/}
-      {/*  name="timezone"*/}
-      {/*  disableForm={true}*/}
-      {/*  label=""*/}
-      {/*  onChange={changeTimezone}*/}
-      {/*>*/}
-      {/*  {timezones.map((metric) => (*/}
-      {/*    <option*/}
-      {/*      key={metric.name}*/}
-      {/*      value={metric.tzCode}*/}
-      {/*      selected={metric.tzCode === timezone}*/}
-      {/*    >*/}
-      {/*      {metric.label}*/}
-      {/*    </option>*/}
-      {/*  ))}*/}
-      {/*</Select>*/}
+      <div className="mt-[4px]">{t('current_timezone', 'Current Timezone')}</div>
+      <Select
+        name="timezone"
+        disableForm={true}
+        label=""
+        onChange={changeTimezone}
+        value={timezone}
+      >
+        <option value="">
+          {t('timezone_auto', 'Auto (your browser timezone)')}
+        </option>
+        {timezones.map((metric) => (
+          <option key={metric.tzCode} value={metric.tzCode}>
+            {metric.label}
+          </option>
+        ))}
+      </Select>
     </div>
   );
 };

--- a/apps/frontend/src/components/standalone-modal/standalone.modal.tsx
+++ b/apps/frontend/src/components/standalone-modal/standalone.modal.tsx
@@ -7,7 +7,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import dayjs from 'dayjs';
 import { useParams } from 'next/navigation';
 import { AddEditModal } from '@gitroom/frontend/components/new-launch/add.edit.modal';
-import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
+import { fromUtc, newDayjs, toUtc } from '@gitroom/frontend/components/layout/set.timezone';
 export const StandaloneModal: FC = () => {
   const fetch = useFetch();
   const params = useParams<{ platform: string }>();
@@ -18,7 +18,7 @@ export const StandaloneModal: FC = () => {
 
   const loadDate = useCallback(async () => {
     if (params.platform === 'all') {
-      return newDayjs().utc().format('YYYY-MM-DDTHH:mm:ss');
+      return toUtc(newDayjs()).format('YYYY-MM-DDTHH:mm:ss');
     }
     return (await (await fetch('/posts/find-slot')).json()).date;
   }, []);
@@ -57,7 +57,7 @@ export const StandaloneModal: FC = () => {
       integrations={integrations}
       reopenModal={() => {}}
       allIntegrations={integrations}
-      date={dayjs.utc(data).local()}
+      date={fromUtc(data)}
     />
   );
 };

--- a/i18n.lock
+++ b/i18n.lock
@@ -634,6 +634,8 @@ checksums:
     time_table_slots: ba2e44486ebe947322acc78d3bc05a3a
     channel_id_copied: 58bf6a74adf570a5daf233ce496149de
     settings_updated: 260e10a61200b581616d766f3af5ae52
+    current_timezone: 5bc1d49a4c592ab2a7477d4bb5b6001b
+    timezone_auto: ea4175545675deec5e94c9498a81fedc
     customer_updated: ab17bcd115b14b72bb2e89f2b48883a4
     custom_url: f1e4e1c6a386d212abe94b937cf5e812
     picture: 14818ef364a0ecc8b738bdb23c46b3c3

--- a/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/integration.schedule.post.ts
@@ -7,11 +7,18 @@ import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/po
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import { AllProvidersSettings } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/all.providers.settings';
 import { Integration } from '@prisma/client';
+import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
 import {
   ValidUrlExtension,
   ValidUrlPath,
 } from '@gitroom/helpers/utils/valid.url.path';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const validUrlExtension = new ValidUrlExtension();
 const validUrlPath = new ValidUrlPath();
@@ -31,7 +38,8 @@ const attachmentUrl = z
 export class IntegrationSchedulePostTool implements AgentToolInterface {
   constructor(
     private _postsService: PostsService,
-    private _integrationService: IntegrationService
+    private _integrationService: IntegrationService,
+    private _organizationService: OrganizationService
   ) {}
   name = 'integrationSchedulePostTool';
 
@@ -74,7 +82,11 @@ If validation fails, the result contains output.errors describing what to fix; t
                 .describe(
                   "If the integration is X, return if it's premium or not"
                 ),
-              date: z.string().describe('The date of the post in UTC time'),
+              date: z
+                .string()
+                .describe(
+                  'The date of the post. Without an explicit offset / Z it is interpreted in the timezone configured in the user Postiz settings (or UTC when none is configured); with an offset it is absolute'
+                ),
               shortLink: z
                 .boolean()
                 .describe(
@@ -137,6 +149,22 @@ If validation fails, the result contains output.errors describing what to fix; t
           (context?.requestContext as any)?.get('organization') as string
         ).id;
         const finalOutput = [];
+
+        // Offset-less dates are interpreted in the user's configured timezone
+        // (when set); dates with an explicit offset / Z stay absolute.
+        const timezoneName =
+          await this._organizationService.getOrgOwnerTimezone(organizationId);
+        if (timezoneName) {
+          for (const platform of inputData.socialPost) {
+            if (!/(Z|[+-]\d{2}:?\d{2})$/i.test(platform.date)) {
+              const shifted = dayjs.tz(platform.date, timezoneName);
+              // an unparsable date is left alone so the error stays recognizable
+              if (shifted.isValid()) {
+                platform.date = shifted.utc().format('YYYY-MM-DDTHH:mm:ss');
+              }
+            }
+          }
+        }
 
         const integrations = {} as Record<string, Integration>;
         for (const platform of inputData.socialPost) {

--- a/libraries/nestjs-libraries/src/chat/tools/posts.list.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/posts.list.tool.ts
@@ -4,10 +4,13 @@ import { z } from 'zod';
 import { Injectable } from '@nestjs/common';
 import { PostsService } from '@gitroom/nestjs-libraries/database/prisma/posts/posts.service';
 import { checkAuth } from '@gitroom/nestjs-libraries/chat/auth.context';
+import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const parseSettings = (settings: string | null) => {
   try {
@@ -19,7 +22,10 @@ const parseSettings = (settings: string | null) => {
 
 @Injectable()
 export class PostsListTool implements AgentToolInterface {
-  constructor(private _postsService: PostsService) {}
+  constructor(
+    private _postsService: PostsService,
+    private _organizationService: OrganizationService
+  ) {}
   name = 'postsListTool';
 
   run() {
@@ -37,17 +43,21 @@ export class PostsListTool implements AgentToolInterface {
       description: `
 List the organization's posts scheduled to be published between two dates (the same data as the "List Posts" API endpoint).
 Returns every post in the window whatever its state (scheduled, draft, published, errored).
-"startDate" and "endDate" are required (UTC) - to list all upcoming posts, pass a wide window (for example from now to a year ahead).
+"startDate" and "endDate" are required - without an explicit offset / Z they are read in the timezone configured in the user Postiz settings (UTC when none is configured), which is also the timezone every returned publish date is rendered in (see output "timezone"). To list all upcoming posts, pass a wide window (for example from now to a year ahead).
 Each item has an "id", its publish date, state, content, channel and current provider settings.
 Posts cannot be deleted through the Postiz tools - if the user wants to delete a post, tell them to do it themselves in the Postiz app; never offer to delete a post.
 `,
       inputSchema: z.object({
         startDate: z
           .string()
-          .describe('Start of the window (UTC), for example 2026-07-20T00:00:00'),
+          .describe(
+            "Start of the window, for example 2026-07-20T00:00:00 (read in the user's timezone unless it carries an offset)"
+          ),
         endDate: z
           .string()
-          .describe('End of the window (UTC), for example 2026-08-20T00:00:00'),
+          .describe(
+            "End of the window, for example 2026-08-20T00:00:00 (read in the user's timezone unless it carries an offset)"
+          ),
         customer: z
           .string()
           .optional()
@@ -60,7 +70,11 @@ Posts cannot be deleted through the Postiz tools - if the user wants to delete a
               id: z
                 .string()
                 .describe('The post id'),
-              publishDate: z.string().describe('UTC time'),
+              publishDate: z
+                .string()
+                .describe(
+                  'The publish date in the "timezone" of the output (UTC when none is configured)'
+                ),
               state: z.string().describe('QUEUE, DRAFT, PUBLISHED or ERROR'),
               content: z.string(),
               settings: z
@@ -72,6 +86,9 @@ Posts cannot be deleted through the Postiz tools - if the user wants to delete a
               integrationName: z.string(),
             })
           ),
+          timezone: z
+            .string()
+            .describe('The timezone every publish date is rendered in'),
         }),
       }),
       execute: async (inputData, context) => {
@@ -80,18 +97,39 @@ Posts cannot be deleted through the Postiz tools - if the user wants to delete a
           (context?.requestContext as any)?.get('organization') as string
         ).id;
 
+        // Offset-less window dates are interpreted in the user's configured
+        // timezone (when set), and every publish date is rendered in it.
+        const timezoneName =
+          (await this._organizationService.getOrgOwnerTimezone(
+            organizationId
+          )) || 'UTC';
+
+        const toUtc = (date: string) => {
+          if (/(Z|[+-]\d{2}:?\d{2})$/i.test(date)) {
+            return date;
+          }
+
+          // an unparsable date is left alone so the error stays recognizable
+          const shifted = dayjs.tz(date, timezoneName);
+          return shifted.isValid()
+            ? shifted.utc().format('YYYY-MM-DDTHH:mm:ss')
+            : date;
+        };
+
         const posts = await this._postsService.getPosts(organizationId, {
-          startDate: inputData.startDate,
-          endDate: inputData.endDate,
+          startDate: toUtc(inputData.startDate),
+          endDate: toUtc(inputData.endDate),
           customer: inputData.customer,
         } as any);
 
         return {
           output: {
+            timezone: timezoneName,
             posts: (posts || []).map((p: any) => ({
               id: p.id,
-              publishDate: dayjs(p.publishDate)
-                .utc()
+              publishDate: dayjs
+                .utc(p.publishDate)
+                .tz(timezoneName)
                 .format('YYYY-MM-DDTHH:mm:ss'),
               state: p.state,
               content: p.content || '',

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -87,6 +87,28 @@ export class OrganizationRepository {
     });
   }
 
+  async getOrgOwnerTimezone(orgId: string) {
+    const owner = await this._userOrg.model.userOrganization.findFirst({
+      where: {
+        organizationId: orgId,
+        disabled: false,
+        role: Role.SUPERADMIN,
+        user: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        user: {
+          select: {
+            timezoneName: true,
+          },
+        },
+      },
+    });
+
+    return owner?.user?.timezoneName || null;
+  }
+
   getUserOrg(id: string) {
     return this._userOrg.model.userOrganization.findFirst({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
@@ -63,6 +63,10 @@ export class OrganizationService {
     return this._organizationRepository.getUserOrg(id);
   }
 
+  getOrgOwnerTimezone(orgId: string) {
+    return this._organizationRepository.getOrgOwnerTimezone(orgId);
+  }
+
   getOrgsByUserId(userId: string) {
     return this._organizationRepository.getOrgsByUserId(userId);
   }

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -91,6 +91,7 @@ model User {
   pictureId             String?
   providerId            String?
   timezone              Int
+  timezoneName          String?
   createdAt             DateTime             @default(now())
   updatedAt             DateTime             @updatedAt
   lastReadNotifications DateTime             @default(now())

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.repository.ts
@@ -287,6 +287,17 @@ export class UsersRepository {
     });
   }
 
+  async updateTimezone(userId: string, timezoneName: string | null) {
+    await this._user.model.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        timezoneName,
+      },
+    });
+  }
+
   async updateEmailNotifications(userId: string, body: EmailNotificationsDto) {
     await this._user.model.user.update({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/users/users.service.ts
@@ -6,6 +6,13 @@ import { EmailNotificationsDto } from '@gitroom/nestjs-libraries/dtos/users/emai
 import { OrganizationRepository } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.repository';
 import { IntegrationRepository } from '@gitroom/nestjs-libraries/database/prisma/integrations/integration.repository';
 import { NotificationService } from '@gitroom/nestjs-libraries/database/prisma/notifications/notification.service';
+import { TimezoneDto } from '@gitroom/nestjs-libraries/dtos/users/timezone.dto';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 @Injectable()
 export class UsersService {
@@ -141,6 +148,21 @@ export class UsersService {
 
   changePersonal(userId: string, body: UserDetailDto) {
     return this._usersRepository.changePersonal(userId, body);
+  }
+
+  updateTimezone(userId: string, body: TimezoneDto) {
+    // an empty name means "auto", which is stored as null
+    const timezoneName = body.timezoneName || null;
+
+    if (timezoneName) {
+      try {
+        dayjs.tz(dayjs(), timezoneName);
+      } catch (err) {
+        throw new HttpException('Invalid timezone', 400);
+      }
+    }
+
+    return this._usersRepository.updateTimezone(userId, timezoneName);
   }
 
   getEmailNotifications(userId: string) {

--- a/libraries/nestjs-libraries/src/dtos/users/timezone.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/users/timezone.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, ValidateIf } from 'class-validator';
+
+export class TimezoneDto {
+  @ValidateIf((o) => o.timezoneName !== null)
+  @IsString()
+  timezoneName: string | null;
+}

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "فترات الجدول الزمني",
   "channel_id_copied": "تم نسخ معرف القناة إلى الحافظة",
   "settings_updated": "تم تحديث الإعدادات",
+  "current_timezone": "المنطقة الزمنية الحالية",
+  "timezone_auto": "تلقائي (منطقة متصفحك الزمنية)",
   "customer_updated": "تم تحديث العميل",
   "custom_url": "رابط مخصص",
   "picture": "صورة",

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "সময়সূচির স্লট",
   "channel_id_copied": "চ্যানেল আইডি ক্লিপবোর্ডে কপি হয়েছে",
   "settings_updated": "সেটিংস আপডেট হয়েছে",
+  "current_timezone": "বর্তমান টাইমজোন",
+  "timezone_auto": "স্বয়ংক্রিয় (আপনার ব্রাউজারের টাইমজোন)",
   "customer_updated": "গ্রাহক আপডেট হয়েছে",
   "custom_url": "কাস্টম URL",
   "picture": "ছবি",

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Zeitplan-Slots",
   "channel_id_copied": "Kanal-ID in die Zwischenablage kopiert",
   "settings_updated": "Einstellungen aktualisiert",
+  "current_timezone": "Aktuelle Zeitzone",
+  "timezone_auto": "Automatisch (Zeitzone Ihres Browsers)",
   "customer_updated": "Kunde aktualisiert",
   "custom_url": "Benutzerdefinierte URL",
   "picture": "Bild",

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -633,6 +633,8 @@
   "time_table_slots": "Time Table Slots",
   "channel_id_copied": "Channel ID copied to clipboard",
   "settings_updated": "Settings Updated",
+  "current_timezone": "Current Timezone",
+  "timezone_auto": "Auto (your browser timezone)",
   "customer_updated": "Customer Updated",
   "custom_url": "Custom URL",
   "picture": "Picture",

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Intervalos de horario",
   "channel_id_copied": "ID del canal copiado al portapapeles",
   "settings_updated": "Configuración actualizada",
+  "current_timezone": "Zona horaria actual",
+  "timezone_auto": "Automático (zona horaria de tu navegador)",
   "customer_updated": "Cliente actualizado",
   "custom_url": "URL personalizada",
   "picture": "Imagen",

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Créneaux horaires",
   "channel_id_copied": "ID du canal copié dans le presse-papiers",
   "settings_updated": "Paramètres mis à jour",
+  "current_timezone": "Fuseau horaire actuel",
+  "timezone_auto": "Auto (le fuseau horaire de votre navigateur)",
   "customer_updated": "Client mis à jour",
   "custom_url": "URL personnalisée",
   "picture": "Image",

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "משבצות לוח זמנים",
   "channel_id_copied": "מזהה הערוץ הועתק ללוח",
   "settings_updated": "ההגדרות עודכנו",
+  "current_timezone": "אזור זמן נוכחי",
+  "timezone_auto": "אוטומטי (אזור הזמן של הדפדפן שלך)",
   "customer_updated": "הלקוח עודכן",
   "custom_url": "כתובת URL מותאמת אישית",
   "picture": "תמונה",

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Fasce orarie",
   "channel_id_copied": "ID canale copiato negli appunti",
   "settings_updated": "Impostazioni aggiornate",
+  "current_timezone": "Fuso orario attuale",
+  "timezone_auto": "Automatico (fuso orario del tuo browser)",
   "customer_updated": "Cliente aggiornato",
   "custom_url": "URL personalizzato",
   "picture": "Immagine",

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "タイムテーブル枠",
   "channel_id_copied": "チャンネルIDがクリップボードにコピーされました",
   "settings_updated": "設定が更新されました",
+  "current_timezone": "現在のタイムゾーン",
+  "timezone_auto": "自動（お使いのブラウザのタイムゾーン）",
   "customer_updated": "顧客情報が更新されました",
   "custom_url": "カスタムURL",
   "picture": "画像",

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "시간표 슬롯",
   "channel_id_copied": "채널 ID가 클립보드에 복사되었습니다",
   "settings_updated": "설정이 업데이트되었습니다",
+  "current_timezone": "현재 시간대",
+  "timezone_auto": "자동(브라우저의 시간대)",
   "customer_updated": "고객 정보가 업데이트되었습니다",
   "custom_url": "맞춤 URL",
   "picture": "사진",

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Horários da Tabela",
   "channel_id_copied": "ID do canal copiado para a área de transferência",
   "settings_updated": "Configurações Atualizadas",
+  "current_timezone": "Fuso horário atual",
+  "timezone_auto": "Automático (fuso horário do seu navegador)",
   "customer_updated": "Cliente Atualizado",
   "custom_url": "URL personalizada",
   "picture": "Imagem",

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Слоты расписания",
   "channel_id_copied": "ID канала скопирован в буфер обмена",
   "settings_updated": "Настройки обновлены",
+  "current_timezone": "Текущий часовой пояс",
+  "timezone_auto": "Авто (часовой пояс вашего браузера)",
   "customer_updated": "Клиент обновлён",
   "custom_url": "Пользовательский URL",
   "picture": "Изображение",

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Zaman Tablosu Dilimleri",
   "channel_id_copied": "Kanal kimliği panoya kopyalandı",
   "settings_updated": "Ayarlar Güncellendi",
+  "current_timezone": "Geçerli Saat Dilimi",
+  "timezone_auto": "Otomatik (tarayıcınızın saat dilimi)",
   "customer_updated": "Müşteri Güncellendi",
   "custom_url": "Özel URL",
   "picture": "Resim",

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "Khung giờ thời gian biểu",
   "channel_id_copied": "Đã sao chép ID kênh vào bộ nhớ tạm",
   "settings_updated": "Đã cập nhật cài đặt",
+  "current_timezone": "Múi giờ hiện tại",
+  "timezone_auto": "Tự động (múi giờ trình duyệt của bạn)",
   "customer_updated": "Đã cập nhật khách hàng",
   "custom_url": "URL tùy chỉnh",
   "picture": "Hình ảnh",

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -630,6 +630,8 @@
   "time_table_slots": "时间表时段",
   "channel_id_copied": "频道 ID 已复制到剪贴板",
   "settings_updated": "设置已更新",
+  "current_timezone": "当前时区",
+  "timezone_auto": "自动（您的浏览器时区）",
   "customer_updated": "客户已更新",
   "custom_url": "自定义 URL",
   "picture": "图片",


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature.

# Why was this change needed?

Every datetime in the app was rendered in whatever timezone the browser happened to be set to. A user working on a machine set to another zone saw the wrong times on the calendar and scheduled posts at the wrong hour, with no way to correct it. This adds an account-scoped IANA timezone so datetimes are shown and entered in the user's own timezone across the calendar, the MCP tools and the public API.

This was attempted once before and rolled back. e5af6382 (7 Aug 2025) added a timezone setting and was reverted three days later in dee9a6d5 and 9aea717e after severe calendar slowness, with two performance fixes in between (326c1b60, d5979ed6) that did not resolve it. The cause was structural rather than incidental: newDayjs() was turned into a timezone-aware constructor and then used as the universal constructor at roughly 60 call sites, including the calendar's render loops. The month view iterates weeks by days by hours by posts, so every cell constructed a timezone-aware object and paid an Intl cost, producing thousands of such constructions per render.

This PR takes the opposite approach. The timezone is a display lens applied once at the API boundary, not a property of the dayjs objects flowing through the app. The database, Temporal and every internal API payload keep carrying absolute UTC instants, and the timezone is never persisted into a datetime. fromUtc turns a UTC instant into a plain machine-local dayjs carrying the user's wall clock, and toUtc is its exact inverse, applied at every write site. Everything between those boundaries works on plain dayjs objects, so render loops never construct a timezone-aware one, and the number of conversions is proportional to the datetimes arriving from the API rather than to the number of rendered cells.

The setting is nullable and defaults to null, meaning auto. With no timezone chosen every helper degenerates to the existing machine-local behaviour, so nothing changes for current users until they opt in.

# Other information:

Tested:

* Regression with the setting unset (default off)
* Create at a chosen wall clock under a non-machine timezone
* Drag and drop between slots
* Round trip: open a scheduled post and save without touching the date
* Timezone change against a pending scheduled post, row and armed workflow
* Recurring post projections across a timezone change
* Now consistency: today highlight, past hour guard, default suggested date
* Posting time slots, add and display
* MCP schedule and list tools
* Public API offset-less and absolute dates
* DST edges: ambiguous and nonexistent wall clocks
* Two users in one organization with different timezones
* Frontend calendar performance

Accepted limitations:

Re-saving a post that falls inside a DST fall-back repeated hour resolves to the earlier of the two instants. This is inherent to representing an instant as a wall clock.

Recurring occurrences step in UTC, so across a DST boundary their wall clock in the user's timezone shifts by an hour. Changing that would change firing semantics and is out of scope here.

Posting-time slots keep their existing UTC-minutes storage, because slots are integration-scoped while the timezone is user-scoped. Only the UI conversions move to the lens.

Two things worth a reviewer's opinion:

getOrgOwnerTimezone resolves the organization's super admin with findFirst and no ordering. For an organization with more than one super admin, which timezone is used to interpret offset-less public API and MCP dates is therefore arbitrary.

The browser extension's standalone modal does not hydrate the lens, so scheduling from the extension stays on browser-local time. That is not a regression, but it is a coverage gap if we want the extension included.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [ ] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
