### PR TITLE
feat(nostr): add @-mention profile autocomplete in the composer

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -7,7 +7,13 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
 import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
-import { getPublicKey, Relay, finalizeEvent, SimplePool } from 'nostr-tools';
+import {
+  getPublicKey,
+  Relay,
+  finalizeEvent,
+  SimplePool,
+  nip19,
+} from 'nostr-tools';
 
 import WebSocket from 'ws';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
@@ -23,6 +29,11 @@ const list = [
   'wss://temp.iris.to',
   'wss://vault.iris.to',
 ];
+
+// NIP-50 full-text search relays. The write relays above do not implement
+// NIP-50, so profile (kind 0) search for @-mention autocomplete is routed to
+// relay.nostr.band, which maintains a search index over profile metadata.
+const searchList = ['wss://relay.nostr.band'];
 
 const pool = new SimplePool();
 
@@ -232,5 +243,82 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         status: 'completed',
       },
     ];
+  }
+
+  // Autocomplete Nostr profiles when the user types "@" in the composer.
+  // Mirrors the mention() contract implemented by the other providers
+  // (e.g. Bluesky): return `{ id, label, image }[]`, where `id` is the value
+  // handed back to `mentionFormat` when the user picks a suggestion.
+  override async mention(
+    token: string,
+    d: { query: string },
+    id: string,
+    integration: Integration
+  ): Promise<
+    { id: string; label: string; image: string }[] | { none: true }
+  > {
+    const query = (d.query || '').trim();
+
+    // The composer only fires autocomplete from 2 characters onward; guard
+    // here too so we never send an empty NIP-50 search to the relay.
+    if (query.length < 2) {
+      return [];
+    }
+
+    // NIP-50 full-text search over profile (kind 0) events.
+    const events = await pool.querySync(searchList, {
+      kinds: [0],
+      search: query,
+      limit: 10,
+    });
+
+    const seen = new Set<string>();
+    const results: { id: string; label: string; image: string }[] = [];
+
+    for (const event of events) {
+      // A pubkey can publish several kind-0 events; keep only the first.
+      if (seen.has(event.pubkey)) {
+        continue;
+      }
+      seen.add(event.pubkey);
+
+      let content: any = {};
+      try {
+        content = JSON.parse(event.content || '{}');
+      } catch {
+        continue;
+      }
+
+      const label =
+        content.display_name || content.displayName || content.name;
+
+      // Skip profiles with no usable name — there is nothing to show.
+      if (!label) {
+        continue;
+      }
+
+      // Suggestions insert an npub (via mentionFormat), so encode the raw
+      // hex pubkey; fall back to the hex key if encoding somehow fails.
+      let npub = event.pubkey;
+      try {
+        npub = nip19.npubEncode(event.pubkey);
+      } catch {
+        /** keep the raw pubkey **/
+      }
+
+      results.push({
+        id: npub,
+        label,
+        image: content.picture || '',
+      });
+    }
+
+    return results;
+  }
+
+  // NIP-27: a `nostr:` URI wrapping the npub renders as a mention in Nostr
+  // clients. `idOrHandle` is the `id` returned from mention() (the npub).
+  mentionFormat(idOrHandle: string, name: string) {
+    return `nostr:${idOrHandle}`;
   }
 }


### PR DESCRIPTION
## What & why

Closes #1603.

The composer already offers `@`-mention autocomplete for every provider that implements the `mention()` contract — X, Bluesky, LinkedIn, Threads, Discord. Nostr inherited the `SocialAbstract` default (`return { none: true }`), so typing `@` in a Nostr post shows *"We don't have autocomplete for this social media"*.

This adds mention support to `NostrProvider`. The composer (`editor.tsx` → `mention.component.tsx`) and the `mentions` controller are already provider-generic, so this is a **backend-only** change — no frontend edits needed.

## How

`libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts`:

- **`mention(token, { query }, id, integration)`** — runs a **NIP-50** full-text search over profile (`kind 0`) events and returns `{ id, label, image }[]`, mirroring the shape the other providers return (closest analog: Bluesky's `searchActors`).
  - Search is routed to `wss://relay.nostr.band`, a NIP-50 search relay that indexes profile metadata. The existing write relays (`nos.lol`, `damus`, …) don't implement NIP-50, so reusing them for search would return nothing — hence a dedicated `searchList`.
  - Results are de-duplicated per `pubkey`, profiles with no usable name are skipped, and the raw hex pubkey is encoded to an **npub** via `nip19.npubEncode` for the `id`.
  - Uses `pool.querySync` from the already-imported `nostr-tools` (`^2.18.2`) — no new dependency.
- **`mentionFormat(idOrHandle, name)`** — wraps the npub as a **NIP-27** `nostr:npub…` reference, which Nostr clients render as a mention.

## Testing note (please verify)

I wrote and reviewed this against the existing provider pattern, but I was **not able to run the full monorepo locally to exercise the composer dropdown end-to-end**, so I'd appreciate a maintainer confirming the live `@`-autocomplete behavior in the Nostr composer before merge. The change is small, self-contained, and additive (it only overrides a method that previously returned `{ none: true }`), so it cannot affect other providers or existing Nostr posting.

## Possible follow-ups (out of scope here)

- Emit a `["p", <hex>]` tag on `post()`/`comment()` when a `nostr:npub` reference is present, so mentioned users get NIP-27 notifications (the reference already renders without it).
