### PR TITLE
fix(sentry): restore user context alongside the identity tags

### DIFF
--- a/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
+++ b/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
@@ -10,12 +10,18 @@ export const setSentryUserContext = (params: {
   paymentId?: string | null;
 }) => {
   try {
+    if (params.userId) {
+      Sentry.setUser({
+        id: params.userId,
+        ...(params.email ? { email: params.email } : {}),
+      });
+      Sentry.setTag('user.id', params.userId);
+    } else {
+      Sentry.setUser(null);
+    }
     if (params.email) {
       // 'user' itself is a reserved tag key - Sentry discards it if set directly
       Sentry.setTag('user.email', params.email);
-    }
-    if (params.userId) {
-      Sentry.setTag('user.id', params.userId);
     }
     if (params.orgId) {
       Sentry.setTag('organization', params.orgId);

--- a/libraries/react-shared-libraries/src/sentry/initialize.sentry.client.ts
+++ b/libraries/react-shared-libraries/src/sentry/initialize.sentry.client.ts
@@ -6,6 +6,10 @@ export const setSentryUser = (
 ) => {
   try {
     if (user?.id) {
+      Sentry.setUser({
+        id: user.id,
+        ...(user.email ? { email: user.email } : {}),
+      });
       if (user.email) {
         // 'user' itself is a reserved tag key - Sentry discards it if set directly
         Sentry.setTag('user.email', user.email);
@@ -14,6 +18,7 @@ export const setSentryUser = (
       Sentry.setTag('organization', user.orgId);
       Sentry.setTag('organization.id', user.orgId);
     } else {
+      Sentry.setUser(null);
       Sentry.setTag('user.email', undefined);
       Sentry.setTag('user.id', undefined);
       Sentry.setTag('organization', undefined);


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix, telemetry (Sentry), touching both backend and frontend. It restores `Sentry.setUser()` in `setSentryUserContext` (`libraries/nestjs-libraries/src/sentry/initialize.sentry.ts`) and in `setSentryUser` (`libraries/react-shared-libraries/src/sentry/initialize.sentry.client.ts`), which commit 62f1d117 had removed in favour of plain identity tags. Both helpers now call `Sentry.setUser({ id, email })` on the authenticated branch and `Sentry.setUser(null)` on the unauthenticated/logout branch, in addition to the tags they already set.

Deliberately unchanged: the `user.email`, `user.id`, `organization`, `organization.id` and `stripe.customer_id` tags all keep their exact current names and values, and no call site of either helper is touched. The change is purely additive — it puts back a second event field alongside the tags rather than moving anything between them.

# Why was this change needed?

62f1d117 dropped `setUser` on the rationale that the Sentry user context is "display-only, not searchable". That premise is wrong — Sentry indexes `user.id`, `user.email`, `user.username` and `user.ip` as first-class searchable event properties — so the removal bought nothing while costing every feature that keys off `event.user`:

- **"Users affected" counts.** Because `sendDefaultPii: true` is set, the SDK still attaches `user.ip_address`, so these did not go blank — they silently degraded to IP-based estimates. Numbers that still look authoritative but no longer count users.
- **Session replay user attribution.** This one bites hard here, since replay runs at `replaysSessionSampleRate: 1.0` and `replaysOnErrorSampleRate: 1.0`. Every replay became anonymous.
- **Release-health / crash-free-users metrics** and any alert rule keyed on unique users.
- **Sentry's user-field PII scrubbing and GDPR user-data deletion tooling**, both of which operate on `event.user`, not on tags.

Keeping the tags and restoring the user context are not mutually exclusive — they are separate fields on the event — so this recovers all of the above without giving up the unprefixed, facetable tag values that 62f1d117 was after.

On the `setUser(null)` branch: on the backend it is defensive rather than load-bearing, because `httpServerIntegration` wraps every inbound request in a fresh isolation scope and both `setTag` and `setUser` write to that scope, so nothing leaks between requests either way. On the frontend it *is* load-bearing — the browser scope is long-lived, so logout genuinely has to clear it.

# Other information:

The synthesized `user` tag now reads `id:<userId>` rather than a bare value. That is Sentry's own convention and not something this PR can change: the tag is built server-side at ingest from `event.user` and is always prefixed with its source field (`id:` > `username:` > `email:` > `ip:`), and a manually-set `user` tag is stripped as reserved. Putting the immutable user id there is deliberate — it survives an email change, so users-affected counts do not fragment when someone updates their address. The human-readable value stays right alongside it in the `user.email` tag.

Two things deliberately left out of scope:

- The `user.email` tag puts the address into Sentry's tag index, where `redactLogAttributes` does not reach (it only filters log attributes, and `beforeSend` only merges `service`/`component`). The `setUser` email is covered by Sentry's user-field PII handling; the tag copy is not. Worth a follow-up, but it predates this PR.
- `organization` and `organization.id` carry the identical value. Harmless, also pre-existing.

Verification note: `tsc --noEmit -p tsconfig.json` reports no errors in either edited file. ESLint could **not** be run against them — `npx eslint` crashes with `TypeError: Converting circular structure to JSON` while loading `eslint.config.mjs`, before it reads any file, and fails identically on files this PR does not touch. So the crash is pre-existing on this branch, but it does mean these two files are unlinted.

# QA

Requires a Sentry project you can read events from. The `user` tag is synthesized server-side at ingest, so Spotlight alone will not show it.

1. [ ] Set `NEXT_PUBLIC_SENTRY_DSN` in `.env` to a DSN for a Sentry project you have access to, then start the stack with `pnpm run dev`
2. [ ] Log in to the app as any user, then note that user's id, email and organization id (from the `User` and `Organization` tables, or the response of `GET /user/self`)
3. [ ] In `apps/backend/src/api/routes/users.controller.ts`, temporarily add `throw new Error('sentry qa backend');` as the first line of the `getSelf` handler (line 100), and let the backend reload
4. [ ] Reload the app in the browser so the frontend calls `/user/self` and the backend throws
5. [ ] Open the new issue in Sentry and confirm the event has a **User** section in Contexts showing the id and email from step 2 — on `staging` this section is absent, and its presence is the core fix
6. [ ] On the same event, confirm all five tags are present: `user` = `id:<userId>`, `user.email` = the email, `user.id` = the id, `organization` and `organization.id` = the org id. The four dotted tags must be unchanged from `staging`
7. [ ] Confirm the issue's "Users affected" count reads 1 rather than an IP-derived estimate
8. [ ] Revert the temporary `throw` from step 3
9. [ ] Trigger a frontend error while logged in (open DevTools and run `setTimeout(() => { throw new Error('sentry qa frontend'); })`), then confirm the resulting Sentry event carries the same User section and tags, and that its attached session replay is attributed to that user instead of Anonymous
10. [ ] Log out via the avatar menu, trigger the same frontend error again from the login screen, and confirm the new event has **no** User section and no `user` / `user.email` / `user.id` / `organization` / `organization.id` tags — this checks that `setUser(null)` clears the long-lived browser scope
11. [ ] Call a public API endpoint with an API key (e.g. `curl -H "Authorization: <org apiKey>" http://localhost:3000/public/v1/posts`) against a temporarily thrown error in that route, and confirm the event carries `organization` / `organization.id` but no user id or email — the public API path passes no `userId` and must not inherit one from an earlier request

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
