### PR TITLE
fix(tiktok): restore video cover frame selection on Direct Post

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -565,6 +565,12 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
                 auto_add_music: firstPost.settings.autoAddMusic === 'yes',
               }
             : {}),
+          ...(!isPhoto && firstPost?.media?.[0]?.thumbnailTimestamp
+            ? {
+                video_cover_timestamp_ms:
+                  firstPost?.media?.[0]?.thumbnailTimestamp,
+              }
+            : {}),
         },
       };
     }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend/orchestrator, TikTok provider). Re-adds `video_cover_timestamp_ms` to the Direct Post video init body in `tiktok.provider.ts` (`buildTikokPostInfoBody`), sourced from the media's `thumbnailTimestamp` and omitted when unset. The old PULL_FROM_URL implementation sent it in `source_info`; the FILE_UPLOAD migration dropped it, so the composer's cover-frame selection was silently ignored for regular TikTok. Per TikTok's current Direct Post schema the field belongs in `post_info`, so it is added there rather than un-commenting the old code. The UPLOAD/inbox flow (which takes no `post_info`) and photo posts are unchanged.

# Why was this change needed?

A customer doing automated publishing reported that the video cover frame cannot be controlled for regular TikTok, even though TikTok's Direct Post API supports `video_cover_timestamp_ms`. This was a regression from the move to FILE_UPLOAD: Instagram and TikTok Business still honor `thumbnailTimestamp`, regular TikTok ignored it.

# Other information:

Verified in testing that TikTok applied the requested cover only to posts published as `PUBLIC_TO_EVERYONE`; a `SELF_ONLY` post kept the first frame despite the identical request body. Not documented by TikTok - observed behavior. A docs PR documenting `thumbnailTimestamp` on the public API media object follows and must merge only after this deploys: gitroomhq/postiz-docs#244

# QA

1. [ ] Connect a regular TikTok channel (not TikTok Business)
2. [ ] Create a post with an mp4 whose first frame is visually distinct from a later frame, open the media's settings in the composer, and pick a later frame as the cover ("Select This Frame")
3. [ ] Publish with content_posting_method DIRECT_POST and a public privacy level
4. [ ] The published TikTok video's cover (profile grid / edit-post preview) should be the selected frame, not the first frame
5. [ ] Publish the same video without selecting a cover frame - the cover should remain the first frame

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
