### PR TITLE
fix(instagram): strip leading @ from collaborator handles

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -694,7 +694,11 @@ export class InstagramProvider
         const collaborators =
           firstPost?.settings?.collaborators?.length && !isStory
             ? `&collaborators=${JSON.stringify(
-                firstPost?.settings?.collaborators.map((p) => p.label)
+                // Instagram rejects handles with a leading @ (error_subcode
+                // 2207018), and the tag input stores whatever the user typed.
+                firstPost?.settings?.collaborators.map((p) =>
+                  p.label.replace(/^@+/, '')
+                )
               )}`
             : ``;
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A production post failed on 2026-08-21 on an `instagram-standalone` channel with the unactionable message "Unknown Error". Instagram had rejected the media container with:

```
{"error":{"message":"Invalid user id","type":"OAuthException","code":110,
 "error_subcode":2207018,"is_transient":false,
 "error_user_title":"Cannot load user with a private profile or invalid username"}}
```

The post carried a collaborator tag whose handle had been entered with a leading `@`. `instagram.tags.tsx` stores the tag label exactly as typed, and `postPending` forwards `p.label` straight into the `collaborators` parameter, so a user who types the handle the way Instagram displays it gets a hard publish failure.

The `@` alone is enough to cause it: creating a container against a live Instagram channel with the same public handle returns HTTP 200 with `@` removed and HTTP 400 with `2207018` when it is present.

Normalising in the provider rather than in the DTO or the tag input covers posts created through the public API as well as the UI.

# Other information:

Verified end to end against a live Instagram channel, driving the real `postPending` / `checkPostStatus` / `finalizePost` path with a collaborator entered as `@handle`. Before the change it threw `BadBody: Unknown Error`; after it, the same input published successfully and the collaborator was accepted.

Complements #1876, which maps `2207018` to a curated message for the cases this cannot fix (genuinely private or misspelled handles). The two are independent and touch different parts of the file.

Not fixed here, and still true after this change: collaborator handles are never validated, and the "max 3" limit is enforced only client-side.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue