### PR TITLE
feat: auto text direction (RTL) in composer editor and previews

### DIFF
--- a/apps/frontend/src/components/launches/general.preview.component.tsx
+++ b/apps/frontend/src/components/launches/general.preview.component.tsx
@@ -111,6 +111,7 @@ export const GeneralPreviewComponent: FC<{
                 </div>
               </div>
               <div
+                dir="auto"
                 className={clsx('text-wrap whitespace-pre', 'preview')}
                 dangerouslySetInnerHTML={{
                   __html: value.text,

--- a/apps/frontend/src/components/new-launch/add.edit.modal.tsx
+++ b/apps/frontend/src/components/new-launch/add.edit.modal.tsx
@@ -150,7 +150,7 @@ export const AddEditModalInnerInner: FC<AddEditModalProps> = (props) => {
         existingData.posts.map((post) => ({
           delay: post.delay,
           content:
-            post.content.indexOf('<p') > -1
+            /<p[\s>]/i.test(post.content)
               ? post.content
               : post.content
                   .split('\n')
@@ -175,7 +175,7 @@ export const AddEditModalInnerInner: FC<AddEditModalProps> = (props) => {
       props.onlyValues?.length
         ? props.onlyValues.map((p) => ({
             content:
-              p.content.indexOf('<p') > -1
+              /<p[\s>]/i.test(p.content)
                 ? p.content
                 : p.content
                     .split('\n')
@@ -188,7 +188,7 @@ export const AddEditModalInnerInner: FC<AddEditModalProps> = (props) => {
         ? props.set.posts[0].value.map((p: any) => ({
             id: makeId(10),
             content:
-              p.content.indexOf('<p') > -1
+              /<p[\s>]/i.test(p.content)
                 ? p.content
                 : p.content
                     .split('\n')

--- a/apps/frontend/src/components/new-launch/add.edit.modal.tsx
+++ b/apps/frontend/src/components/new-launch/add.edit.modal.tsx
@@ -150,7 +150,7 @@ export const AddEditModalInnerInner: FC<AddEditModalProps> = (props) => {
         existingData.posts.map((post) => ({
           delay: post.delay,
           content:
-            post.content.indexOf('<p>') > -1
+            post.content.indexOf('<p') > -1
               ? post.content
               : post.content
                   .split('\n')
@@ -175,7 +175,7 @@ export const AddEditModalInnerInner: FC<AddEditModalProps> = (props) => {
       props.onlyValues?.length
         ? props.onlyValues.map((p) => ({
             content:
-              p.content.indexOf('<p>') > -1
+              p.content.indexOf('<p') > -1
                 ? p.content
                 : p.content
                     .split('\n')
@@ -188,7 +188,7 @@ export const AddEditModalInnerInner: FC<AddEditModalProps> = (props) => {
         ? props.set.posts[0].value.map((p: any) => ({
             id: makeId(10),
             content:
-              p.content.indexOf('<p>') > -1
+              p.content.indexOf('<p') > -1
                 ? p.content
                 : p.content
                     .split('\n')

--- a/apps/frontend/src/components/new-launch/editor.tsx
+++ b/apps/frontend/src/components/new-launch/editor.tsx
@@ -907,7 +907,11 @@ export const OnlyEditor = forwardRef<
   const editor = useEditor({
     extensions: [
       Document,
-      Paragraph,
+      Paragraph.configure({
+        HTMLAttributes: {
+          dir: 'auto',
+        },
+      }),
       Text,
       Underline,
       Bold,
@@ -1021,6 +1025,9 @@ export const OnlyEditor = forwardRef<
         ? [
             Heading.configure({
               levels: [1, 2, 3],
+              HTMLAttributes: {
+                dir: 'auto',
+              },
             }),
           ]
         : []),

--- a/apps/frontend/src/components/new-launch/providers/facebook/facebook.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/facebook/facebook.preview.tsx
@@ -153,6 +153,7 @@ export const FacebookPreview: FC<{
       </div>
       {background ? (
         <div
+          dir="auto"
           className="-mx-[15px] min-h-[320px] flex items-center justify-center text-center px-[32px] py-[32px] text-[28px] font-[700] leading-[36px] whitespace-pre-line break-words"
           style={{ background: background.background, color: background.text }}
           dangerouslySetInnerHTML={{
@@ -161,6 +162,7 @@ export const FacebookPreview: FC<{
         />
       ) : (
         <div
+          dir="auto"
           className="text-[14px] font-[400] whitespace-pre-line"
           dangerouslySetInnerHTML={{
             __html: renderContent?.[0]?.text,
@@ -295,6 +297,7 @@ export const FacebookPreview: FC<{
                       </div>
                     </div>
                     <div
+                      dir="auto"
                       className="whitespace-pre-line text-[14px] font-[400]"
                       dangerouslySetInnerHTML={{
                         __html: value.text,

--- a/apps/frontend/src/components/new-launch/providers/instagram/instagram.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/instagram/instagram.preview.tsx
@@ -34,6 +34,7 @@ export const InstagramPreview: FC<{
 
     const finalValue =
       `<strong class="text-[15px] font-[600]">${integration?.name} </strong>` +
+      `<span dir="auto">` +
       newContent
         .slice(start, end)
         .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
@@ -43,7 +44,7 @@ export const InstagramPreview: FC<{
       newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
-      `</mark>`;
+      `</mark></span>`;
 
     return { text: finalValue, images: p.image };
   });

--- a/apps/frontend/src/components/new-launch/providers/instagram/instagram.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/instagram/instagram.preview.tsx
@@ -82,6 +82,7 @@ export const InstagramPreview: FC<{
         />
       )}
       <div
+        dir="auto"
         className="text-[14px] font-[400] whitespace-pre-line"
         dangerouslySetInnerHTML={{
           __html: renderContent?.[0]?.text,
@@ -181,6 +182,7 @@ export const InstagramPreview: FC<{
                 <div className="flex flex-col gap-[6px] flex-1">
                   <div className="flex gap-[4px] py-[8px]">
                     <div
+                      dir="auto"
                       className="whitespace-pre-line text-[14px] font-[400] flex-1"
                       dangerouslySetInnerHTML={{
                         __html: value.text,

--- a/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.preview.tsx
@@ -318,6 +318,7 @@ export const LinkedinPreview: FC<{
         </div>
       </div>
       <div
+        dir="auto"
         className="text-[14px] font-[400] whitespace-pre-line"
         dangerouslySetInnerHTML={{
           __html: renderContent?.[0]?.text,
@@ -452,6 +453,7 @@ export const LinkedinPreview: FC<{
                     </div>
                   </div>
                   <div
+                    dir="auto"
                     className="whitespace-pre-line text-[14px] font-[400]"
                     dangerouslySetInnerHTML={{
                       __html: value.text,

--- a/apps/frontend/src/components/new-launch/providers/pinterest/pinterest.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/pinterest/pinterest.preview.tsx
@@ -152,6 +152,7 @@ export const PinterestPreview: FC<{
         )}
       </div>
       <div
+        dir="auto"
         className="mt-[13px] whitespace-pre-line"
         dangerouslySetInnerHTML={{ __html: renderContent?.[0]?.text || '' }}
       ></div>

--- a/apps/frontend/src/components/new-launch/providers/reddit/reddit.provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/reddit/reddit.provider.tsx
@@ -37,6 +37,7 @@ const RenderRedditComponent: FC<{
     case 'self':
       return (
         <div
+          dir="auto"
           dangerouslySetInnerHTML={{ __html: firstPost?.content }}
           style={{
             whiteSpace: 'pre-wrap',
@@ -139,6 +140,7 @@ const RedditPreview: FC = (props) => {
                         {integration?.name}
                       </div>
                       <div
+                        dir="auto"
                         dangerouslySetInnerHTML={{ __html: p.text }}
                         style={{
                           whiteSpace: 'pre-wrap',

--- a/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.preview.tsx
@@ -74,7 +74,7 @@ export const TiktokPreview: FC<{
         />
         <div className="absolute pointer-events-none w-full h-full start-0 top-0 px-[12px] py-[25px] justify-end items-start text-white flex flex-col">
           <div className="text-[14px] font-[500]">@{integration?.name}</div>
-          <div className="text-[13px] font-[400] whitespace-pre-line line-clamp-6 w-full"
+          <div dir="auto" className="text-[13px] font-[400] whitespace-pre-line line-clamp-6 w-full"
             dangerouslySetInnerHTML={{ __html: renderContent?.[0]?.text || '' }}
           />
         </div>

--- a/apps/frontend/src/components/new-launch/providers/youtube/youtube.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/youtube/youtube.preview.tsx
@@ -141,6 +141,7 @@ export const YoutubePreview: FC<{
         </div>
       </div>
       <div
+        dir="auto"
         className="bg-youtubeBgAction rounded-[12px] p-[12px] text-[12px] font-[400] whitespace-pre-line"
         dangerouslySetInnerHTML={{ __html: renderContent?.[0]?.text }}
       />

--- a/libraries/helpers/src/utils/sanitize.post.content.ts
+++ b/libraries/helpers/src/utils/sanitize.post.content.ts
@@ -15,6 +15,7 @@ const ALLOWED_TAGS = [
 ];
 
 const ALLOWED_ATTR = [
+  'dir',
   'href',
   'target',
   'rel',

--- a/libraries/helpers/src/utils/strip.html.validation.ts
+++ b/libraries/helpers/src/utils/strip.html.validation.ts
@@ -179,17 +179,17 @@ export const stripHtmlValidation = (
     return striptags(
       convertMention(
         value
-          .replace(/<h1>([.\s\S]*?)<\/h1>/g, (match, p1) => {
+          .replace(/<h1[^>]*>([.\s\S]*?)<\/h1>/g, (match, p1) => {
             return `<h1># ${p1}</h1>\n`;
           })
           .replace(/&amp;/gi, '&')
           .replace(/&nbsp;/gi, ' ')
           .replace(/&quot;/gi, '"')
           .replace(/&#39;/gi, "'")
-          .replace(/<h2>([.\s\S]*?)<\/h2>/g, (match, p1) => {
+          .replace(/<h2[^>]*>([.\s\S]*?)<\/h2>/g, (match, p1) => {
             return `<h2>## ${p1}</h2>\n`;
           })
-          .replace(/<h3>([.\s\S]*?)<\/h3>/g, (match, p1) => {
+          .replace(/<h3[^>]*>([.\s\S]*?)<\/h3>/g, (match, p1) => {
             return `<h3>### ${p1}</h3>\n`;
           })
           .replace(/<u>([.\s\S]*?)<\/u>/g, (match, p1) => {
@@ -201,7 +201,7 @@ export const stripHtmlValidation = (
           .replace(/<li.*?>([.\s\S]*?)<\/li.*?>/gm, (match, p1) => {
             return `<li>- ${p1.replace(/\n/gm, '')}</li>`;
           })
-          .replace(/<p>([.\s\S]*?)<\/p>/g, (match, p1) => {
+          .replace(/<p[^>]*>([.\s\S]*?)<\/p>/g, (match, p1) => {
             return `<p>${p1}</p>\n`;
           })
           .replace(

--- a/libraries/helpers/src/utils/strip.html.validation.ts
+++ b/libraries/helpers/src/utils/strip.html.validation.ts
@@ -217,7 +217,7 @@ export const stripHtmlValidation = (
       .replace(/&lt;/gi, '<');
   }
 
-  if (value.indexOf('<p') === -1 && !none) {
+  if (!/<p[\s>]/i.test(value) && !none) {
     return value;
   }
 

--- a/libraries/helpers/src/utils/strip.html.validation.ts
+++ b/libraries/helpers/src/utils/strip.html.validation.ts
@@ -217,7 +217,7 @@ export const stripHtmlValidation = (
       .replace(/&lt;/gi, '<');
   }
 
-  if (value.indexOf('<p>') === -1 && !none) {
+  if (value.indexOf('<p') === -1 && !none) {
     return value;
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (frontend, composer + previews). Adds automatic text direction (`dir="auto"`) to the post composer: the TipTap editor emits `dir="auto"` on every paragraph and heading (`new-launch/editor.tsx`), and the text wrappers of the default preview (`general.preview.component.tsx`) and the Facebook, LinkedIn, Instagram, TikTok, YouTube, Pinterest and Reddit previews carry `dir="auto"` as well. Supporting changes the new attribute required: `'dir'` added to the sanitizer whitelist (`sanitize.post.content.ts`), the literal `indexOf('<p>')` checks in `strip.html.validation.ts` and `add.edit.modal.tsx` relaxed to `indexOf('<p')` so paragraphs with attributes are still recognized (otherwise stripHtmlValidation returned raw HTML at publish time), and the Instagram preview caption is wrapped in its own `dir="auto"` span so the prepended Latin username doesn't force the caption LTR.

# Why was this change needed?

A customer writing posts in Hebrew reported that Postiz has no RTL support: with the UI in English, Hebrew text in the editor and preview renders left-to-right with misplaced punctuation. Direction was only ever inherited from the document (it flips only when the whole UI language is Hebrew/Arabic). `dir="auto"` resolves direction from the first strong directional character, which is exactly how X, Facebook and Threads render post text (verified in their live DOM), so the editor and previews now match what gets published. The editor resolves per paragraph; previews resolve whole-post, same as the platforms.

# Other information:

The first strong character decides: lines starting with neutral characters (numbers, emoji, "@") follow the first strong letter after them, matching platform behavior. The `indexOf('<p')` fix matters for correctness beyond previews - without it, content saved with the new attribute would have been published to platforms with literal HTML tags.

# QA

1. [ ] Open the composer (Create Post) with the UI language set to English.
2. [ ] Type a Hebrew line, an English line, and a line starting with a number followed by Hebrew (e.g. "1. שלום"), each as its own paragraph.
3. [ ] In the editor, the Hebrew and number-first lines are right-aligned (RTL) while the English line stays left-aligned.
4. [ ] The global preview shows the whole post RTL (post starts with Hebrew); the Instagram preview shows the username inline followed by correctly ordered Hebrew.
5. [ ] Schedule the post to a channel and verify the published text is plain (no literal HTML tags) and renders RTL on the platform.
6. [ ] Edit an existing post and confirm the content loads without duplicated/double-wrapped paragraphs.
7. [ ] Type an English-only post and confirm nothing changed for LTR content.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
