### PR TITLE
feat(billing): set-to-cancel email with the exact end date

### DIFF
--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -145,7 +145,7 @@ export class BillingController {
   ) {
     const result = await this._stripeService.setToCancel(org.id);
 
-    if (result.cancel_at && dayjs(result.cancel_at).isAfter(dayjs(), 'day')) {
+    if (result.cancel_at && dayjs(result.cancel_at).isAfter(dayjs())) {
       try {
         await this._notificationService.sendEmail(
           user.email,

--- a/apps/backend/src/api/routes/billing.controller.ts
+++ b/apps/backend/src/api/routes/billing.controller.ts
@@ -145,21 +145,18 @@ export class BillingController {
   ) {
     const result = await this._stripeService.setToCancel(org.id);
 
-    if (result.cancel_at) {
-      const isFutureCancel = dayjs(result.cancel_at).isAfter(dayjs(), 'day');
+    if (result.cancel_at && dayjs(result.cancel_at).isAfter(dayjs(), 'day')) {
       try {
         await this._notificationService.sendEmail(
           user.email,
-          'Your subscription has been cancelled',
-          `${
-            isFutureCancel
-              ? `Your subscription has been cancelled. You will keep access to all features until ${dayjs(
-                  result.cancel_at
-                ).format('MMMM D, YYYY')}.`
-              : 'Your subscription has been cancelled and access to paid features has ended.'
-          }<br /><br />Changed your mind? You can resubscribe anytime from your <a href="${
+          'Your Postiz subscription is set to cancel',
+          `Your subscription is pending cancellation and will end on ${dayjs(
+            result.cancel_at
+          ).format(
+            'D MMM, YYYY'
+          )}, the end of your current billing cycle. Until then you can keep using Postiz as usual. Changed your mind? You can reactivate at any time from the <a href="${
             process.env.FRONTEND_URL
-          }/billing">billing page</a>.`
+          }/billing">Billing page</a>.`
         );
       } catch (err) {
         logger.error('cancellation_email_failed', {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (backend, billing). Reworks the customer email sent from `BillingController.cancel` (`POST /billing/cancel`) so it is only sent when `StripeService.setToCancel` took the cancel-at-period-end branch (`cancel_at` in the future). The subject is now "Your Postiz subscription is set to cancel" and the body states the exact end date (`D MMM, YYYY`, same format as the Billing page), that access continues until then, and that the plan can be reactivated from the Billing page. The immediate-cancel branch (failed latest invoice / `past_due`) and the un-cancel branch no longer send anything. `setToCancel`, the endpoint response shape and the frontend are unchanged.

# Why was this change needed?

Customers finalizing a cancellation should get a clear confirmation that the subscription is pending cancellation, with the precise end date, rather than a generic "has been cancelled" message. The previous wording also sent an "access has ended" email on the immediate-cancel path, which this copy would misdescribe, so that path is now silent.

# Other information:

Copy agreed internally. The email is best-effort: failures are logged (`cancellation_email_failed`) and never fail the cancel request.

# QA

1. [ ] Sign in with an account that has an active Stripe subscription and open Billing
2. [ ] Click "Cancel subscription", confirm "Yes, cancel", decline the discount offer with "Cancel my subscription"
3. [ ] The page shows "Your subscription will be canceled at <date>" and the user receives an email with subject "Your Postiz subscription is set to cancel" whose body states the same date and links to the Billing page
4. [ ] Click "Reactivate subscription" (or cancel again if the page did not refresh the cancel state)
5. [ ] The subscription is active again and no second email is sent

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
