### PR TITLE
feat(admin-stats): active orgs per post creation source

### DIFF
--- a/apps/frontend/src/components/admin/admin-stats.component.tsx
+++ b/apps/frontend/src/components/admin/admin-stats.component.tsx
@@ -27,6 +27,7 @@ interface StatsResponse {
   scheduledAccounts?: StatsBlock;
   publishingChannels?: StatsBlock;
   scheduledChannels?: StatsBlock;
+  activeOrgsBySource?: StatsBlock;
 }
 
 const isoDaysAgo = (days: number) => {
@@ -280,6 +281,14 @@ export const AdminStatsComponent: FC = () => {
                 />
               </div>
             )}
+            {data.activeOrgsBySource && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <SummaryCard
+                  label="Unique users - active (all sources combined)"
+                  value={data.activeOrgsBySource.total}
+                />
+              </div>
+            )}
           </div>
 
           <div className="flex gap-[12px] items-start">
@@ -334,6 +343,14 @@ export const AdminStatsComponent: FC = () => {
                 <PerSocialTable
                   title="Unique users - scheduled"
                   block={data.scheduledAccounts}
+                />
+              </div>
+            )}
+            {data.activeOrgsBySource && (
+              <div className="flex-1 min-w-[220px] shrink-0">
+                <PerSocialTable
+                  title="Active users per source"
+                  block={data.activeOrgsBySource}
                 />
               </div>
             )}

--- a/libraries/nestjs-libraries/src/database/prisma/admin-stats/admin-stats.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/admin-stats/admin-stats.repository.ts
@@ -27,6 +27,7 @@ export interface StatsResponse {
   scheduledAccounts: { total: number; perSocial: PerSocial[] };
   publishingChannels: { total: number; perSocial: PerSocial[] };
   scheduledChannels: { total: number; perSocial: PerSocial[] };
+  activeOrgsBySource: { total: number; perSocial: PerSocial[] };
 }
 
 const sortDesc = (list: PerSocial[]) =>
@@ -212,6 +213,43 @@ export class AdminStatsRepository {
     };
   }
 
+  // Distinct organizations with at least one top-level scheduled, published
+  // or failed post in the range, per creation source (web, API, MCP, ...).
+  // The total is distinct across all sources combined, not a summation.
+  private async sourceStats(params: StatsParams) {
+    const where: Prisma.PostWhereInput = {
+      parentPostId: null,
+      deletedAt: null,
+      publishDate: { gte: params.from, lte: params.to },
+      state: { in: ['QUEUE', 'PUBLISHED', 'ERROR'] },
+    };
+
+    const groups = await this._post.model.post.groupBy({
+      by: ['organizationId', 'creationMethod'],
+      where,
+    });
+
+    const allOrgs = new Set<string>();
+    const orgsBySource = new Map<string, Set<string>>();
+    for (const g of groups) {
+      if (!orgsBySource.has(g.creationMethod)) {
+        orgsBySource.set(g.creationMethod, new Set());
+      }
+      orgsBySource.get(g.creationMethod)!.add(g.organizationId);
+      allOrgs.add(g.organizationId);
+    }
+
+    return {
+      total: allOrgs.size,
+      perSocial: sortDesc(
+        [...orgsBySource.entries()].map(([provider, orgs]) => ({
+          provider,
+          count: orgs.size,
+        }))
+      ),
+    };
+  }
+
   private async connectedStats(params: StatsParams) {
     const where: Prisma.IntegrationWhereInput = {
       deletedAt: null,
@@ -239,12 +277,14 @@ export class AdminStatsRepository {
   }
 
   async getStats(params: StatsParams): Promise<StatsResponse> {
-    const [errors, posts, accounts, connected] = await Promise.all([
-      this.errorStats(params),
-      this.postStats(params),
-      this.accountStats(params),
-      this.connectedStats(params),
-    ]);
+    const [errors, posts, accounts, connected, activeOrgsBySource] =
+      await Promise.all([
+        this.errorStats(params),
+        this.postStats(params),
+        this.accountStats(params),
+        this.connectedStats(params),
+        this.sourceStats(params),
+      ]);
 
     return {
       from: params.from.toISOString(),
@@ -256,6 +296,7 @@ export class AdminStatsRepository {
       scheduledAccounts: accounts.scheduledAccounts,
       publishingChannels: accounts.publishingChannels,
       scheduledChannels: accounts.scheduledChannels,
+      activeOrgsBySource,
     };
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (backend + frontend, super-admin stats page). Adds a new `activeOrgsBySource` block to the `/admin/stats` response: the number of distinct organizations with at least one top-level post in the selected range whose state is `QUEUE`, `PUBLISHED` or `ERROR`, grouped by `Post.creationMethod` (`WEB` / `API` / `MCP` / `CLI` / `AUTOPOST` / `UNKNOWN`). Implemented as `sourceStats()` in `admin-stats.repository.ts` (a single Prisma `groupBy` on `organizationId` + `creationMethod`, folded into per-source sets like the existing `accountStats`) and wired into `getStats()`. The frontend `admin-stats.component.tsx` renders it as one more summary card ("Unique users - active (all sources combined)") and one more table ("Active users per source"). Existing fields, params, gating, service and controller are unchanged; no schema change.

# Why was this change needed?

We want to see, per day, how many organizations actually use Postiz through each entry point (web UI, public API, MCP, CLI), not only how many posts exist. The total is distinct across all sources (an org using both web and API on one day counts once), while each source row counts that org once, so the table always accounts for the total. Posts created before the `creationMethod` column existed (2026-05-12) show up under `UNKNOWN`.

# Other information:

Drafts and soft-deleted posts are excluded. Back-filling `creationMethod` for old posts is out of scope.

# QA

1. [ ] Log in as a super admin and open `/admin/stats` with the "Today" preset; note the new card "Unique users - active (all sources combined)" and the table "Active users per source" at the end of each row
2. [ ] From the web UI, schedule a post for today; from the public API (`POST /public/v1/posts`, same org), schedule one post for today and two posts for the day after tomorrow, one of them with `"creationMethod": "CLI"`; via MCP (`integrationSchedulePostTool`) schedule one for the day after tomorrow
3. [ ] Today: the table shows `WEB 1` and `API 1`, the card shows `1` (same org on two sources counts once in the total)
4. [ ] Day after tomorrow: the table shows `API 1`, `CLI 1`, `MCP 1`, card `1`
5. [ ] Create a draft and delete another scheduled post on that day; the numbers do not change
6. [ ] Schedule a post via the API from a second organization on the same day; that day's `API` row becomes `2` and the card becomes `2`
7. [ ] Select a multi-day range covering all of the above; each row shows the distinct org count across the range, and the card is the distinct total across all sources
8. [ ] Existing cards/tables on the page show the same values as before

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
