### PR TITLE
fix(tiktok): resolve and persist the public post id for analytics

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.repository.ts
@@ -411,6 +411,24 @@ export class PostsRepository {
     });
   }
 
+  updateResolvedRelease(
+    id: string,
+    orgId: string,
+    releaseId: string,
+    releaseURL: string
+  ) {
+    return this._post.model.post.update({
+      where: {
+        id,
+        organizationId: orgId,
+      },
+      data: {
+        releaseId,
+        releaseURL,
+      },
+    });
+  }
+
   async changeState(id: string, state: State, err?: any, body?: any) {
     const update = await this._post.model.post.update({
       where: {

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -209,10 +209,28 @@ export class PostsService {
     // }
 
     try {
+      let releaseId = post.releaseId;
+      if (integrationProvider.resolveReleaseId) {
+        const resolved = await integrationProvider.resolveReleaseId(
+          getIntegration.token,
+          releaseId,
+          getIntegration
+        );
+        if (resolved && resolved.postId !== releaseId) {
+          await this._postRepository.updateResolvedRelease(
+            post.id,
+            orgId,
+            resolved.postId,
+            resolved.releaseURL
+          );
+          releaseId = resolved.postId;
+        }
+      }
+
       const loadAnalytics = await integrationProvider.postAnalytics(
         getIntegration.internalId,
         getIntegration.token,
-        post.releaseId,
+        releaseId,
         date
       );
       await ioRedis.set(

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -34,6 +34,11 @@ export interface IAuthenticator {
     postId: string,
     fromDate: number,
   ): Promise<AnalyticsData[]>;
+  resolveReleaseId?(
+    accessToken: string,
+    releaseId: string,
+    integration: Integration
+  ): Promise<{ postId: string; releaseURL: string } | undefined>; // Final id + URL to persist when the stored releaseId is still a publish id, undefined when nothing to resolve (yet)
   changeNickname?(
     id: string,
     accessToken: string,

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.business.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.business.provider.ts
@@ -424,9 +424,10 @@ export class TiktokBusinessProvider
     pendingData: { publishId: string },
     integration: Integration
   ): Promise<PendingCheckResponse> {
+    let body: string;
     let post: any;
     try {
-      post = await (
+      body = await (
         await this.fetch(
           `${this.baseUrl}/business/publish/status/?business_id=${encodeURIComponent(
             integration.internalId
@@ -441,7 +442,8 @@ export class TiktokBusinessProvider
           0,
           true
         )
-      ).json();
+      ).text();
+      post = JSON.parse(body);
     } catch (err) {
       if (err instanceof RefreshToken || err instanceof Disconnect) {
         throw err;
@@ -468,7 +470,7 @@ export class TiktokBusinessProvider
       return { status: 'pending', pendingData };
     }
 
-    const { status, post_ids, reason } = post?.data || {};
+    const { status, reason } = post?.data || {};
 
     if (status === 'SEND_TO_USER_INBOX') {
       return {
@@ -481,15 +483,15 @@ export class TiktokBusinessProvider
     if (status === 'PUBLISH_COMPLETE') {
       // post_ids can lag up to 3 minutes behind PUBLISH_COMPLETE, and never
       // shows up at all for non-public posts - fall back to the profile URL
-      // and keep the share_id (postAnalytics resolves it later).
-      const publicPostId = post_ids?.[0];
+      // and keep the share_id (resolveReleaseId fixes it later).
+      const publicPostId = this.publicPostId(body);
 
       return {
         status: 'completed',
         releaseURL: !publicPostId
           ? `https://www.tiktok.com/@${integration.profile}`
           : `https://www.tiktok.com/@${integration.profile}/video/${publicPostId}`,
-        postId: !publicPostId ? pendingData.publishId : String(publicPostId),
+        postId: !publicPostId ? pendingData.publishId : publicPostId,
       };
     }
 
@@ -928,6 +930,12 @@ export class TiktokBusinessProvider
     return videoListData?.data?.videos;
   }
 
+  // post_ids holds int64 ids that exceed Number.MAX_SAFE_INTEGER, so the id
+  // must be read from the raw body instead of the parsed JSON
+  private publicPostId(body: string) {
+    return body.match(/"post_ids"\s*:\s*\[\s*"?(\d+)"?/)?.[1];
+  }
+
   private throwIfTokenError(body: { code?: number }) {
     if (body?.code === 0) {
       return;
@@ -1098,6 +1106,44 @@ export class TiktokBusinessProvider
     }
   }
 
+  // Posts saved before post_ids became available keep their share_id
+  // (v_pub_... / p_pub_...) as releaseId - resolve it to the public post id
+  async resolveReleaseId(
+    accessToken: string,
+    releaseId: string,
+    integration: Integration
+  ) {
+    if (releaseId.indexOf('_pub_') === -1) {
+      return undefined;
+    }
+
+    const body = await (
+      await this.fetch(
+        `${this.baseUrl}/business/publish/status/?business_id=${encodeURIComponent(
+          integration.internalId
+        )}&publish_id=${encodeURIComponent(releaseId)}`,
+        {
+          method: 'GET',
+          headers: {
+            'Access-Token': accessToken,
+          },
+        }
+      )
+    ).text();
+
+    this.throwIfTokenError(JSON.parse(body));
+
+    const publicPostId = this.publicPostId(body);
+    if (!publicPostId) {
+      return undefined;
+    }
+
+    return {
+      postId: publicPostId,
+      releaseURL: `https://www.tiktok.com/@${integration.profile}/video/${publicPostId}`,
+    };
+  }
+
   async postAnalytics(
     integrationId: string,
     accessToken: string,
@@ -1105,33 +1151,6 @@ export class TiktokBusinessProvider
     fromDate: number
   ): Promise<AnalyticsData[]> {
     const today = dayjs().format('YYYY-MM-DD');
-
-    // Posts saved before post_ids became available keep their share_id
-    // (v_pub_url~... / p_pub_url~...) as releaseId - resolve it to the public
-    // post id first.
-    if (postId.indexOf('_pub_url') > -1) {
-      const post = await (
-        await this.fetch(
-          `${this.baseUrl}/business/publish/status/?business_id=${encodeURIComponent(
-            integrationId
-          )}&publish_id=${encodeURIComponent(postId)}`,
-          {
-            method: 'GET',
-            headers: {
-              'Access-Token': accessToken,
-            },
-          }
-        )
-      ).json();
-
-      this.throwIfTokenError(post);
-
-      if (!post?.data?.post_ids?.[0]) {
-        return [];
-      }
-
-      postId = String(post.data.post_ids[0]);
-    }
 
     try {
       const videoQueryData = await (

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -1120,13 +1120,13 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
   }
 
   // Posts published before moderation finished keep their publish_id
-  // (v_pub_url~... / v_pub_file~...) as releaseId - resolve it to the video id
+  // (v_pub_file~... / p_pub_url~...) as releaseId - resolve it to the post id
   async resolveReleaseId(
     accessToken: string,
     releaseId: string,
     integration: Integration
   ) {
-    if (releaseId.indexOf('v_pub_') === -1) {
+    if (releaseId.indexOf('_pub_') === -1) {
       return undefined;
     }
 

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -420,6 +420,14 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
+  // publicaly_available_post_id is an int64 that exceeds Number.MAX_SAFE_INTEGER,
+  // so it must be read from the raw body instead of the parsed JSON
+  private publicPostId(body: string) {
+    return body.match(
+      /"publicaly_available_post_id"\s*:\s*\[\s*"?(\d+)"?/
+    )?.[1];
+  }
+
   // Single status check for a publish_id, no loops and no timers: `post` returns
   // a `pending` PostResponse right after the upload, and the post workflow polls
   // this method with durable timers, so a stuck/retried check can never re-run
@@ -429,9 +437,10 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     pendingData: { publishId: string },
     integration: Integration
   ): Promise<PendingCheckResponse> {
+    let body: string;
     let post: any;
     try {
-      post = await (
+      body = await (
         await this.fetch(
           'https://open.tiktokapis.com/v2/post/publish/status/fetch/',
           {
@@ -448,7 +457,8 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
           0,
           true
         )
-      ).json();
+      ).text();
+      post = JSON.parse(body);
     } catch (err) {
       if (err instanceof RefreshToken || err instanceof Disconnect) {
         throw err;
@@ -460,7 +470,7 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       return { status: 'pending', pendingData };
     }
 
-    const { status, publicaly_available_post_id } = post?.data || {};
+    const { status } = post?.data || {};
 
     if (status === 'SEND_TO_USER_INBOX') {
       return {
@@ -471,16 +481,16 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     }
 
     if (status === 'PUBLISH_COMPLETE') {
-      // an empty array is truthy, so index it once and branch on the value
-      const publicPostId = publicaly_available_post_id?.[0];
+      // the id only shows up once moderation approves the post - fall back to
+      // the profile URL and keep the publish_id (resolveReleaseId fixes it later)
+      const publicPostId = this.publicPostId(body);
 
       return {
         status: 'completed',
         releaseURL: !publicPostId
           ? `https://www.tiktok.com/@${integration.profile}`
           : `https://www.tiktok.com/@${integration.profile}/video/${publicPostId}`,
-        // TikTok returns the id as a number, releaseId in the db is a string
-        postId: !publicPostId ? pendingData.publishId : String(publicPostId),
+        postId: !publicPostId ? pendingData.publishId : publicPostId,
       };
     }
 
@@ -1109,6 +1119,44 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     }
   }
 
+  // Posts published before moderation finished keep their publish_id
+  // (v_pub_url~... / v_pub_file~...) as releaseId - resolve it to the video id
+  async resolveReleaseId(
+    accessToken: string,
+    releaseId: string,
+    integration: Integration
+  ) {
+    if (releaseId.indexOf('v_pub_') === -1) {
+      return undefined;
+    }
+
+    const body = await (
+      await this.fetch(
+        'https://open.tiktokapis.com/v2/post/publish/status/fetch/',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json; charset=UTF-8',
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify({
+            publish_id: releaseId,
+          }),
+        }
+      )
+    ).text();
+
+    const publicPostId = this.publicPostId(body);
+    if (!publicPostId) {
+      return undefined;
+    }
+
+    return {
+      postId: publicPostId,
+      releaseURL: `https://www.tiktok.com/@${integration.profile}/video/${publicPostId}`,
+    };
+  }
+
   async postAnalytics(
     integrationId: string,
     accessToken: string,
@@ -1116,30 +1164,6 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
     fromDate: number
   ): Promise<AnalyticsData[]> {
     const today = dayjs().format('YYYY-MM-DD');
-
-    if (postId.indexOf('v_pub_url') > -1) {
-      const post = await (
-        await fetch(
-          'https://open.tiktokapis.com/v2/post/publish/status/fetch/',
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json; charset=UTF-8',
-              Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({
-              publish_id: postId,
-            }),
-          }
-        )
-      ).json();
-
-      if (!post?.data?.publicaly_available_post_id?.[0]) {
-        return [];
-      }
-
-      postId = post.data.publicaly_available_post_id[0];
-    }
 
     try {
       // Query video details using the video ID


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, TikTok + TikTok Business providers, post analytics). Adds an optional `resolveReleaseId` method to the provider interface; `PostsService.checkPostAnalytics` calls it before `postAnalytics` and, when it returns an id different from the stored one, persists it through the new `PostsRepository.updateResolvedRelease` (writes `releaseId` + `releaseURL`) and queries analytics with the resolved id. Both TikTok providers implement it by moving the publish-id → post-id resolution out of `postAnalytics` (which is now only the `video/query` call), matching any publish-id prefix (`_pub_`, which covers `v_pub_file~` video uploads, `p_pub_url~` photo posts and `v_pub_url~` URL pulls) instead of only `v_pub_url`, and reading the id from the raw response text with a regex so the 19-digit int64 is not rounded by `JSON.parse`; `checkPostStatus` uses the same helper. No schema change, no workflow/activity change, and the `postAnalytics` return type and every other provider are untouched.

Supersedes #1984, which covered the prefix widening and the unrounded read for the legacy provider only.

# Why was this change needed?

A customer reported that `GET /public/v1/analytics/post/{postId}` returned `[]` for every one of their TikTok posts, even ones that were published and live, and that `releaseURL` on those posts was their profile link rather than the video permalink, so the API gave them no way to reach or measure the published video.

Root cause, verified against live TikTok responses:

1. TikTok's `post/publish/status/fetch` only fills `publicaly_available_post_id` after moderation approves the post, usually seconds to minutes after `PUBLISH_COMPLETE` (https://developers.tiktok.com/doc/content-posting-api-reference-get-video-status). The workflow marks the post published on `PUBLISH_COMPLETE`, when that array is still empty, so the publish id (`v_pub_file~…`) was stored as `releaseId` and the profile URL as `releaseURL`.
2. The lazy resolution in `postAnalytics` only ran for ids containing `v_pub_url`. Current video uploads produce `v_pub_file~` and photo posts `p_pub_url~` (the Business provider `v_pub_url~` / `p_pub_url~`), so it never ran, and `video/query` was called with the publish id, matching nothing. Photo posts are a large share of the affected posts, so the guard matches `_pub_` on both providers.
3. When the id was present, it was read from `.json()`. The legacy API sends it as a bare JSON number that exceeds `Number.MAX_SAFE_INTEGER`; a real id observed in testing, `…770241`, parses as `…770000`, which would have been persisted as a permanently wrong `releaseId`.
4. Nothing ever wrote a resolved id back, so `releaseId` / `releaseURL` stayed wrong for the life of the post and every analytics call re-resolved.

The three fixes ship together deliberately: widening the prefix without the raw-body read would persist a rounded id, and resolving without persisting leaves the API's `releaseId` / `releaseURL` wrong forever.

# Other information:

The persistence is a new optional provider hook rather than a change to `postAnalytics`'s return type, so the other providers and the frontend / public-API consumers of `AnalyticsData[]` are unaffected. Posts are only rewritten when the resolved id differs from the stored one, so a post with a real video id costs nothing extra. Extending the publish workflow's pending phase to wait for the id was considered and rejected because it would require a new workflow version; lazy resolution on the first analytics read covers existing posts as well.

Verified end to end against real connected channels for both providers, via the public API:

- Legacy TikTok (video): a new public video was stored with a `v_pub_file~` publish id and the profile URL. The first analytics call returned Views/Likes/Comments/Shares and persisted the 19-digit video id (matching the raw body digit for digit; `JSON.parse` of the same body gives a different, rounded number) plus the `/video/<id>` permalink; `GET /public/v1/posts` now exposes both. A second call returned the same metrics without rewriting the post.
- Legacy TikTok (photo): a new public photo post was stored with a `p_pub_url~` publish id. The immediate analytics call returned `[]` with no write; once TikTok exposed the id (about 45 s later, also as a bare JSON number) the next call resolved, persisted the id and `/video/<id>` URL (which TikTok serves for photo posts as well) and returned metrics; a further call did not rewrite the post.
- TikTok Business: same flow with a `v_pub_url~` share id. Calls made while `post_ids` was still absent returned `[]` and persisted nothing; once it appeared (about 30 s later) the next call resolved, persisted and returned metrics.
- Publish ids whose video was later deleted on TikTok come back with no id at all; the resolver returns nothing and analytics stays `[]` with no write.
- Regressions: a post on a provider without `postAnalytics` still returns `[]`, a post with `releaseId = 'missing'` still returns `{ missing: true }`, and an X post (provider with `postAnalytics` but no resolver) returns its analytics with `releaseId` / `releaseURL` untouched.

# QA

1. [ ] With a connected TikTok (or TikTok Business) channel, publish a public video post and a public photo post and wait for them to reach PUBLISHED.
2. [ ] Check the post row (or `GET /public/v1/posts`): `releaseId` is a publish id (`v_pub_file~…` for the video, `p_pub_url~…` for the photo, `v_pub_url~…` on Business) and `releaseURL` is the profile link, unless TikTok already exposed the id.
3. [ ] Call `GET /public/v1/analytics/post/{postId}?date=<now ms>` (or open Statistics in the calendar preview). If TikTok has not finished moderation yet, expect `[]` and no change to the post row; retry after a minute.
4. [ ] Once resolved, expect Views/Likes/Comments/Shares in the response, and the post row to hold the 19-digit video id as `releaseId` and `https://www.tiktok.com/@<profile>/video/<id>` as `releaseURL`. Compare the id digit by digit against the permalink TikTok shows; open it and confirm it is the video.
5. [ ] Call the analytics endpoint again: same metrics, and the post row's `updatedAt` is unchanged.
6. [ ] Call the analytics endpoint for a published post on a non-TikTok channel (e.g. X): analytics returned as before, `releaseId` / `releaseURL` unchanged.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcaeTzorDM71yKNf9h3Fo4

