### PR TITLE
fix(public-api): guard undefined posts in getPost and return 404 on missing post in deletePost

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -275,6 +275,9 @@ export class PublicIntegrationsController {
   ) {
     Sentry.metrics.count('public_api-request', 1);
     const getPostById = await this._postsService.getPost(org.id, id);
+    if (!getPostById?.group) {
+      throw new HttpException({ msg: 'Post not found' }, 404);
+    }
     return this._postsService.deletePost(org.id, getPostById.group);
   }
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -543,9 +543,9 @@ export class PostsService {
           ),
         }))
       ),
-      integrationPicture: posts[0]?.integration?.picture,
-      integration: posts[0].integrationId,
-      settings: JSON.parse(posts[0].settings || '{}'),
+      integrationPicture: posts?.[0]?.integration?.picture,
+      integration: posts?.[0]?.integrationId,
+      settings: JSON.parse(posts?.[0]?.settings || '{}'),
     };
 
     return list;


### PR DESCRIPTION
## Summary

Fixes an unhandled `TypeError` (HTTP 500) when calling `DELETE /api/public/v1/posts/:id` with non-existent or already-deleted post IDs, returning a clean `404 Not Found` response instead.

## Problem

In `PostsService.getPost`, `integrationId` and `settings` dereference `posts[0]` directly without optional chaining:

```ts
// libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
integrationPicture: posts[0]?.integration?.picture,
integration: posts[0].integrationId, // throws when posts is []
settings: JSON.parse(posts[0].settings || '{}'),
```

When a post ID does not resolve, `posts` is an empty array (`[]`). Accessing `posts[0].integrationId` throws:
```
TypeError: Cannot read properties of undefined (reading 'integrationId')
```

Additionally, in `PublicIntegrationsController.deletePost`, `_postsService.deletePost` was called with `getPostById.group` without verifying that the post/group actually exists.

## Solution

1. Added optional chaining in `libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts`:
   ```ts
   integrationPicture: posts?.[0]?.integration?.picture,
   integration: posts?.[0]?.integrationId,
   settings: JSON.parse(posts?.[0]?.settings || '{}'),
   ```
2. Added a 404 check in `PublicIntegrationsController.deletePost` following the controller's existing error response pattern:
   ```ts
   if (!getPostById?.group) {
     throw new HttpException({ msg: 'Post not found' }, 404);
   }
   ```

Closes #1998
