### PR TITLE
fix(media): retry a ranged media read that comes back non-206

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -308,6 +308,11 @@ export abstract class SocialAbstract {
       // upload corrupted chunks. The store answers the same range correctly
       // seconds later, so retry the read before giving up on the post.
       if (response.status !== 206) {
+        // release the socket before moving on: the abandoned body can be the
+        // whole object, and undici keeps the connection checked out until it
+        // is consumed or cancelled.
+        await response.body?.cancel().catch(() => {});
+
         if (totalRetries <= 2) {
           await timer(5000);
           return this.mediaChunk(path, start, end, identifier, totalRetries + 1);

--- a/libraries/nestjs-libraries/src/integrations/social.abstract.ts
+++ b/libraries/nestjs-libraries/src/integrations/social.abstract.ts
@@ -88,6 +88,21 @@ export class Disconnect extends ApplicationFailure {
   }
 }
 
+// The status a media read actually answered with, for the failure details that
+// get persisted with the post - without it the stored error is an empty '{}'
+// and there is no way to tell a store that ignored Range from one that was down.
+export function rangeReadFailure(response: {
+  status: number;
+  statusText: string;
+  ok: boolean;
+}) {
+  return JSON.stringify({
+    status: response.status,
+    statusText: response.statusText,
+    ok: response.ok,
+  });
+}
+
 export class BadBody extends ApplicationFailure {
   constructor(identifier: string, json: string, body: BodyInit, message = '') {
     super(truncateForTemporal(message, MAX_FAILURE_MESSAGE), 'bad_body', true, [
@@ -274,7 +289,8 @@ export abstract class SocialAbstract {
     path: string,
     start: number,
     end: number,
-    identifier = ''
+    identifier = '',
+    totalRetries = 0
   ): Promise<Buffer> {
     if (path.indexOf('http') === 0) {
       setHeartbeatDetails(
@@ -289,11 +305,17 @@ export abstract class SocialAbstract {
       } as any);
       // Anything but 206 means the server ignored the Range header: buffering
       // response.body here would silently load the whole file into memory and
-      // upload corrupted chunks.
+      // upload corrupted chunks. The store answers the same range correctly
+      // seconds later, so retry the read before giving up on the post.
       if (response.status !== 206) {
+        if (totalRetries <= 2) {
+          await timer(5000);
+          return this.mediaChunk(path, start, end, identifier, totalRetries + 1);
+        }
+
         throw new BadBody(
           identifier,
-          '{}',
+          rangeReadFailure(response),
           Buffer.from('{}'),
           `Media server did not honor the range request (status ${response.status})`
         );

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -13,6 +13,7 @@ import {
   RefreshToken,
   SocialAbstract,
   ValidityMedia,
+  rangeReadFailure,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { TikTokDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/tiktok.dto';
 import { timer } from '@gitroom/helpers/utils/timer';
@@ -691,7 +692,12 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
   // Returns a streaming body for the [start, end] byte range of the media so we
   // never hold the whole file in memory: a ranged GET for remote URLs, a ranged
   // read stream for local files.
-  private async tiktokChunkStream(path: string, start: number, end: number) {
+  private async tiktokChunkStream(
+    path: string,
+    start: number,
+    end: number,
+    totalRetries = 0
+  ) {
     if (path.indexOf('http') === 0) {
       // identity encoding so the store keeps content-length and can answer
       // with the requested range, matching every other media read
@@ -704,11 +710,20 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       } as any);
 
       // A store that ignores Range (200 with the full file) or answers with an
-      // error page would corrupt the upload at this offset.
+      // error page would corrupt the upload at this offset, so the body is
+      // never used - but the same store answers the identical range correctly
+      // seconds later, so retry the read first. Once the retries are spent the
+      // BadBody stands: the caller rethrows it rather than waiting on TikTok
+      // for a verdict on bytes that never arrived.
       if (response.status !== 206) {
+        if (totalRetries <= 2) {
+          await timer(5000);
+          return this.tiktokChunkStream(path, start, end, totalRetries + 1);
+        }
+
         throw new BadBody(
           'tiktok-error-upload',
-          '{}',
+          rangeReadFailure(response),
           '{}',
           'The media storage did not return the requested byte range, please try again'
         );

--- a/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/tiktok.provider.ts
@@ -716,6 +716,11 @@ export class TiktokProvider extends SocialAbstract implements SocialProvider {
       // BadBody stands: the caller rethrows it rather than waiting on TikTok
       // for a verdict on bytes that never arrived.
       if (response.status !== 206) {
+        // release the socket before moving on: the abandoned body can be the
+        // whole object, and undici keeps the connection checked out until it
+        // is consumed or cancelled.
+        await response.body?.cancel().catch(() => {});
+
         if (totalRetries <= 2) {
           await timer(5000);
           return this.tiktokChunkStream(path, start, end, totalRetries + 1);

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -494,6 +494,11 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
       // seconds later, so retry the read instead of failing the whole upload
       // on one bad answer.
       if (response.status !== 206) {
+        // release the socket before moving on: the abandoned body can be the
+        // whole object, and undici keeps the connection checked out until it
+        // is consumed or cancelled.
+        await response.body?.cancel().catch(() => {});
+
         if (totalRetries <= 2) {
           await timer(5000);
           return this.youtubeChunkStream(path, start, end, totalRetries + 1);

--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -16,11 +16,13 @@ import {
   RefreshToken,
   SocialAbstract,
   ValidityMedia,
+  rangeReadFailure,
   stripQuery,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import * as process from 'node:process';
 import dayjs from 'dayjs';
 import { createReadStream, statSync } from 'fs';
+import { timer } from '@gitroom/helpers/utils/timer';
 import { getSsrfSafeDispatcher } from '@gitroom/nestjs-libraries/dtos/webhooks/ssrf.safe.dispatcher';
 import { setHeartbeatDetails } from '@gitroom/nestjs-libraries/temporal/temporal.heartbeat';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
@@ -428,7 +430,7 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
 
   // Resolves the total byte size of the media without loading it into memory:
   // a HEAD request for remote URLs, statSync for local files.
-  private async youtubeMediaSize(path: string): Promise<number> {
+  private async youtubeMediaSize(path: string, totalRetries = 0): Promise<number> {
     if (path.indexOf('http') === 0) {
       // the media path is user-influenced, keep the SSRF-safe dispatcher that
       // this.fetch applies to every other outbound request. identity encoding
@@ -441,10 +443,17 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
         dispatcher: getSsrfSafeDispatcher(),
       } as any);
       const length = head.headers.get('content-length');
+      // Same transient store behaviour as the ranged reads below: retry before
+      // failing the post, nothing irreversible has happened at this point.
       if (!length) {
+        if (totalRetries <= 2) {
+          await timer(5000);
+          return this.youtubeMediaSize(path, totalRetries + 1);
+        }
+
         throw new BadBody(
           this.identifier,
-          '{}',
+          rangeReadFailure(head),
           '{}',
           'Could not determine the video size for the YouTube upload'
         );
@@ -458,7 +467,12 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
   // Returns a streaming body for the [start, end] byte range of the media so we
   // never hold the whole file in memory: a ranged GET for remote URLs, a ranged
   // read stream for local files.
-  private async youtubeChunkStream(path: string, start: number, end: number) {
+  private async youtubeChunkStream(
+    path: string,
+    start: number,
+    end: number,
+    totalRetries = 0
+  ) {
     if (path.indexOf('http') === 0) {
       // identity encoding so the store keeps content-length and can answer
       // with the requested range: a transformed (compressed) response loses
@@ -475,11 +489,19 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
       } as any);
 
       // A store that ignores Range (200 with the full file) or answers with an
-      // error page would corrupt the upload at this offset.
+      // error page would corrupt the upload at this offset, so the body is
+      // never used - but the same store answers the identical range correctly
+      // seconds later, so retry the read instead of failing the whole upload
+      // on one bad answer.
       if (response.status !== 206) {
+        if (totalRetries <= 2) {
+          await timer(5000);
+          return this.youtubeChunkStream(path, start, end, totalRetries + 1);
+        }
+
         throw new BadBody(
           this.identifier,
-          '{}',
+          rangeReadFailure(response),
           '{}',
           'The media storage did not return the requested byte range, please try again'
         );


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix in the orchestrator/provider layer (media reads shared by all chunked uploaders).

`youtubeChunkStream`, `tiktokChunkStream` and `SocialAbstract.mediaChunk` all read the stored video back in ranged GETs and threw a non-retryable `BadBody` the moment the store answered anything other than `206`. A single such answer failed the whole post. They now retry the identical range up to three times (the existing `totalRetries` / `timer(5000)` recursion used by `SocialAbstract.fetch` and `runStreamedUpload`) before giving up, and record the real `{status, statusText, ok}` in the failure details instead of a hardcoded `'{}'`. `youtubeMediaSize` gets the same treatment for a HEAD with no `Content-Length`.

What deliberately stayed the same: the refusal itself. A non-206 body is still never fed into the upload, and once the retries are spent the failure is still a terminal `BadBody`, so genuinely broken media fails exactly as before, only with a diagnosable error.

# Why was this change needed?

## The customer case

A Postiz Cloud customer had **15 of 15** scheduled YouTube posts fail between Aug 27 and Sep 1, every one with `The media storage did not return the requested byte range, please try again` thrown from `youtubeChunkStream` -> `finalizePost`. 14 of them published successfully after simply restarting the unchanged row — same media, thumbnail, description and credentials. Their own client-side checker read the same objects successfully, with correct `206` and `Content-Range`, immediately before each restart. Two more rows from Aug 14 show the identical signature.

## It is prod-wide, and #1853 did not fix it

Querying `Post.error LIKE '%youtubeChunkStream%'` over the last 30 days: **5-10 failed posts per day, across 2-6 organizations, every single day**. The rate is flat across the merge of #1853 (2026-08-07, `d1765d40`), which added `accept-encoding: identity` to these reads on the theory that a compressed response loses its `Content-Length` and Cloudflare then answers a range request with the whole object. **That is deployed and the failures continued at the same rate**, so the header was not sufficient on its own.

We also could not tell what was actually happening, because the `BadBody` json argument was hardcoded `'{}'` — and that argument is the only field that carries response diagnostics into `Post.error` / `Errors.message`. All 15 customer rows decode to `{"identifier":"youtube","json":"{}","body":"{}"}`. Nothing reaches Sentry either: `post.activity.ts` only logs webhook failures, so a non-retryable `BadBody` goes straight to `changeState(...ERROR...)` and is never reported.

## Reproduced directly against the CDN

Issuing the worker's exact request shape (`Range: bytes=<8 MiB window>`, `accept-encoding: identity`, nothing else) against the hosted object from one of the failed rows, **two of eight consecutive requests returned HTTP 200 carrying the complete 771 MB object** — no `Content-Range`, `cf-cache-status: BYPASS` — with correct `206` responses seconds either side from the same POP. So Cloudflare in front of R2 intermittently ignores `Range` and answers with the whole file. Not offset-specific, not file-specific, not reproducible on demand.

## The fault lives only on objects too large for the cache

A sweep of **2,900 distinct production mp4 objects** (ranged GET, identity encoding) found exactly **three** with `cf-cache-status: BYPASS` — at 641.2 MB, 622.6 MB and 618.4 MB. Every other object returned `MISS` (1636), `REVALIDATED` (650) or `HIT` (211), the largest cacheable one being 299.6 MB. So the cacheability cliff sits between 299.6 MB and 618.4 MB, which brackets Cloudflare's documented [maximum cacheable file size](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/) of **512 MB** on Free/Pro/Business (5 GB on Enterprise).

Sampling with 8 MiB windows, every 200 we have ever observed was on a `BYPASS` object:

| Object | Cache status | Result |
| --- | --- | --- |
| 771 MB | BYPASS | 0 faults / 576 requests (300 random offsets + 3 sequential passes) |
| 622.6 MB | BYPASS | 1 x 200-with-full-object / 100 requests (plus 1 on a separate probe) |
| 641.2 MB | BYPASS | 0 / 100 |
| 618.4 MB | BYPASS | 0 / 100 |
| 299.6 MB | HIT (control) | 0 / 100 |

Aggregate: 1 fault in 876 requests on BYPASS objects (~0.11%), 0 in ~3,000 on cacheable ones. The rate is bursty rather than steady — the reproduction above hit 2 in 8 (25%) on a different day, two orders of magnitude higher. At the 0.11% rate a 771 MB video (92 chunks) still has roughly a 10% chance of losing at least one chunk; during a burst it is near-certain. That is consistent with 5-10 failed posts a day.

Retrying is safe here because the YouTube path is a resumable upload session: `finalizePost` probes `probeUploadSession` for the committed offset and resumes from exactly there, so re-reading a range cannot duplicate or corrupt a video. TikTok has no such probe, which is why its retry stays inside the read and still ends in `BadBody` — the caller rethrows rather than waiting on TikTok for a verdict on bytes that never arrived.

# QA

Verified end to end against a real connected YouTube channel, driving real posts through backend -> Temporal -> YouTube, with a local storage server standing in for the CDN so the 200-with-full-object answer can be injected on demand. To reproduce:

1. [ ] Point a YouTube post at a media URL served by a stand-in HTTP server that answers ranged GETs correctly, except that every third ranged request replies `200` with the full object and no `Content-Range` (the exact shape Cloudflare returns).
2. [ ] Schedule the post and let the workflow run. Expected: the upload completes and the post reaches `PUBLISHED`. In the storage log each injected `200` is followed ~5 s later by a repeat request for the *identical* byte range that returns `206`, and the upload continues from there. Observed: 4 injected 200s, all recovered, post published.
3. [ ] Switch the stand-in server to answer *every* ranged request with `200` and the full object, and schedule another post. Expected: exactly 4 attempts on the same range (initial + 3 retries) roughly 5 s apart, then the post goes to `ERROR`. Observed as described.
4. [ ] Read that failed post's error: `select error from "Post" where id = '<the post id>';`. Expected: the details now contain `{"status":200,"statusText":"OK","ok":true}` instead of the previous empty `{"json":"{}"}`, naming the answer the store actually gave.
5. [ ] Confirm no behaviour change on the happy path: schedule a post against a correctly behaving media URL and check it publishes with exactly one request per chunk and no retries in the log.
6. [ ] Re-run step 2 after the body-cancel fix (`8c4d5113`) and confirm recovery still works. Expected: the post publishes as before, and the retry following each injected `200` now returns quickly rather than always waiting the full backoff, since the socket is released instead of being held by the abandoned response. Observed: 5 injected 200s, all recovered, several retries answered in 0.2-0.7 s.

# Other information:

- **Infra follow-up, not a code change.** Since every observed 200 was on an object Cloudflare refuses to cache because it exceeds the 512 MB plan limit, raising that limit (an Enterprise setting) or keeping uploads below it would remove the population where the fault lives. Someone with access to the zone should confirm the plan and limit. Worth noting `uploads.postiz.com` already sends `cache-control: max-age=14400` on these responses and also carries a stray `location: https://postiz.com/api/success` header on both 200 and 206 answers, which suggests a rule sitting in front of the bucket.
- Supersedes #1932, which added the same `{status, statusText, ok}` diagnostics on their own. That work is folded in here as an exported `rangeReadFailure` helper shared by all three read sites, so #1932 can be closed.
- Related: #1813 introduced the two bespoke chunk readers, #1835 swept `accept-encoding: identity` across the shared helpers a day later and missed them, #1853 added it to them. A longer-term cleanup would be deleting `youtubeMediaSize` in favour of `SocialAbstract.mediaSize` and consolidating both chunk readers into a shared ranged-stream helper, which is the one shape `SocialAbstract` does not currently offer.

