### PR TITLE
fix: friendly message when Threads reports an UNKNOWN container error

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -186,7 +186,9 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
         this.identifier,
         JSON.stringify({ status, error_message }),
         '{}',
-        error_message || 'Threads could not process the media'
+        error_message && error_message !== 'UNKNOWN'
+          ? error_message
+          : 'Threads could not process the media, please check the media format and try again'
       );
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Threads provider, error messaging). `ThreadsProvider.checkContainerStatus` already surfaces Meta's `error_message` when a media container ends in ERROR/EXPIRED, but Meta sometimes returns the literal string `UNKNOWN` as the message, which then lands verbatim as the post's failure reason. The fallback branch now also treats `UNKNOWN` as an unhelpful message and replaces it with "Threads could not process the media, please check the media format and try again". Real Meta messages still pass through untouched, and the raw `{status, error_message}` JSON is still persisted in the BadBody body for debugging.

# Why was this change needed?

A support ticket (August 2026) from a customer publishing via automation had a series of Threads posts failing with just "UNKNOWN" as the error - Meta's own message for their media-processing failures. "UNKNOWN" gives the user nothing to act on; the curated fallback at least points them at the media as the thing to check, consistent with how the other providers phrase media-processing failures.

# Other information:

Came out of a support-ticket investigation together with two sibling PRs (Bearer-prefix API auth, Instagram container-error mapping); each is independent.

# QA

Verified by driving the real provider's `checkContainerStatus` with controlled container-status responses: `{status: "ERROR", error_message: "UNKNOWN"}` and `{status: "ERROR"}` with no message both throw BadBody with the new curated text, `{status: "ERROR", error_message: "The media is too long"}` passes the real message through unchanged, and `{status: "FINISHED"}` still returns normally.

1. [ ] Schedule a Threads post with a media file Threads cannot process (e.g. a video outside Threads' supported specs)
2. [ ] Wait for the container to end in ERROR; if Meta reports a real error_message, that exact message should appear on the failed post
3. [ ] For failures where Meta reports UNKNOWN (or no message), the post error should read "Threads could not process the media, please check the media format and try again" instead of "UNKNOWN"
4. [ ] Publish a valid Threads post and confirm it still publishes normally

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
