### PR TITLE
fix(launch-modal): repeat interval leaks between post modal opens

### DIFF
--- a/apps/frontend/src/components/new-launch/store.ts
+++ b/apps/frontend/src/components/new-launch/store.ts
@@ -143,6 +143,7 @@ const initialState = {
   activateExitButton: true,
   date: newDayjs(),
   postComment: PostComment.ALL,
+  repeater: undefined as undefined | number,
   tags: [] as { label: string; value: string }[],
   totalChars: 0,
   tab: 0 as 0,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, post modal). Adds the missing `repeater` field to `initialState` in the new-launch zustand store, so the modal's unmount `reset()` actually clears the repeat interval. Without it the selected interval leaked into the next modal open - shown on existing non-recurring posts and inherited by new ones - and was silently attached to the saved post via `inter`.

# Why was this change needed?

The post modal's repeat interval (`repeater` in the launch zustand store) was never cleared when the modal closed: `reset()` spreads `initialState`, and `repeater` was missing from it. As a result, after selecting an interval and closing the modal (saving as draft, scheduling, or just closing), the value leaked into the next modal open:

- opening an existing non-recurring post showed the previous interval instead of none
- creating a new post inherited it too
- in both cases saving would silently attach the stale interval to the post (`inter` is sent whenever `repeater` is truthy)

Adding `repeater` to `initialState` makes the unmount `reset()` clear it on every close path. `repeater` was the only store field missing from `initialState`.

Verified in the running app: reproduced the leak pre-fix (existing non-recurring draft showed "Repeat Post Every Week" after picking Week in a previous modal); post-fix the selector opens clean, and a post that genuinely has `intervalInDays` still loads its interval correctly.

# Other information:

None.

# QA

1. [ ] Start the stack (`pnpm run dev:docker`, then `pnpm run dev`) and open the calendar.
2. [ ] Click an empty slot to open the post modal, pick a channel, and set the repeat interval to "Repeat Post Every Week".
3. [ ] Close the modal (the X, or save it as a draft - any close path unmounts the launch store and calls `reset()`).
4. [ ] Click another empty slot to open a fresh post modal. Expected: the repeat selector shows no interval selected. Before the fix it showed "Repeat Post Every Week" carried over from the previous modal.
5. [ ] Repeat the leak check against an existing post: after step 2-3, open an existing non-recurring post or draft from the calendar. Expected: its repeat selector is empty. Before the fix it showed the stale "Week".
6. [ ] Save that non-recurring post and reopen it. Expected: still no interval, and the saved post has no `intervalInDays` (check the post row or the calendar, which shows no recurrence marker) - the stale interval is no longer silently attached via `inter`.
7. [ ] Regression: create a post that genuinely repeats, set "Repeat Post Every Week", save it, then reopen it. Expected: it loads with "Week" still selected and its `intervalInDays` intact.
8. [ ] Regression on the other reset paths: pick an interval, then schedule the post (rather than closing), and open a new modal. Expected: the selector is clean there too.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LuzNZyVpFdLKXio4SxJb8
