### PR TITLE
fix(tiktok): keep the post id intact and resolve publish ids for analytics

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -420,6 +420,14 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
+  // TikTok sends the post id as a 19-digit number, which JSON.parse rounds off
+  // past Number.MAX_SAFE_INTEGER, so read it out of the raw body as a string.
+  private publicPostId(body: string) {
+    return body.match(
+      /"publicaly_available_post_id"\s*:\s*\[\s*"?(\d+)"?/
+    )?.[1];
+  }
+
   // Single status check for a publish_id, no loops and no timers: `post` returns
   // a `pending` PostResponse right after the upload, and the post workflow polls
   // this method with durable timers, so a stuck/retried check can never re-run
@@ -430,8 +438,9 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     integration: Integration
   ): Promise<PendingCheckResponse> {
     let post: any;
+    let body: string;
     try {
-      post = await (
+      body = await (
         await this.fetch(
           'https://open.tiktokapis.com/v2/post/publish/status/fetch/',
           {
@@ -448,7 +457,8 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
           0,
           true
         )
-      ).json();
+      ).text();
+      post = JSON.parse(body);
     } catch (err) {
       if (err instanceof RefreshToken || err instanceof Disconnect) {
         throw err;
@@ -460,7 +470,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       return { status: 'pending', pendingData };
     }
 
-    const { status, publicaly_available_post_id } = post?.data || {};
+    const { status } = post?.data || {};
 
     if (status === 'SEND_TO_USER_INBOX') {
       return {
@@ -471,16 +481,14 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     }
 
     if (status === 'PUBLISH_COMPLETE') {
-      // an empty array is truthy, so index it once and branch on the value
-      const publicPostId = publicaly_available_post_id?.[0];
+      const publicPostId = this.publicPostId(body);
 
       return {
         status: 'completed',
         releaseURL: !publicPostId
           ? `https://www.tiktok.com/@${integration.profile}`
           : `https://www.tiktok.com/@${integration.profile}/video/${publicPostId}`,
-        // TikTok returns the id as a number, releaseId in the db is a string
-        postId: !publicPostId ? pendingData.publishId : String(publicPostId),
+        postId: !publicPostId ? pendingData.publishId : publicPostId,
       };
     }
 
@@ -1117,8 +1125,11 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
   ): Promise<AnalyticsData[]> {
     const today = dayjs().format('YYYY-MM-DD');
 
-    if (postId.indexOf('v_pub_url') > -1) {
-      const post = await (
+    // anything that is not a plain video id is a publish_id (v_pub_file~,
+    // p_pub_url~, v_pub_url~), kept when TikTok published without handing us
+    // the video id - resolve it before querying the video.
+    if (!/^\d+$/.test(postId)) {
+      const body = await (
         await fetch(
           'https://open.tiktokapis.com/v2/post/publish/status/fetch/',
           {
@@ -1132,13 +1143,14 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
             }),
           }
         )
-      ).json();
+      ).text();
 
-      if (!post?.data?.publicaly_available_post_id?.[0]) {
+      const publicPostId = this.publicPostId(body);
+      if (!publicPostId) {
         return [];
       }
 
-      postId = post.data.publicaly_available_post_id[0];
+      postId = publicPostId;
     }
 
     try {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix.

# Why was this change needed?

A customer reported that `GET /public/v1/analytics/post/{postId}` returned an
empty array for every one of their TikTok posts, including posts that were
demonstrably published and live. Investigating it surfaced two defects that
compound, both in `tiktok.provider.ts`.

**The post id was being corrupted before we stored it.** TikTok returns
`publicaly_available_post_id` as a 19-digit JSON *number*. That is past
`Number.MAX_SAFE_INTEGER`, so `JSON.parse` rounds it, and the existing
`String(publicPostId)` faithfully stringified an already-wrong value. A live
response observed during testing:

```
raw body        {"data":{"status":"PUBLISH_COMPLETE",
                 "publicaly_available_post_id":[7678907398077074696]}}
after .json()    7678907398077074000     <- rounded
```

`checkPostStatus` persisted that rounded value as `releaseId`, so analytics
lookups matched no video, and it also built `releaseURL` from it, so the
stored "open on TikTok" link pointed at nothing. TikTok soft-404s these:
HTTP 200 with `"statusCode":10204,"statusMsg":"item doesn't exist"` in the
page payload, versus `"statusCode":0` for the real id, which is why the
broken links were never noticed by status-code checks. Of TikTok posts
published in the last 40 days that carry a numeric `releaseId`, 1264 have a
`/video/` URL built from a rounded id and 0 have one built from an intact id.

**Publish ids were never resolved.** When TikTok reports `PUBLISH_COMPLETE`
without a public post id we fall back to storing the publish id, and
`postAnalytics` is meant to resolve it later. That resolution was gated on
the id containing `v_pub_url`, a form current publishes no longer produce:
video uploads emit `v_pub_file~` and photo publishes emit `p_pub_url~`.
Neither matched, so the publish id was passed to `video/query` as if it were
a video id, matched nothing, and returned no analytics. Testing for a plain
numeric video id instead resolves any publish id regardless of prefix, and
avoids needing another patch when the prefix changes again.

The two are fixed together because they are inseparable in practice: widening
the prefix alone would resolve the id and then round it, and the string-safe
read alone would never be reached for the ids that need it.

# Other information:

Verified end to end against a real connected TikTok channel.

- `checkPostStatus` on a live `PUBLISH_COMPLETE` response now returns
  `7678907398077074696` where the previous code produced
  `7678907398077074000`, and builds the matching `releaseURL`.
- The two URLs resolve as expected: the intact id gives `"statusCode":0`,
  the rounded id `"statusCode":10204`. Confirmed on two separate videos.
- `GET /public/v1/analytics/post/{postId}` for a post whose `releaseId` is a
  `v_pub_file~` publish id now returns Views/Likes/Comments/Shares (HTTP 200);
  it returned `[]` before.
- Non-zero metrics pass through correctly (checked against an older video:
  122 views, 5 likes, 1 share).
- Degradation paths unchanged: a status body with no id, an empty
  `publicaly_available_post_id` array, and an unresolvable publish id each
  still yield the publish-id fallback or `[]`, with no throw.

Historical rows are deliberately untouched, but because the resolution happens
at read time, existing posts holding a `v_pub_file~` or `p_pub_url~` publish id
start returning analytics without a migration. Posts already storing a rounded
numeric id are not recoverable from our side, since the original id is gone.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQKfzfBUZkPVFJU956FP3c
