### PR TITLE
feat: manage multiple organizations from the app (create, rename, delete, switch)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,8 @@ EXTENSION_ID=""
 
 # Misc Settings
 OPENAI_API_KEY=""
+# Maximum number of organizations a single user can create for himself
+# MAX_ORGS_PER_USER=10
 # OAuth client configured for the ChatGPT app. Only this client can receive
 # verified user email claims for ChatGPT Enterprise domain restrictions.
 OPENAI_OAUTH_CLIENT_ID=""

--- a/apps/backend/src/api/routes/users.controller.ts
+++ b/apps/backend/src/api/routes/users.controller.ts
@@ -1,8 +1,11 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpException,
+  Param,
+  Patch,
   Post,
   Query,
   Req,
@@ -25,6 +28,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { UsersService } from '@gitroom/nestjs-libraries/database/prisma/users/users.service';
 import { UserDetailDto } from '@gitroom/nestjs-libraries/dtos/users/user.details.dto';
 import { EmailNotificationsDto } from '@gitroom/nestjs-libraries/dtos/users/email-notifications.dto';
+import { OrganizationNameDto } from '@gitroom/nestjs-libraries/dtos/organizations/organization.name.dto';
 import { HttpForbiddenException } from '@gitroom/nestjs-libraries/services/exception.filter';
 import { RealIP } from 'nestjs-real-ip';
 import { UserAgent } from '@gitroom/nestjs-libraries/user/user.agent';
@@ -304,11 +308,77 @@ export class UsersController {
     );
   }
 
