### PR TITLE
fix(posts): find-slot never responds when all channels are disabled

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -1320,8 +1320,9 @@ export class PostsService {
     );
     return this.findFreeDateTimeRecursive(
       orgId,
-      findTimes,
-      dayjs.utc().startOf('day')
+      findTimes.length ? findTimes : [120, 400, 700],
+      dayjs.utc().startOf('day'),
+      0
     );
   }
 
@@ -1337,8 +1338,17 @@ export class PostsService {
   private async findFreeDateTimeRecursive(
     orgId: string,
     times: number[],
-    date: dayjs.Dayjs
+    date: dayjs.Dayjs,
+    daysChecked: number
   ): Promise<string> {
+    // stop searching after a year so an empty times list can never recurse forever
+    if (daysChecked > 365) {
+      return date
+        .clone()
+        .add(times[0] || 0, 'minutes')
+        .format('YYYY-MM-DDTHH:mm:00');
+    }
+
     const list = await this._postRepository.getPostsCountsByDates(
       orgId,
       times,
@@ -1346,7 +1356,12 @@ export class PostsService {
     );
 
     if (!list.length) {
-      return this.findFreeDateTimeRecursive(orgId, times, date.add(1, 'day'));
+      return this.findFreeDateTimeRecursive(
+        orgId,
+        times,
+        date.add(1, 'day'),
+        daysChecked + 1
+      );
     }
 
     const num = list.reduce<null | number>((prev, curr) => {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A paying customer reported on 2026-08-22 that clicking "Create Post" did nothing at all, making the app unusable right after they purchased a subscription. Their trial had expired, which left every integration in the organization with `disabled = true`, and upgrading does not re-enable channels.

In that state, `GET /posts/find-slot` (which the Create Post button awaits before opening the editor) never responds: `getPostingTimes` only reads enabled integrations, so `findFreeDateTimeRecursive` receives an empty times list, gets an empty result for every day, and recurses forever, one DB query per day, to infinity. The click fails silently.

This PR makes find-slot always answer:

- When no enabled integration contributes posting times, fall back to the schema-default times `[120, 400, 700]`.
- Cap the recursive free-slot search at 365 days as a safety net, so no empty/exhausted times list can loop forever again.

With this fix the editor opens and the disabled channels are shown greyed out with the existing "please upgrade your plan" tooltip, so the user can see what is actually wrong. The fallback also covers the other callers of `findFreeDateTime` (`/posts/find-slot/:id`, public API, autopost, agent), where an id pointing at a disabled integration hits the same loop.

# Other information:

Tested end to end on a local environment: with all of an organization's channels disabled, Create Post previously hung forever; after the fix, `/posts/find-slot` returns 200 with the first fallback slot and the editor opens with the channels greyed out. `/posts/find-slot/:id` with a disabled integration id also returns. Verified the normal path (enabled channels) is unchanged.

Re-enabling channels on subscription upgrade is a separate follow-up.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYTuLLhYQsLCdgxBFEXpG9