### PR TITLE
fix: map Instagram container errors through handleErrors and add 2207085

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -367,6 +367,14 @@ export class InstagramProvider
       }
     }
 
+    if (body.indexOf('2207085') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          'Instagram could not process the video, please check the video format, duration and resolution and try again',
+      };
+    }
+
     if (body.indexOf('2207077') > -1) {
       return {
         type: 'bad-body' as const,
@@ -631,11 +639,13 @@ export class InstagramProvider
     ).json();
 
     if (status_code === 'ERROR' || status_code === 'EXPIRED') {
+      const body = JSON.stringify({ status_code, status });
+      const handle = this.handleErrors(body, 200);
       throw new BadBody(
         this.identifier,
-        JSON.stringify({ status_code, status }),
+        body,
         '{}',
-        status || 'Instagram could not process the media'
+        handle?.value || status || 'Instagram could not process the media'
       );
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Instagram provider, error messaging). Two small changes in `instagram.provider.ts`: (1) `igContainerStatus` now runs the container's `{status_code, status}` body through the provider's existing `handleErrors` mapping before throwing, so curated messages (like the existing 2207082 mapping) apply to container-status failures instead of the raw Meta text such as "Error: Media upload has failed with error code 2207082"; (2) adds a `handleErrors` mapping for error code 2207085 ("Instagram could not process the video, please check the video format, duration and resolution and try again"). Unmapped statuses still pass Meta's raw text through, and the raw JSON body persisted on the BadBody is unchanged.

# Why was this change needed?

A support ticket (August 2026) from a customer publishing via automation had recurring Instagram failures showing only "Error: Media upload has failed with error code 2207082/2207085". The provider already curates these codes for direct fetch errors, but container-status failures bypassed the mapping, so users got an opaque numeric code for what is a media-processing problem they can act on.

# Other information:

Came out of a support-ticket investigation together with two sibling PRs (Bearer-prefix API auth, Threads UNKNOWN container error); each is independent. No overlap with #1876, which maps 2207018 only.

# QA

Verified by driving the real provider's `igContainerStatus` with controlled container-status responses: status "Error: Media upload has failed with error code 2207082" now throws BadBody "Could not upload your media" (the existing mapping), 2207085 throws the new curated video message, an unmapped status string still passes through verbatim, and `status_code: "FINISHED"` returns normally.

1. [ ] Schedule an Instagram post with a video Meta will fail to process (e.g. outside the supported specs) so the media container ends in ERROR with code 2207082 or 2207085
2. [ ] The failed post's error should show the curated message ("Could not upload your media" / the 2207085 video-format message) instead of "Error: Media upload has failed with error code ..."
3. [ ] Force an unmapped container failure (any other code) and confirm Meta's original status text is still shown
4. [ ] Publish a valid Instagram post (image and video) and confirm both still publish normally

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