+  @Post('/organizations')
+  async createOrganization(
+    @GetUserFromRequest() user: User,
+    @Req() req: Request,
+    @Body() body: OrganizationNameDto,
+    @Res({ passthrough: true }) response: Response
+  ) {
+    this.assertNotImpersonating(req);
+    const org = await this._orgService.createOrgForUser(user.id, body.name);
+    this.setShowOrgCookie(response, org.id);
+    return org;
+  }
+
+  @Patch('/organizations/:id')
+  async updateOrganization(
+    @GetUserFromRequest() user: User,
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Body() body: OrganizationNameDto
+  ) {
+    this.assertNotImpersonating(req);
+    return this._orgService.updateOrganizationName(user.id, id, body.name);
+  }
+
+  @Delete('/organizations/:id')
+  async deleteOrganization(
+    @GetUserFromRequest() user: User,
+    @GetOrgFromRequest() organization: Organization,
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Res({ passthrough: true }) response: Response
+  ) {
+    this.assertNotImpersonating(req);
+    const orgToDelete = await this._orgService.getOrgToDelete(user.id, id);
+
+    if (process.env.STRIPE_PUBLISHABLE_KEY && orgToDelete.paymentId) {
+      try {
+        await this._stripeService.cancelAllSubscriptions(orgToDelete.id);
+      } catch (err) {
+        console.log(err);
+        throw new HttpException(
+          'Could not cancel your subscription, please try again or contact support',
+          400
+        );
+      }
+    }
+
+    await this._orgService.deleteOwnedOrganization(orgToDelete.id, user.id);
+
+    const remaining = (await this._orgService.getOrgsByUserId(user.id)).filter(
+      (item) => !item.users[0].disabled
+    );
+    const nextOrg =
+      remaining.find((item) => item.id === organization.id) || remaining[0];
+    if (nextOrg) {
+      this.setShowOrgCookie(response, nextOrg.id);
+    }
+
+    return { id: nextOrg?.id };
+  }
+
   @Post('/change-org')
   changeOrg(
     @Body('id') id: string,
     @Res({ passthrough: true }) response: Response
   ) {
+    this.setShowOrgCookie(response, id);
+    response.status(200).send();
+  }
+
+  private setShowOrgCookie(response: Response, id: string) {
     response.cookie('showorg', id, {
       domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
       ...(!process.env.NOT_SECURED
@@ -324,8 +394,16 @@ export class UsersController {
     if (process.env.NOT_SECURED) {
       response.header('showorg', id);
     }
+  }
 
-    response.status(200).send();
+  private assertNotImpersonating(req: Request) {
+    const impersonate = req.cookies.impersonate || req.headers.impersonate;
+    if (impersonate) {
+      throw new HttpException(
+        'Organizations cannot be changed while impersonating',
+        400
+      );
+    }
   }
 
   @Post('/delete-account')

--- a/apps/backend/src/services/auth/auth.middleware.ts
+++ b/apps/backend/src/services/auth/auth.middleware.ts
@@ -99,7 +99,7 @@ export class AuthMiddleware implements NestMiddleware {
       const setOrg =
         organization.find((org) => org.id === orgHeader) || organization[0];
 
-      if (!organization) {
+      if (!setOrg) {
         throw new HttpForbiddenException();
       }
 

--- a/apps/frontend/src/components/layout/check.payment.tsx
+++ b/apps/frontend/src/components/layout/check.payment.tsx
@@ -4,6 +4,7 @@ import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { useToaster } from '@gitroom/react/toaster/toaster';
 import { useDecisionModal } from '@gitroom/frontend/components/layout/new-modal';
+import { usePathname, useRouter } from 'next/navigation';
 export const CheckPayment: FC<{
   check: string;
   mutate: () => void;
@@ -24,6 +25,8 @@ export const CheckPaymentInner: FC<{
   const fetch = useFetch();
   const toaster = useToaster();
   const modal = useDecisionModal();
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (showLoader) {
@@ -60,6 +63,10 @@ export const CheckPaymentInner: FC<{
     if (status === 2) {
       setShowLoader(false);
       props.mutate();
+      const search = new URLSearchParams(window.location.search);
+      search.delete('check');
+      const query = search.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
     }
   }, []);
   useEffect(() => {

--- a/apps/frontend/src/components/layout/organization.selector.tsx
+++ b/apps/frontend/src/components/layout/organization.selector.tsx
@@ -2,32 +2,36 @@
 
 import React, { FC, useCallback, useMemo } from 'react';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
-import useSWR from 'swr';
 import { useUser } from '@gitroom/frontend/components/layout/user.context';
 import clsx from 'clsx';
+import Link from 'next/link';
+import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+import { useToaster } from '@gitroom/react/toaster/toaster';
+import { useVariables } from '@gitroom/react/helpers/variable.context';
+import {
+  OrganizationNameModal,
+  useOrganizations,
+  UserOrganization,
+} from '@gitroom/frontend/components/settings/organizations.component';
 export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
   asOpenSelect,
 }) => {
   const fetch = useFetch();
   const user = useUser();
-  const load = useCallback(async () => {
-    return await (await fetch('/user/organizations')).json();
-  }, []);
-  const { isLoading, data } = useSWR('organizations', load, {
-    revalidateIfStale: false,
-    revalidateOnFocus: false,
-    refreshWhenOffline: false,
-    refreshWhenHidden: false,
-    revalidateOnReconnect: false,
-  });
+  const t = useT();
+  const toast = useToaster();
+  const modals = useModals();
+  const { billingEnabled } = useVariables();
+  const { isLoading, data } = useOrganizations();
   const current = useMemo(() => {
-    return data?.find((d: any) => d.id === user?.orgId);
-  }, [data]);
-  const withoutCurrent = useMemo(() => {
-    return data?.filter((d: any) => d.id !== user?.orgId);
-  }, [current, data]);
+    return data?.find((d) => d.id === user?.orgId);
+  }, [data, user?.orgId]);
   const changeOrg = useCallback(
-    (org: { name: string; id: string }) => async () => {
+    (org: UserOrganization) => async () => {
+      if (org.id === user?.orgId) {
+        return;
+      }
       await fetch('/user/change-org', {
         method: 'POST',
         body: JSON.stringify({
@@ -36,9 +40,51 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
       });
       window.location.reload();
     },
-    []
+    [fetch, user?.orgId]
   );
-  if (isLoading || (!isLoading && data?.length === 1)) {
+  const createOrganization = useCallback(
+    async (name: string) => {
+      const response = await fetch('/user/organizations', {
+        method: 'POST',
+        body: JSON.stringify({ name }),
+      });
+      if (response.status !== 200 && response.status !== 201) {
+        const body = await response.json().catch(() => ({ message: '' }));
+        const message = Array.isArray(body.message)
+          ? body.message[0]
+          : body.message;
+        toast.show(
+          message ||
+            t('could_not_create_organization', 'Could not create organization'),
+          'warning'
+        );
+        return;
+      }
+      window.location.reload();
+    },
+    [fetch, t, toast]
+  );
+  const openCreate = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      modals.openModal({
+        classNames: {
+          modal: 'bg-transparent text-textColor',
+        },
+        title: t('create_organization', 'Create organization'),
+        withCloseButton: true,
+        children: (
+          <OrganizationNameModal
+            button={t('create_organization', 'Create organization')}
+            onSubmit={createOrganization}
+          />
+        ),
+      });
+    },
+    [t, createOrganization, modals]
+  );
+  if (isLoading) {
     return null;
   }
   return (
@@ -68,39 +114,53 @@ export const OrganizationSelector: FC<{ asOpenSelect?: boolean }> = ({
               )}
             </div>
           )}
-          {data?.length > 1 && (
+          {!!data?.length && (
             <div
               className={clsx(
-                'hidden py-[12px] px-[12px] group-hover:flex absolute top-[100%] end-0 w-max max-w-[400px] bg-third border-tableBorder border gap-[12px] cursor-pointer flex-col',
+                'hidden py-[12px] px-[12px] group-hover:flex absolute top-[100%] end-0 w-max min-w-[220px] max-w-[400px] bg-third border-tableBorder border gap-[12px] cursor-pointer flex-col z-[400]',
                 asOpenSelect ? '!flex !relative max-w-[500px] mx-auto mb-[10px]' : '',
               )}
             >
-              {withoutCurrent?.map(
-                (org: {
-                  name: string;
-                  id: string;
-                  users: { role: 'SUPERADMIN' | 'ADMIN' | 'USER' }[];
-                }) => (
+              {data.map((org) => (
                   <div
-                    key={org?.id}
+                    key={org.id}
                     onClick={changeOrg(org)}
-                    className="whitespace-nowrap truncate"
+                    className={clsx(
+                      'whitespace-nowrap truncate',
+                      org.id === user?.orgId && 'text-newTextColor'
+                    )}
                   >
-                    {org?.name}
-                    {!!org?.users?.[0]?.role && (
-                      <span className="text-customColor18">
+                    {org.name}
+                    {!!org.users?.[0]?.role && (
+                      <span className="text-textItemBlur">
                         {' '}
                         (
-                        {org?.users?.[0]?.role === 'SUPERADMIN'
-                          ? 'Super-Admin'
-                          : org?.users?.[0]?.role === 'ADMIN'
-                          ? 'Admin'
-                          : 'User'}
+                        {org.users[0].role === 'SUPERADMIN'
+                          ? t('super_admin', 'Super Admin')
+                          : org.users[0].role === 'ADMIN'
+                          ? t('admin', 'Admin')
+                          : t('user', 'User')}
+                        {org.id === user?.orgId
+                          ? ` · ${t('current_organization', 'Current')}`
+                          : ''}
                         )
                       </span>
                     )}
                   </div>
-                )
+                ))}
+              <div className="h-[1px] bg-tableBorder" />
+              {!user?.impersonate && (
+                <div onClick={openCreate}>
+                  {t('create_organization', 'Create organization')}
+                </div>
+              )}
+              {!(billingEnabled && user?.tier?.current === 'FREE') && (
+                <Link
+                  href="/settings?tab=organizations"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  {t('manage_organizations', 'Manage organizations')}
+                </Link>
               )}
             </div>
           )}

--- a/apps/frontend/src/components/layout/settings.component.tsx
+++ b/apps/frontend/src/components/layout/settings.component.tsx
@@ -32,6 +32,7 @@ import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { SVGLine } from '@gitroom/frontend/components/launches/launches.component';
 import { GlobalSettings } from '@gitroom/frontend/components/settings/global.settings';
 import { ApprovedAppsComponent } from '@gitroom/frontend/components/approved-apps/approved-apps.component';
+import { OrganizationsComponent } from '@gitroom/frontend/components/settings/organizations.component';
 export const SettingsPopup: FC<{
   getRef?: Ref<any>;
 }> = (props) => {
@@ -81,12 +82,20 @@ export const SettingsPopup: FC<{
     close();
   }, []);
 
-  const [tab, setTab] = useState('global_settings');
+  const currentTab = url.get('tab');
+  const [tab, setTab] = useState(currentTab || 'global_settings');
+
+  useEffect(() => {
+    if (currentTab) {
+      setTab(currentTab);
+    }
+  }, [currentTab]);
 
   const t = useT();
   const list = useMemo(() => {
     const arr = [];
     arr.push({ tab: 'global_settings', label: t('global_settings', 'Global Settings') });
+    arr.push({ tab: 'organizations', label: t('organizations', 'Organizations') });
     // Populate tabs based on user permissions
     if (user?.tier?.team_members && isGeneral) {
       arr.push({ tab: 'teams', label: t('teams', 'Teams') });
@@ -163,6 +172,11 @@ export const SettingsPopup: FC<{
               {tab === 'global_settings' && (
                 <div>
                   <GlobalSettings />
+                </div>
+              )}
+              {tab === 'organizations' && (
+                <div>
+                  <OrganizationsComponent />
                 </div>
               )}
               {tab === 'teams' && !!user?.tier?.team_members && isGeneral && (

--- a/apps/frontend/src/components/public-api/public.component.tsx
+++ b/apps/frontend/src/components/public-api/public.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useMemo } from 'react';
-import useSWR, { useSWRConfig } from 'swr';
+import { useSWRConfig } from 'swr';
 import { useUser } from '../layout/user.context';
 import copy from 'copy-to-clipboard';
 import { useToaster } from '@gitroom/react/toaster/toaster';
@@ -10,6 +10,7 @@ import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { useDecisionModal } from '@gitroom/frontend/components/layout/new-modal';
 import { DeveloperComponent } from '@gitroom/frontend/components/developer/developer.component';
+import { useOrganizations } from '@gitroom/frontend/components/settings/organizations.component';
 import clsx from 'clsx';
 
 const mcpClients = [
@@ -730,21 +731,11 @@ const PublicApiContent = () => {
 
 export const PublicComponent = () => {
   const t = useT();
-  const fetch = useFetch();
   const user = useUser();
   const [subTab, setSubTab] = useState<'api' | 'developer'>('api');
-  const loadOrganizations = useCallback(async () => {
-    return await (await fetch('/user/organizations')).json();
-  }, []);
-  const { data: organizations } = useSWR('organizations', loadOrganizations, {
-    revalidateIfStale: false,
-    revalidateOnFocus: false,
-    refreshWhenOffline: false,
-    refreshWhenHidden: false,
-    revalidateOnReconnect: false,
-  });
+  const { data: organizations } = useOrganizations();
   const currentOrg = useMemo(() => {
-    return organizations?.find((org: any) => org?.id === user?.orgId);
+    return organizations?.find((org) => org?.id === user?.orgId);
   }, [organizations, user?.orgId]);
 
   return (

--- a/apps/frontend/src/components/settings/organizations.component.tsx
+++ b/apps/frontend/src/components/settings/organizations.component.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { Button } from '@gitroom/react/form/button';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import useSWR from 'swr';
+import React, { FC, useCallback, useMemo } from 'react';
+import { useUser } from '@gitroom/frontend/components/layout/user.context';
+import { useModals } from '@gitroom/frontend/components/layout/new-modal';
+import { Input } from '@gitroom/react/form/input';
+import { useForm, FormProvider } from 'react-hook-form';
+import { classValidatorResolver } from '@hookform/resolvers/class-validator';
+import { OrganizationNameDto } from '@gitroom/nestjs-libraries/dtos/organizations/organization.name.dto';
+import { useToaster } from '@gitroom/react/toaster/toaster';
+import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+
+export type UserOrganization = {
+  id: string;
+  name: string;
+  users: { role: 'SUPERADMIN' | 'ADMIN' | 'USER'; disabled: boolean }[];
+};
+
+export const useOrganizations = () => {
+  const fetch = useFetch();
+  const load = useCallback(async () => {
+    return (await fetch('/user/organizations')).json();
+  }, [fetch]);
+
+  return useSWR<UserOrganization[]>('organizations', load, {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    refreshWhenOffline: false,
+    refreshWhenHidden: false,
+    revalidateOnReconnect: false,
+  });
+};
+
+const roleLabel = (
+  role: 'SUPERADMIN' | 'ADMIN' | 'USER',
+  t: ReturnType<typeof useT>
+) => {
+  if (role === 'SUPERADMIN') {
+    return t('super_admin', 'Super Admin');
+  }
+  if (role === 'ADMIN') {
+    return t('admin', 'Admin');
+  }
+  return t('user', 'User');
+};
+
+const readErrorMessage = async (response: Response, fallback: string) => {
+  const body = await response.json().catch(() => ({ message: '' }));
+  const message = Array.isArray(body.message) ? body.message[0] : body.message;
+  return message || fallback;
+};
+
+export const OrganizationNameModal: FC<{
+  name?: string;
+  button: string;
+  onSubmit: (name: string) => Promise<void>;
+}> = ({ name = '', button, onSubmit }) => {
+  const t = useT();
+  const resolver = useMemo(() => {
+    return classValidatorResolver(OrganizationNameDto);
+  }, []);
+  const form = useForm({
+    values: {
+      name,
+    },
+    resolver,
+    mode: 'onChange',
+  });
+  const submit = useCallback(
+    async (values: { name: string }) => {
+      await onSubmit(values.name);
+    },
+    [onSubmit]
+  );
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(submit)}>
+        <div className="relative flex gap-[10px] flex-col flex-1 p-[16px] pt-0">
+          <Input
+            label="Organization name"
+            translationKey="organization_name"
+            name="name"
+            placeholder={t('organization_name', 'Organization name')}
+          />
+          <Button type="submit" className="mt-[18px]">
+            {button}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
+
+export const OrganizationsComponent = () => {
+  const fetch = useFetch();
+  const user = useUser();
+  const modals = useModals();
+  const toast = useToaster();
+  const t = useT();
+  const { data, mutate } = useOrganizations();
+  const impersonating = !!user?.impersonate;
+
+  const changeOrg = useCallback(
+    (org: UserOrganization) => async () => {
+      if (org.id === user?.orgId) {
+        return;
+      }
+      await fetch('/user/change-org', {
+        method: 'POST',
+        body: JSON.stringify({
+          id: org.id,
+        }),
+      });
+      window.location.reload();
+    },
+    [fetch, user?.orgId]
+  );
+
+  const createOrganization = useCallback(async (name: string) => {
+    const response = await fetch('/user/organizations', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+    if (response.status !== 200 && response.status !== 201) {
+      toast.show(
+        await readErrorMessage(
+          response,
+          t('could_not_create_organization', 'Could not create organization')
+        ),
+        'warning'
+      );
+      return;
+    }
+    window.location.reload();
+  }, [fetch, t, toast]);
+
+  const renameOrganization = useCallback(
+    (org: UserOrganization) => async (name: string) => {
+      const response = await fetch(`/user/organizations/${org.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ name }),
+      });
+      if (response.status !== 200 && response.status !== 201) {
+        toast.show(
+          await readErrorMessage(
+            response,
+            t('could_not_rename_organization', 'Could not rename organization')
+          ),
+          'warning'
+        );
+        return;
+      }
+      await mutate();
+      modals.closeAll();
+      toast.show(t('organization_renamed', 'Organization renamed'));
+    },
+    [fetch, t, toast, mutate, modals]
+  );
+
+  const openCreate = useCallback(() => {
+    modals.openModal({
+      classNames: {
+        modal: 'bg-transparent text-textColor',
+      },
+      title: t('create_organization', 'Create organization'),
+      withCloseButton: true,
+      children: (
+        <OrganizationNameModal
+          button={t('create_organization', 'Create organization')}
+          onSubmit={createOrganization}
+        />
+      ),
+    });
+  }, [t, createOrganization, modals]);
+
+  const openRename = useCallback(
+    (org: UserOrganization) => () => {
+      modals.openModal({
+        classNames: {
+          modal: 'bg-transparent text-textColor',
+        },
+        title: t('rename_organization', 'Rename organization'),
+        withCloseButton: true,
+        children: (
+          <OrganizationNameModal
+            name={org.name}
+            button={t('rename_organization', 'Rename organization')}
+            onSubmit={renameOrganization(org)}
+          />
+        ),
+      });
+    },
+    [t, renameOrganization, modals]
+  );
+
+  const remove = useCallback(
+    (org: UserOrganization) => async () => {
+      if (
+        !(await deleteDialog(
+          t(
+            'delete_organization_confirm',
+            'This organization, its channels and posts will be deleted. This action cannot be undone, are you sure?'
+          ),
+          t('yes_delete_organization', 'Yes, delete this organization')
+        ))
+      ) {
+        return;
+      }
+      const response = await fetch(`/user/organizations/${org.id}`, {
+        method: 'DELETE',
+      });
+      if (response.status !== 200 && response.status !== 201) {
+        toast.show(
+          await readErrorMessage(
+            response,
+            t('could_not_delete_organization', 'Could not delete organization')
+          ),
+          'warning'
+        );
+        return;
+      }
+      window.location.reload();
+    },
+    [fetch, t, toast]
+  );
+
+  return (
+    <div className="flex flex-col">
+      <h3 className="text-[20px]">{t('organizations', 'Organizations')}</h3>
+      <div className="text-textItemBlur mt-[4px]">
+        {t(
+          'organizations_description',
+          'Create organizations to separate projects, then switch between them'
+        )}
+      </div>
+      <div className="my-[16px] mt-[16px] bg-sixth border-fifth border rounded-[4px] p-[24px] flex flex-col gap-[24px]">
+        <div className="flex flex-col gap-[16px]">
+          {(data || []).map((org) => {
+            const role = org.users?.[0]?.role;
+            const isCurrent = org.id === user?.orgId;
+            const isOwner = role === 'SUPERADMIN';
+            const canDelete = isOwner && (data || []).length > 1;
+            return (
+              <div key={org.id} className="flex items-center gap-[12px]">
+                <div className="flex-1 min-w-0 truncate">{org.name}</div>
+                <div className="flex-1 text-textItemBlur">
+                  {role ? roleLabel(role, t) : ''}
+                  {isCurrent
+                    ? ` · ${t('current_organization', 'Current')}`
+                    : ''}
+                </div>
+                <div className="flex-1 flex justify-end gap-[8px]">
+                  {!isCurrent && (
+                    <Button
+                      className="!h-[24px] rounded-[4px] text-[12px]"
+                      onClick={changeOrg(org)}
+                      secondary={true}
+                    >
+                      {t('switch', 'Switch')}
+                    </Button>
+                  )}
+                  {isOwner && !impersonating && (
+                    <Button
+                      className="!h-[24px] rounded-[4px] text-[12px]"
+                      onClick={openRename(org)}
+                      secondary={true}
+                    >
+                      {t('rename', 'Rename')}
+                    </Button>
+                  )}
+                  {canDelete && !impersonating && (
+                    <Button
+                      className="!bg-red-800 !h-[24px] rounded-[4px] text-[12px]"
+                      onClick={remove(org)}
+                    >
+                      {t('delete', 'Delete')}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        {!impersonating && (
+          <div>
+            <Button onClick={openCreate}>
+              {t('create_organization', 'Create organization')}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/i18n.lock
+++ b/i18n.lock
@@ -742,3 +742,18 @@ checksums:
     post_already_published_republish_warning: b552a207c31d6381fb831da005dac9ed
     republish_at: 282cf74a2c63ff46388104f9853bfaf8
     republish_recurring_note: e0eafbc730f5e8d5f9f5cb5aab48fe2d
+    organizations: bd50dd0b17bd74a72b728a8385b5ee28
+    organizations_description: 12498c2a27a01cf0bfbf3ec49fe68668
+    organization_name: e69fb0acbe75358352890a6f04e4b9c0
+    create_organization: e79a6de15033cc09a320a6f9c294d696
+    rename_organization: 40fbc31b7c6669fa1117b8ad50f33492
+    manage_organizations: fea7e7313d1fc8c628870900b031663d
+    organization_renamed: ce9685a3896d45976b57326a187c5c65
+    current_organization: 27f172f76ac28e72cb062f80002b0ad5
+    switch: bab779e32d2519152481e180aea26879
+    rename: 6f9413e4606e8d83a010685008fb2931
+    delete_organization_confirm: 8048bdb3bea0fa4bc8a7dfccfc13f3f8
+    yes_delete_organization: 64e38997a8dd575d9020bdc58eb7c58d
+    could_not_create_organization: 632bfcc6464390bc3e8eae128e54444f
+    could_not_rename_organization: 163ff0fddd1c8800b5d31e1b7a29294b
+    could_not_delete_organization: 82df8baa656deed351e391e96aaaf088

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.repository.ts
@@ -1,5 +1,5 @@
-import { PrismaRepository } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
-import { Role, ShortLinkPreference, SubscriptionTier } from '@prisma/client';
+import { PrismaRepository, PrismaTransaction } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
+import { Prisma, Role, ShortLinkPreference, SubscriptionTier } from '@prisma/client';
 import { Injectable } from '@nestjs/common';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import { CreateOrgUserDto } from '@gitroom/nestjs-libraries/dtos/auth/create.org.user.dto';
@@ -10,7 +10,8 @@ export class OrganizationRepository {
   constructor(
     private _organization: PrismaRepository<'organization'>,
     private _userOrg: PrismaRepository<'userOrganization'>,
-    private _user: PrismaRepository<'user'>
+    private _user: PrismaRepository<'user'>,
+    private _transaction: PrismaTransaction
   ) {}
 
   createMaxUser(id: string, name: string, saasName: string, email: string) {
@@ -297,11 +298,16 @@ export class OrganizationRepository {
       await this._organization.model.organization.findFirst({
         where: {
           id: orgId,
+          deletedAt: null,
         },
         select: {
           subscription: true,
         },
       });
+
+    if (!checkForSubscription) {
+      return false;
+    }
 
     if (
       process.env.STRIPE_PUBLISHABLE_KEY &&
@@ -374,6 +380,42 @@ export class OrganizationRepository {
     });
   }
 
+  createOrgForUser(userId: string, name: string) {
+    return this._organization.model.organization.create({
+      data: {
+        name,
+        apiKey: AuthService.fixedEncryption(makeId(20)),
+        allowTrial: false,
+        isTrailing: false,
+        users: {
+          create: {
+            role: Role.SUPERADMIN,
+            userId,
+          },
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+  }
+
+  updateOrganizationName(orgId: string, name: string) {
+    return this._organization.model.organization.update({
+      where: {
+        id: orgId,
+      },
+      data: {
+        name,
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+  }
+
   getOrgByCustomerId(customerId: string) {
     return this._organization.model.organization.findFirst({
       where: {
@@ -410,6 +452,7 @@ export class OrganizationRepository {
         users: {
           select: {
             role: true,
+            disabled: true,
             user: {
               select: {
                 email: true,
@@ -456,6 +499,45 @@ export class OrganizationRepository {
         deletedAt: new Date(),
       },
     });
+  }
+
+  deleteOrganizationIfNotLast(orgId: string, userId: string) {
+    return this._transaction.model
+      .$transaction(
+        async (tx) => {
+          const enabledOrgs = await tx.userOrganization.count({
+            where: {
+              userId,
+              disabled: false,
+              organization: {
+                deletedAt: null,
+              },
+            },
+          });
+
+          if (enabledOrgs <= 1) {
+            return null;
+          }
+
+          return tx.organization.update({
+            where: {
+              id: orgId,
+            },
+            data: {
+              deletedAt: new Date(),
+            },
+          });
+        },
+        {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        }
+      )
+      .catch((err) => {
+        if (err?.code === 'P2034') {
+          return null;
+        }
+        throw err;
+      });
   }
 
   async deleteTeamMember(orgId: string, userId: string) {

--- a/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/organizations/organization.service.ts
@@ -2,20 +2,21 @@ import { CreateOrgUserDto } from '@gitroom/nestjs-libraries/dtos/auth/create.org
 import { HttpException, Injectable } from '@nestjs/common';
 import { OrganizationRepository } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.repository';
 import { NotificationService } from '@gitroom/nestjs-libraries/database/prisma/notifications/notification.service';
+import { IntegrationRepository } from '@gitroom/nestjs-libraries/database/prisma/integrations/integration.repository';
 import { AddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/add.team.member.dto';
 import { AdminAddTeamMemberDto } from '@gitroom/nestjs-libraries/dtos/settings/admin.add.team.member.dto';
 import { pricing } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/pricing';
 import { AuthService } from '@gitroom/helpers/auth/auth.service';
 import dayjs from 'dayjs';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
-import { Organization, ShortLinkPreference, User } from '@prisma/client';
-import { AutopostService } from '@gitroom/nestjs-libraries/database/prisma/autopost/autopost.service';
+import { Organization, Role, ShortLinkPreference, User } from '@prisma/client';
 
 @Injectable()
 export class OrganizationService {
   constructor(
     private _organizationRepository: OrganizationRepository,
-    private _notificationsService: NotificationService
+    private _notificationsService: NotificationService,
+    private _integrationRepository: IntegrationRepository
   ) {}
   async createOrgAndUser(
     body: Omit<CreateOrgUserDto, 'providerToken'> & { providerId?: string },
@@ -65,6 +66,98 @@ export class OrganizationService {
 
   getOrgsByUserId(userId: string) {
     return this._organizationRepository.getOrgsByUserId(userId);
+  }
+
+  async createOrgForUser(userId: string, name: string) {
+    const maxOrgs = Number(process.env.MAX_ORGS_PER_USER) || 10;
+    const enabledOrgs = (
+      await this._organizationRepository.getOrgsByUserId(userId)
+    ).filter((item) => !item.users[0].disabled);
+
+    if (enabledOrgs.length >= maxOrgs) {
+      throw new HttpException(
+        `You can create up to ${maxOrgs} organizations`,
+        400
+      );
+    }
+
+    return this._organizationRepository.createOrgForUser(userId, name);
+  }
+
+  async updateOrganizationName(userId: string, orgId: string, name: string) {
+    const org = await this.getUserOrgById(userId, orgId);
+    if (org.users[0].role !== Role.SUPERADMIN) {
+      throw new HttpException(
+        'You do not have permission to rename this organization',
+        400
+      );
+    }
+
+    return this._organizationRepository.updateOrganizationName(orgId, name);
+  }
+
+  async getOrgToDelete(userId: string, orgId: string) {
+    const orgs = await this._organizationRepository.getOrgsByUserId(userId);
+    const org = orgs.find((item) => item.id === orgId && !item.users[0].disabled);
+    if (!org) {
+      throw new HttpException('Organization not found', 400);
+    }
+    if (org.users[0].role !== Role.SUPERADMIN) {
+      throw new HttpException(
+        'You do not have permission to delete this organization',
+        400
+      );
+    }
+
+    const enabledOrgs = orgs.filter((item) => !item.users[0].disabled);
+    if (enabledOrgs.length === 1) {
+      throw new HttpException(
+        'You cannot delete your only organization. Delete your account instead',
+        400
+      );
+    }
+
+    const team = await this._organizationRepository.getTeam(org.id);
+    if (
+      team?.users?.some(
+        (member) => member.user.id !== userId && !member.disabled
+      )
+    ) {
+      throw new HttpException(
+        'Please remove your team members before deleting this organization',
+        400
+      );
+    }
+
+    return org;
+  }
+
+  async deleteOwnedOrganization(orgId: string, userId: string) {
+    await this._integrationRepository.deleteIntegrationsForAccount(orgId);
+    const deleted =
+      await this._organizationRepository.deleteOrganizationIfNotLast(
+        orgId,
+        userId
+      );
+
+    if (!deleted) {
+      throw new HttpException(
+        'Could not delete the organization, please refresh the page and try again',
+        400
+      );
+    }
+
+    return deleted;
+  }
+
+  private async getUserOrgById(userId: string, orgId: string) {
+    const orgs = await this._organizationRepository.getOrgsByUserId(userId);
+    const org = orgs.find((item) => item.id === orgId && !item.users[0].disabled);
+    if (!org) {
+      throw new HttpException('Organization not found', 400);
+    }
+
+    return org;
   }
 
   updateApiKey(orgId: string) {

--- a/libraries/nestjs-libraries/src/dtos/organizations/organization.name.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/organizations/organization.name.dto.ts
@@ -1,0 +1,9 @@
+import { IsDefined, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class OrganizationNameDto {
+  @IsString()
+  @IsDefined()
+  @MinLength(3)
+  @MaxLength(128)
+  name: string;
+}

--- a/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ar/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "إعادة نشر المنشور",
   "post_already_published_republish_warning": "تم نشر هذا المنشور بالفعل. إعادة النشر ستقوم بنشره مرة أخرى على",
   "republish_at": "في",
-  "republish_recurring_note": "هذا منشور متكرر: ستنطبق تغييراتك على جميع التكرارات المستقبلية بدءًا من الآن."
+  "republish_recurring_note": "هذا منشور متكرر: ستنطبق تغييراتك على جميع التكرارات المستقبلية بدءًا من الآن.",
+  "organizations": "المؤسسات",
+  "organizations_description": "أنشئ مؤسسات لفصل المشاريع، ثم بدّل بينها",
+  "organization_name": "اسم المؤسسة",
+  "create_organization": "إنشاء مؤسسة",
+  "rename_organization": "إعادة تسمية المؤسسة",
+  "manage_organizations": "إدارة المؤسسات",
+  "organization_renamed": "تمت إعادة تسمية المؤسسة",
+  "current_organization": "الحالية",
+  "switch": "تبديل",
+  "rename": "إعادة تسمية",
+  "delete_organization_confirm": "سيتم حذف هذه المؤسسة وقنواتها ومنشوراتها. لا يمكن التراجع عن هذا الإجراء، هل أنت متأكد؟",
+  "yes_delete_organization": "نعم، احذف هذه المؤسسة",
+  "could_not_create_organization": "تعذّر إنشاء المؤسسة",
+  "could_not_rename_organization": "تعذّرت إعادة تسمية المؤسسة",
+  "could_not_delete_organization": "تعذّر حذف المؤسسة"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/bn/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "পোস্টটি পুনঃপ্রকাশ করুন",
   "post_already_published_republish_warning": "এই পোস্টটি ইতিমধ্যে প্রকাশিত হয়েছে। পুনঃপ্রকাশ করলে এটি আবার প্রকাশিত হবে",
   "republish_at": "সময়",
-  "republish_recurring_note": "এটি একটি পুনরাবৃত্তিমূলক পোস্ট: আপনার পরিবর্তনসমূহ এখন থেকে শুরু করে সকল ভবিষ্যৎ পুনরাবৃত্তিতে প্রয়োগ হবে।"
+  "republish_recurring_note": "এটি একটি পুনরাবৃত্তিমূলক পোস্ট: আপনার পরিবর্তনসমূহ এখন থেকে শুরু করে সকল ভবিষ্যৎ পুনরাবৃত্তিতে প্রয়োগ হবে।",
+  "organizations": "সংগঠন",
+  "organizations_description": "প্রকল্পগুলো আলাদা করতে সংগঠন তৈরি করুন, তারপর এর মধ্যে স্যুইচ করুন",
+  "organization_name": "সংগঠনের নাম",
+  "create_organization": "সংগঠন তৈরি করুন",
+  "rename_organization": "সংগঠনের নাম পরিবর্তন করুন",
+  "manage_organizations": "সংগঠনগুলো পরিচালনা করুন",
+  "organization_renamed": "সংগঠনের নাম পরিবর্তন হয়েছে",
+  "current_organization": "বর্তমান",
+  "switch": "স্যুইচ",
+  "rename": "নাম পরিবর্তন",
+  "delete_organization_confirm": "এই সংগঠন, এর চ্যানেল এবং পোস্টগুলো মুছে যাবে। এই কাজটি আর ফিরিয়ে আনা যাবে না, আপনি নিশ্চিত?",
+  "yes_delete_organization": "হ্যাঁ, এই সংগঠনটি মুছে ফেলুন",
+  "could_not_create_organization": "সংগঠন তৈরি করা যায়নি",
+  "could_not_rename_organization": "সংগঠনের নাম পরিবর্তন করা যায়নি",
+  "could_not_delete_organization": "সংগঠন মুছে ফেলা যায়নি"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/de/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/de/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Beitrag erneut veröffentlichen",
   "post_already_published_republish_warning": "Dieser Beitrag wurde bereits veröffentlicht. Durch erneutes Veröffentlichen wird er erneut veröffentlicht auf",
   "republish_at": "um",
-  "republish_recurring_note": "Dies ist ein wiederkehrender Beitrag: Ihre Änderungen gelten ab jetzt für alle zukünftigen Wiederholungen."
+  "republish_recurring_note": "Dies ist ein wiederkehrender Beitrag: Ihre Änderungen gelten ab jetzt für alle zukünftigen Wiederholungen.",
+  "organizations": "Organisationen",
+  "organizations_description": "Erstellen Sie Organisationen, um Projekte zu trennen, und wechseln Sie dann zwischen ihnen",
+  "organization_name": "Organisationsname",
+  "create_organization": "Organisation erstellen",
+  "rename_organization": "Organisation umbenennen",
+  "manage_organizations": "Organisationen verwalten",
+  "organization_renamed": "Organisation umbenannt",
+  "current_organization": "Aktuell",
+  "switch": "Wechseln",
+  "rename": "Umbenennen",
+  "delete_organization_confirm": "Diese Organisation, ihre Kanäle und Beiträge werden gelöscht. Diese Aktion kann nicht rückgängig gemacht werden, sind Sie sicher?",
+  "yes_delete_organization": "Ja, diese Organisation löschen",
+  "could_not_create_organization": "Organisation konnte nicht erstellt werden",
+  "could_not_rename_organization": "Organisation konnte nicht umbenannt werden",
+  "could_not_delete_organization": "Organisation konnte nicht gelöscht werden"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/en/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/en/translation.json
@@ -740,5 +740,20 @@
   "republish_the_post": "Republish the post",
   "post_already_published_republish_warning": "This post was already published. Republishing will publish it again to",
   "republish_at": "at",
-  "republish_recurring_note": "This is a recurring post: your changes apply to all future recurrences starting now."
+  "republish_recurring_note": "This is a recurring post: your changes apply to all future recurrences starting now.",
+  "organizations": "Organizations",
+  "organizations_description": "Create organizations to separate projects, then switch between them",
+  "organization_name": "Organization name",
+  "create_organization": "Create organization",
+  "rename_organization": "Rename organization",
+  "manage_organizations": "Manage organizations",
+  "organization_renamed": "Organization renamed",
+  "current_organization": "Current",
+  "switch": "Switch",
+  "rename": "Rename",
+  "delete_organization_confirm": "This organization, its channels and posts will be deleted. This action cannot be undone, are you sure?",
+  "yes_delete_organization": "Yes, delete this organization",
+  "could_not_create_organization": "Could not create organization",
+  "could_not_rename_organization": "Could not rename organization",
+  "could_not_delete_organization": "Could not delete organization"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/es/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/es/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Volver a publicar la publicación",
   "post_already_published_republish_warning": "Esta publicación ya fue publicada. Volver a publicarla la publicará nuevamente en",
   "republish_at": "a las",
-  "republish_recurring_note": "Esta es una publicación recurrente: tus cambios se aplican a todas las recurrencias futuras a partir de ahora."
+  "republish_recurring_note": "Esta es una publicación recurrente: tus cambios se aplican a todas las recurrencias futuras a partir de ahora.",
+  "organizations": "Organizaciones",
+  "organizations_description": "Crea organizaciones para separar proyectos y cambia entre ellas",
+  "organization_name": "Nombre de la organización",
+  "create_organization": "Crear organización",
+  "rename_organization": "Renombrar organización",
+  "manage_organizations": "Gestionar organizaciones",
+  "organization_renamed": "Organización renombrada",
+  "current_organization": "Actual",
+  "switch": "Cambiar",
+  "rename": "Renombrar",
+  "delete_organization_confirm": "Esta organización, sus canales y publicaciones se eliminarán. Esta acción no se puede deshacer, ¿estás seguro?",
+  "yes_delete_organization": "Sí, eliminar esta organización",
+  "could_not_create_organization": "No se pudo crear la organización",
+  "could_not_rename_organization": "No se pudo renombrar la organización",
+  "could_not_delete_organization": "No se pudo eliminar la organización"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/fr/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Republier la publication",
   "post_already_published_republish_warning": "Cette publication a déjà été publiée. La republier la publiera à nouveau sur",
   "republish_at": "à",
-  "republish_recurring_note": "Il s'agit d'une publication récurrente : vos modifications s'appliquent à toutes les récurrences futures à partir de maintenant."
+  "republish_recurring_note": "Il s'agit d'une publication récurrente : vos modifications s'appliquent à toutes les récurrences futures à partir de maintenant.",
+  "organizations": "Organisations",
+  "organizations_description": "Créez des organisations pour séparer vos projets, puis basculez entre elles",
+  "organization_name": "Nom de l'organisation",
+  "create_organization": "Créer une organisation",
+  "rename_organization": "Renommer l'organisation",
+  "manage_organizations": "Gérer les organisations",
+  "organization_renamed": "Organisation renommée",
+  "current_organization": "Actuelle",
+  "switch": "Changer",
+  "rename": "Renommer",
+  "delete_organization_confirm": "Cette organisation, ses chaînes et ses publications seront supprimées. Cette action est irréversible, êtes-vous sûr ?",
+  "yes_delete_organization": "Oui, supprimer cette organisation",
+  "could_not_create_organization": "Impossible de créer l'organisation",
+  "could_not_rename_organization": "Impossible de renommer l'organisation",
+  "could_not_delete_organization": "Impossible de supprimer l'organisation"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/he/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/he/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "לפרסם מחדש את הפוסט",
   "post_already_published_republish_warning": "הפוסט הזה כבר פורסם. פרסום מחדש יפרסם אותו שוב ב",
   "republish_at": "בשעה",
-  "republish_recurring_note": "זהו פוסט חוזר: השינויים שלך יחולו על כל ההופעות העתידיות החל מעכשיו."
+  "republish_recurring_note": "זהו פוסט חוזר: השינויים שלך יחולו על כל ההופעות העתידיות החל מעכשיו.",
+  "organizations": "ארגונים",
+  "organizations_description": "צרו ארגונים כדי להפריד בין פרויקטים, ואז עברו ביניהם",
+  "organization_name": "שם הארגון",
+  "create_organization": "יצירת ארגון",
+  "rename_organization": "שינוי שם ארגון",
+  "manage_organizations": "ניהול ארגונים",
+  "organization_renamed": "שם הארגון שונה",
+  "current_organization": "נוכחי",
+  "switch": "החלפה",
+  "rename": "שינוי שם",
+  "delete_organization_confirm": "הארגון הזה, הערוצים והפוסטים שלו יימחקו. לא ניתן לבטל פעולה זו, האם אתה בטוח?",
+  "yes_delete_organization": "כן, מחק את הארגון הזה",
+  "could_not_create_organization": "לא ניתן ליצור את הארגון",
+  "could_not_rename_organization": "לא ניתן לשנות את שם הארגון",
+  "could_not_delete_organization": "לא ניתן למחוק את הארגון"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/it/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/it/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Ripubblica il post",
   "post_already_published_republish_warning": "Questo post è già stato pubblicato. Ripubblicandolo verrà pubblicato nuovamente su",
   "republish_at": "a",
-  "republish_recurring_note": "Questo è un post ricorrente: le tue modifiche verranno applicate a tutte le future ricorrenze a partire da ora."
+  "republish_recurring_note": "Questo è un post ricorrente: le tue modifiche verranno applicate a tutte le future ricorrenze a partire da ora.",
+  "organizations": "Organizzazioni",
+  "organizations_description": "Crea organizzazioni per separare i progetti, poi passa dall'una all'altra",
+  "organization_name": "Nome dell'organizzazione",
+  "create_organization": "Crea organizzazione",
+  "rename_organization": "Rinomina organizzazione",
+  "manage_organizations": "Gestisci organizzazioni",
+  "organization_renamed": "Organizzazione rinominata",
+  "current_organization": "Corrente",
+  "switch": "Cambia",
+  "rename": "Rinomina",
+  "delete_organization_confirm": "Questa organizzazione, i suoi canali e i suoi post verranno eliminati. Questa azione non può essere annullata, sei sicuro?",
+  "yes_delete_organization": "Sì, elimina questa organizzazione",
+  "could_not_create_organization": "Impossibile creare l'organizzazione",
+  "could_not_rename_organization": "Impossibile rinominare l'organizzazione",
+  "could_not_delete_organization": "Impossibile eliminare l'organizzazione"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ja/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "投稿を再公開する",
   "post_already_published_republish_warning": "この投稿は既に公開されています。再公開すると、もう一度投稿されます：",
   "republish_at": "公開日時：",
-  "republish_recurring_note": "これは定期投稿です：今後すべての繰り返しに対して変更が適用されます。"
+  "republish_recurring_note": "これは定期投稿です：今後すべての繰り返しに対して変更が適用されます。",
+  "organizations": "組織",
+  "organizations_description": "プロジェクトを分けるために組織を作成し、それらを切り替えられます",
+  "organization_name": "組織名",
+  "create_organization": "組織を作成",
+  "rename_organization": "組織の名前を変更",
+  "manage_organizations": "組織を管理",
+  "organization_renamed": "組織の名前を変更しました",
+  "current_organization": "現在",
+  "switch": "切り替え",
+  "rename": "名前を変更",
+  "delete_organization_confirm": "この組織とそのチャンネル、投稿は削除されます。この操作は元に戻せません。よろしいですか？",
+  "yes_delete_organization": "はい、この組織を削除します",
+  "could_not_create_organization": "組織を作成できませんでした",
+  "could_not_rename_organization": "組織の名前を変更できませんでした",
+  "could_not_delete_organization": "組織を削除できませんでした"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ka_ge/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ka_ge/translation.json
@@ -504,5 +504,20 @@
     "label_who_can_reply_to_this_post": "ვის შეუძლია პასუხის გაცემა ამ პოსტზე?",
     "delete_integration": "ინტეგრაციის წაშლა",
     "start_writing_your_post": "დაიწყეთ თქვენი პოსტის წერა წინასწარი ხედვისთვის",
-    "faq_can_i_trust_postiz_gitroom": "Შემიძლია ვენდო Postiz-ს?"
+    "faq_can_i_trust_postiz_gitroom": "Შემიძლია ვენდო Postiz-ს?",
+    "organizations": "ორგანიზაციები",
+    "organizations_description": "შექმენით ორგანიზაციები პროექტების გასამიჯნურად, შემდეგ გადართეთ მათ შორის",
+    "organization_name": "ორგანიზაციის სახელი",
+    "create_organization": "ორგანიზაციის შექმნა",
+    "rename_organization": "ორგანიზაციის სახელის გადარქმევა",
+    "manage_organizations": "ორგანიზაციების მართვა",
+    "organization_renamed": "ორგანიზაციას სახელი გადაერქმა",
+    "current_organization": "მიმდინარე",
+    "switch": "გადართვა",
+    "rename": "გადარქმევა",
+    "delete_organization_confirm": "ეს ორგანიზაცია, მისი არხები და პოსტები წაიშლება. ეს მოქმედება შეუქცევადია, დარწმუნებული ხართ?",
+    "yes_delete_organization": "დიახ, ამ ორგანიზაციის წაშლა",
+    "could_not_create_organization": "ორგანიზაციის შექმნა ვერ მოხერხდა",
+    "could_not_rename_organization": "ორგანიზაციის სახელის გადარქმევა ვერ მოხერხდა",
+    "could_not_delete_organization": "ორგანიზაციის წაშლა ვერ მოხერხდა"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ko/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "게시물 다시 게시하기",
   "post_already_published_republish_warning": "이 게시물은 이미 게시되었습니다. 다시 게시하면 다음에 다시 게시됩니다:",
   "republish_at": "다음 시간에",
-  "republish_recurring_note": "이 게시물은 반복 게시물입니다. 변경사항은 지금부터 시작하는 모든 향후 반복에 적용됩니다."
+  "republish_recurring_note": "이 게시물은 반복 게시물입니다. 변경사항은 지금부터 시작하는 모든 향후 반복에 적용됩니다.",
+  "organizations": "조직",
+  "organizations_description": "프로젝트를 분리하기 위해 조직을 만들고 그 사이를 전환하세요",
+  "organization_name": "조직 이름",
+  "create_organization": "조직 만들기",
+  "rename_organization": "조직 이름 바꾸기",
+  "manage_organizations": "조직 관리",
+  "organization_renamed": "조직 이름이 변경되었습니다",
+  "current_organization": "현재",
+  "switch": "전환",
+  "rename": "이름 바꾸기",
+  "delete_organization_confirm": "이 조직과 해당 채널 및 게시물이 삭제됩니다. 이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
+  "yes_delete_organization": "예, 이 조직을 삭제합니다",
+  "could_not_create_organization": "조직을 만들 수 없습니다",
+  "could_not_rename_organization": "조직 이름을 바꿀 수 없습니다",
+  "could_not_delete_organization": "조직을 삭제할 수 없습니다"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/pt/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Republicar a publicação",
   "post_already_published_republish_warning": "Esta publicação já foi publicada. Republicar irá publicá-la novamente em",
   "republish_at": "em",
-  "republish_recurring_note": "Esta é uma publicação recorrente: suas alterações se aplicam a todas as futuras recorrências a partir de agora."
+  "republish_recurring_note": "Esta é uma publicação recorrente: suas alterações se aplicam a todas as futuras recorrências a partir de agora.",
+  "organizations": "Organizações",
+  "organizations_description": "Crie organizações para separar projetos e alterne entre elas",
+  "organization_name": "Nome da organização",
+  "create_organization": "Criar organização",
+  "rename_organization": "Renomear organização",
+  "manage_organizations": "Gerenciar organizações",
+  "organization_renamed": "Organização renomeada",
+  "current_organization": "Atual",
+  "switch": "Alternar",
+  "rename": "Renomear",
+  "delete_organization_confirm": "Esta organização, seus canais e publicações serão excluídos. Esta ação não pode ser desfeita, tem certeza?",
+  "yes_delete_organization": "Sim, excluir esta organização",
+  "could_not_create_organization": "Não foi possível criar a organização",
+  "could_not_rename_organization": "Não foi possível renomear a organização",
+  "could_not_delete_organization": "Não foi possível excluir a organização"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/ru/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Опубликовать пост повторно",
   "post_already_published_republish_warning": "Этот пост уже был опубликован. Повторная публикация опубликует его снова в",
   "republish_at": "в",
-  "republish_recurring_note": "Это повторяющийся пост: ваши изменения будут применяться ко всем будущим публикациям, начиная с этого момента."
+  "republish_recurring_note": "Это повторяющийся пост: ваши изменения будут применяться ко всем будущим публикациям, начиная с этого момента.",
+  "organizations": "Организации",
+  "organizations_description": "Создавайте организации, чтобы разделять проекты, и переключайтесь между ними",
+  "organization_name": "Название организации",
+  "create_organization": "Создать организацию",
+  "rename_organization": "Переименовать организацию",
+  "manage_organizations": "Управление организациями",
+  "organization_renamed": "Организация переименована",
+  "current_organization": "Текущая",
+  "switch": "Переключить",
+  "rename": "Переименовать",
+  "delete_organization_confirm": "Эта организация, её каналы и публикации будут удалены. Это действие нельзя отменить, вы уверены?",
+  "yes_delete_organization": "Да, удалить эту организацию",
+  "could_not_create_organization": "Не удалось создать организацию",
+  "could_not_rename_organization": "Не удалось переименовать организацию",
+  "could_not_delete_organization": "Не удалось удалить организацию"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/tr/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Gönderiyi tekrar yayımla",
   "post_already_published_republish_warning": "Bu gönderi zaten yayımlanmış. Tekrar yayımlamak, gönderiyi yeniden yayımlar",
   "republish_at": "tarihinde/saatinde",
-  "republish_recurring_note": "Bu tekrar eden bir gönderi: yaptığınız değişiklikler bundan sonraki tüm tekrarlar için geçerli olacaktır."
+  "republish_recurring_note": "Bu tekrar eden bir gönderi: yaptığınız değişiklikler bundan sonraki tüm tekrarlar için geçerli olacaktır.",
+  "organizations": "Organizasyonlar",
+  "organizations_description": "Projeleri ayırmak için organizasyonlar oluşturun, ardından aralarında geçiş yapın",
+  "organization_name": "Organizasyon adı",
+  "create_organization": "Organizasyon oluştur",
+  "rename_organization": "Organizasyonu yeniden adlandır",
+  "manage_organizations": "Organizasyonları yönet",
+  "organization_renamed": "Organizasyon yeniden adlandırıldı",
+  "current_organization": "Geçerli",
+  "switch": "Değiştir",
+  "rename": "Yeniden adlandır",
+  "delete_organization_confirm": "Bu organizasyon, kanalları ve gönderileri silinecek. Bu işlem geri alınamaz, emin misiniz?",
+  "yes_delete_organization": "Evet, bu organizasyonu sil",
+  "could_not_create_organization": "Organizasyon oluşturulamadı",
+  "could_not_rename_organization": "Organizasyon yeniden adlandırılamadı",
+  "could_not_delete_organization": "Organizasyon silinemedi"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/vi/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "Đăng lại bài viết",
   "post_already_published_republish_warning": "Bài viết này đã được đăng. Đăng lại sẽ xuất bản bài viết một lần nữa đến",
   "republish_at": "lúc",
-  "republish_recurring_note": "Đây là bài viết định kỳ: các thay đổi của bạn sẽ áp dụng cho tất cả các lần lặp lại trong tương lai bắt đầu từ bây giờ."
+  "republish_recurring_note": "Đây là bài viết định kỳ: các thay đổi của bạn sẽ áp dụng cho tất cả các lần lặp lại trong tương lai bắt đầu từ bây giờ.",
+  "organizations": "Tổ chức",
+  "organizations_description": "Tạo các tổ chức để tách biệt dự án, sau đó chuyển đổi giữa chúng",
+  "organization_name": "Tên tổ chức",
+  "create_organization": "Tạo tổ chức",
+  "rename_organization": "Đổi tên tổ chức",
+  "manage_organizations": "Quản lý tổ chức",
+  "organization_renamed": "Đã đổi tên tổ chức",
+  "current_organization": "Hiện tại",
+  "switch": "Chuyển",
+  "rename": "Đổi tên",
+  "delete_organization_confirm": "Tổ chức này, các kênh và bài đăng của nó sẽ bị xóa. Hành động này không thể hoàn tác, bạn có chắc chắn không?",
+  "yes_delete_organization": "Có, xóa tổ chức này",
+  "could_not_create_organization": "Không thể tạo tổ chức",
+  "could_not_rename_organization": "Không thể đổi tên tổ chức",
+  "could_not_delete_organization": "Không thể xóa tổ chức"
 }

--- a/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
+++ b/libraries/react-shared-libraries/src/translation/locales/zh/translation.json
@@ -737,5 +737,20 @@
   "republish_the_post": "重新发布帖子",
   "post_already_published_republish_warning": "此帖子已发布。重新发布将再次将其发布到",
   "republish_at": "于",
-  "republish_recurring_note": "这是一个重复的帖子：你的更改将从现在开始应用于所有未来的重复内容。"
+  "republish_recurring_note": "这是一个重复的帖子：你的更改将从现在开始应用于所有未来的重复内容。",
+  "organizations": "组织",
+  "organizations_description": "创建组织以区分不同项目，然后在其间切换",
+  "organization_name": "组织名称",
+  "create_organization": "创建组织",
+  "rename_organization": "重命名组织",
+  "manage_organizations": "管理组织",
+  "organization_renamed": "组织已重命名",
+  "current_organization": "当前",
+  "switch": "切换",
+  "rename": "重命名",
+  "delete_organization_confirm": "该组织及其频道和帖子将被删除。此操作无法撤销，确定要继续吗？",
+  "yes_delete_organization": "是，删除该组织",
+  "could_not_create_organization": "无法创建组织",
+  "could_not_rename_organization": "无法重命名组织",
+  "could_not_delete_organization": "无法删除组织"
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (backend + frontend, organization management). Adds full self-service management of the organizations a user owns: `POST/PATCH/DELETE /user/organizations` in `apps/backend/src/api/routes/users.controller.ts` (create / rename / delete, backed by `OrganizationService.createOrgForUser`, `updateOrganizationName`, `getOrgToDelete`, `deleteOwnedOrganization`), an always-visible org switcher with a create-org entry in `organization.selector.tsx`, and a new "Organizations" settings tab (`organizations.component.tsx`, deep-linkable via `/settings?tab=organizations`) listing every org with switch/rename/delete actions. Deliberately unchanged: org switching itself (`/user/change-org`), invites/team management, and the soft-delete semantics used everywhere else in the app.

# Why was this change needed?

`UserOrganization` is already many-to-many and users end up with several orgs (invites, agencies, impersonation by support), but there was no way to create, rename or delete your own org from the app - the switcher only rendered once you already had 2+ orgs, and everything else went through support. Agencies that need more channels than the biggest plan currently have to register a whole new account with a new email; with this they can create an additional org from their existing account, pay for it separately (own Stripe customer, `allowTrial=false` so no second free trial), and remove it when the project ends. Deletion follows the exact same path as account deletion: Stripe subscriptions are cancelled first, then integrations and posts are soft-deleted - pending Temporal workflows resolve quietly because `getPost` already returns false for soft-deleted posts.

Safety rails on delete: SUPERADMIN on the target org required, refuses to delete the last enabled org (re-checked inside a SERIALIZABLE transaction so two concurrent deletes cannot leave a user with zero orgs), refuses while other enabled team members exist (disabled members from a subscription downgrade don't block), and all three endpoints plus the UI actions are blocked while impersonating. Creation is capped by `MAX_ORGS_PER_USER` (default 10).

Also included, as direct consequences of the above: joining via an invitation link now rejects soft-deleted orgs, the auth middleware no longer throws a `TypeError` when no org resolves (the previous `if (!organization)` check was dead code on an array), and `CheckPayment` now strips `?check=` (keeping other query params) after a successful payment so a reload/org switch doesn't hang on the payment loader.

# Other information:

- There is overlap with #1916 (create + rename via Global Settings); this PR covers the same creation endpoint plus rename/delete/manage-tab, shared `useOrganizations` SWR hook, impersonation guards, the org cap and the race-free last-org protection. Happy to rework whatever the maintainers prefer from each.
- Rename is SUPERADMIN-only (owner of the target org) rather than `@CheckPolicies([Create, ADMIN])`, because the renamed org is not necessarily the currently-selected org the policy guard evaluates against.
- Uploads/media rows and files are left untouched on delete, consistent with soft-delete and with account deletion.
- New i18n keys added to all 16 locales + `i18n.lock`.

# QA

Setup: run Postiz locally (docker compose infra + backend + frontend) and register a user, then log in.

1. [ ] Hover the org switcher in the top bar: it is now visible with a single org, lists the current org marked "Current", and shows "Create organization"
2. [ ] Create a second org from the switcher: a modal asks for the name (3-128 chars enforced), after submit you are switched to the new org; in the DB the new org has its own `apiKey`, `allowTrial=false`, `isTrailing=false` and your role is `SUPERADMIN`
3. [ ] With `STRIPE_PUBLISHABLE_KEY` unset you land on the dashboard; with billing enabled you get the first-billing plans screen for the new org
4. [ ] Open Settings: a new "Organizations" tab lists all your orgs with role labels; "Rename" updates the name live (SWR mutate) and the switcher reflects it
5. [ ] Try deleting the org while it is your only one: backend refuses with "You cannot delete your only organization. Delete your account instead"
6. [ ] Invite a team member to a second org and accept the invite: deleting that org now fails with "Please remove your team members before deleting this organization"; set the member's `UserOrganization.disabled=true` in the DB (what a subscription downgrade does) and the delete succeeds
7. [ ] Delete an org you are NOT currently in: you stay on your current org; delete the org you ARE in: the app lands you on another org you own
8. [x] Verify a stale `showorg` cookie: delete an org from browser A while browser B had it selected - browser B falls back to another org without errors
9. [ ] While impersonating a user (superadmin), the create/rename/delete actions are hidden in the UI and the three endpoints answer 400 "Organizations cannot be changed while impersonating"; switching orgs still works
10. [ ] Create orgs until the cap: the 11th returns "You can create up to 10 organizations" (override with `MAX_ORGS_PER_USER`)
11. [ ] Fire two `DELETE /user/organizations/:id` in parallel for your last two orgs: exactly one succeeds, the other gets a 400 and the user keeps one enabled org
12. [ ] With billing on, complete a checkout on a second org, then delete it: the Stripe subscription is cancelled and the first org's subscription is untouched
13. [ ] After a successful payment, loading any page with `?check=<id>&tab=x` clears the loader, drops only `check` and keeps `tab`

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [ ] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [ ] I checked that there were no similar issues or PRs already open for this.
- [ ] This PR fixes just ONE issue
- [X] I have filled in the QA section above with real steps to verify this change.
