### PR TITLE
fix(bluesky): don't disconnect the channel when Bluesky login fails with a 5xx

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/bluesky.provider.ts
@@ -371,8 +371,22 @@ export class BlueskyProvider extends SocialAbstract implements SocialProvider {
         identifier: body.identifier,
         password: body.password,
       });
-    } catch (err) {
-      throw new RefreshToken('bluesky', JSON.stringify(err), {} as BodyInit);
+    } catch (err: any) {
+      // Only a definite 4xx (bad password, account taken down) means the
+      // credentials are broken. A 5xx or network error is Bluesky being
+      // unavailable: let it propagate as a transient failure instead of
+      // marking the channel as disconnected.
+      const status = err?.status;
+      if (
+        typeof status === 'number' &&
+        status >= 400 &&
+        status < 500 &&
+        status !== 429
+      ) {
+        throw new RefreshToken('bluesky', JSON.stringify(err), {} as BodyInit);
+      }
+
+      throw err;
     }
 
     return agent;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Bluesky provider). `getAgent` in bluesky.provider.ts wrapped every `agent.login` error as `RefreshToken`, so any failure to create a session marked the channel as needing reconnection. It now only does that for a definite 4xx (excluding 429): bad password, account taken down. 5xx, 429 and network errors propagate as-is and take the existing transient paths (activity retry in postPending, the prep-failure retry loop in finalizePost). Nothing changes for real credential failures.

# Why was this change needed?

On 2026-08-26 a customer's Bluesky channel was disconnected because Bluesky's load balancer answered the createSession call with a 502 `UpstreamFailure`. The channel's credentials were fine, but the next four scheduled posts failed with "Refresh channel needed" until the customer re-entered the credentials. A transient outage on Bluesky's side should not require user action. In production all other Bluesky refresh_token errors in August were genuine 401s (`AuthenticationRequired`, `AccountTakedown`), which keep the same behavior.

# Other information:

Same status-gating pattern the file already uses for the `agent.post` call. Companion fix for the reconnect click on custom-fields channels: https://github.com/gitroomhq/postiz-app/pull/2004.

# QA

1. [ ] Point a Bluesky channel's `service` at a local stub that returns 502 for `/xrpc/com.atproto.server.createSession`, schedule a post
2. [ ] The channel must NOT get the red "!" / `refreshNeeded`; the post retries and eventually fails as a normal post error
3. [ ] Change the stub to return 401 `{"error":"AuthenticationRequired"}`, schedule another post
4. [ ] The channel is marked as needing reconnection, as before

Verified with a ts-node harness driving `getAgent` against a local stub for 502, 503, 429, connection refused (all propagate raw) and 401 AuthenticationRequired, 401 AccountTakedown, 400 (all become RefreshToken).

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
- [X] I have filled in the QA section above with real steps to verify this change.
