### PR TITLE
fix(analytics): remove hardcoded 5% trend badge from provider analytics

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -991,7 +991,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
             : d.name === 'page_daily_follows'
             ? 'Page followers'
             : 'Media views',
-        percentageChange: 5,
+        percentageChange: 0,
         data: d?.values?.map((v: any) => ({
           total: sumValue(v.value),
           date: dayjs(v.end_time).format('YYYY-MM-DD'),

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -1102,7 +1102,7 @@ export class InstagramProvider
     analytics.push(
       ...(data?.map((d: any) => ({
         label: this.setTitle(d.name),
-        percentageChange: 5,
+        percentageChange: 0,
         data: d.values.map((v: any) => ({
           total: v.value,
           date: dayjs(v.end_time).format('YYYY-MM-DD'),
@@ -1113,7 +1113,7 @@ export class InstagramProvider
     analytics.push(
       ...data2.map((d: any) => ({
         label: this.setTitle(d.name),
-        percentageChange: 5,
+        percentageChange: 0,
         data: [
           {
             total: d.total_value.value,

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -436,7 +436,7 @@ export class LinkedinPageProvider
       data: analytics[
         key as 'Page Views' | 'Organic Followers' | 'Paid Followers'
       ],
-      percentageChange: 5,
+      percentageChange: 0,
     }));
   }
 

--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -732,7 +732,7 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
     return (
       data?.map((d: any) => ({
         label: capitalize(d.name),
-        percentageChange: 5,
+        percentageChange: 0,
         data: d.total_value
           ? [{ total: d.total_value.value, date: dayjs().format('YYYY-MM-DD') }]
           : d.values.map((v: any) => ({

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -1479,7 +1479,7 @@ export class XProvider extends SocialAbstract implements SocialProvider {
 
       return Object.entries(metrics).map(([key, value]) => ({
         label: key.replace('_count', '').replace('_', ' ').toUpperCase(),
-        percentageChange: 5,
+        percentageChange: 0,
         data: [
           {
             total: String(0),


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (analytics). The Instagram, Facebook, LinkedIn Page, Threads and X providers returned a hardcoded `percentageChange: 5` on every analytics metric - a leftover stub from the original analytics commit - which rendered a fake green "5.0%" trend badge on every card, including all-zero ones. All five now return 0, which the frontend's `TrendIndicator` hides. No real trend is computed yet.

# Why was this change needed?

A customer reported on 2026-08-21 that the channel analytics page made no sense: every metric card, including all-zero ones, showed a green "5.0%" trend badge, next to real data pulled from the platform's insights API.

The badge is not computed anywhere: the Instagram, Facebook, LinkedIn Page, Threads and X providers return a hardcoded `percentageChange: 5` on every analytics metric, a leftover stub from the original analytics commit. All other providers return 0, which the frontend's TrendIndicator hides.

This sets the five remaining providers to 0 as well, so the fake trend badge no longer renders. Computing a real previous-period comparison can be a future improvement.

# Other information:

Verified locally that the badge disappears from the analytics cards after the change.

# QA

1. [ ] Start the stack (`pnpm run dev:docker`, then `pnpm run dev`) and connect at least one of the affected channels: Instagram, Facebook Page, LinkedIn Page, Threads or X.
2. [ ] Open Analytics and select that channel.
3. [ ] Expected: no metric card shows the green "5.0%" trend badge any more - including cards whose value is 0. The metric numbers, labels and charts themselves are unchanged.
4. [ ] Compare against `origin/main` on the same channel if you want the before/after: there every card, including the all-zero ones, carries a green 5.0%.
5. [ ] Check the payload directly: `curl -H "Authorization: <org api key>" http://localhost:3000/public/v1/analytics/<integration id>`. Expected: every entry has `"percentageChange": 0`.
6. [ ] Regression on an unaffected provider (e.g. Mastodon, Bluesky, YouTube - anything already returning 0): open its analytics. Expected: unchanged, still no badge, since `TrendIndicator` already hid a 0.
7. [ ] Confirm the badge component itself is untouched: nothing in `TrendIndicator` changed, so a provider that ever returns a real non-zero `percentageChange` would still render a badge.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GMt4rL4sJsVxC9fER76Kv
