### PR TITLE
fix(frontend): reconnect click on a custom-fields channel opened a 404 page

### DIFF
--- a/apps/frontend/src/components/launches/launches.component.tsx
+++ b/apps/frontend/src/components/launches/launches.component.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { AddProviderButton } from '@gitroom/frontend/components/launches/add.provider.component';
+import {
+  AddProviderButton,
+  CustomVariables,
+} from '@gitroom/frontend/components/launches/add.provider.component';
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import SafeImage from '@gitroom/react/helpers/safe.image';
 import { capitalize, groupBy, orderBy } from 'lodash';
@@ -26,6 +29,7 @@ import { useT } from '@gitroom/react/translation/get.transation.service.client';
 import { useIntegrationList } from '@gitroom/frontend/components/launches/helpers/use.integration.list';
 import useCookie from 'react-use-cookie';
 import { Onboarding } from '@gitroom/frontend/components/onboarding/onboarding';
+import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 
 export const SVGLine = () => {
   return (
@@ -358,6 +362,7 @@ export const LaunchesComponent = () => {
   const toast = useToaster();
   const fireEvents = useFireEvents();
   const t = useT();
+  const modal = useModals();
   const [reload, setReload] = useState(false);
   const [collapseMenu, setCollapseMenu] = useCookie('collapseMenu', '0');
   const [mode] = useCookie('mode', 'dark');
@@ -441,9 +446,31 @@ export const LaunchesComponent = () => {
     (
         integration: Integration & {
           identifier: string;
+          isCustomFields?: boolean;
+          customFields?: any[];
         }
       ) =>
       async () => {
+        // Custom-fields providers (Bluesky, etc.) have no OAuth URL to redirect
+        // to: reconnect by re-entering the credentials, like the menu does.
+        if (integration.isCustomFields) {
+          modal.openModal({
+            title: t('custom_url', 'Custom URL'),
+            withCloseButton: false,
+            classNames: {
+              modal: 'md',
+            },
+            children: (
+              <CustomVariables
+                identifier={integration.identifier}
+                gotoUrl={(url: string) => router.push(url)}
+                variables={integration.customFields || []}
+              />
+            ),
+          });
+          return;
+        }
+
         const { url } = await (
           await fetch(
             `/integrations/social/${integration.identifier}?refresh=${integration.internalId}`,


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, channel list). `refreshChannel` in launches.component.tsx fetched `/integrations/social/:id?refresh=…` and did `window.location.href = url`. For custom-fields providers (Bluesky and other credential-based channels) that `url` is the random state string, not an OAuth page, so the browser navigated to `/<state>` and hit the 404 page. The handler now opens the same `CustomVariables` credentials modal the channel menu's "Update credentials" action uses when `integration.isCustomFields` is set. OAuth providers are unchanged.

# Why was this change needed?

A customer whose Bluesky channel got disconnected clicked the "Channel disconnected, click to reconnect" avatar and landed on a 404. The channel menu already hides "Reconnect channel" for custom-fields providers, but the avatar overlay and the row click did not have that guard.

# Other information:

Companion to https://github.com/gitroomhq/postiz-app/pull/2003, which stops a transient Bluesky 5xx from disconnecting the channel in the first place.

# QA

1. [ ] Have a Bluesky channel with `refreshNeeded = true` (set it in the DB or break its password and let a post fail)
2. [ ] In the calendar channel list, click the red "!" on its avatar, then also click the channel row itself
3. [ ] Both open the "Custom URL" credentials modal instead of navigating to a 404 page
4. [ ] A disconnected OAuth channel (e.g. X) still redirects to the provider's auth page on the same click

Verified locally before and after the change: pre-fix the click navigated to `/<6-char state>` and showed the Next 404 page; post-fix both click sites open the modal.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
- [X] I have filled in the QA section above with real steps to verify this change.
