### PR TITLE
fix(nostr): convert the hex private key to bytes before signing posts

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/nostr.provider.ts
@@ -71,6 +71,12 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     };
   }
 
+  private secretKey(password: string) {
+    return Uint8Array.from(
+      (password.match(/.{1,2}/g) || []).map((byte: any) => parseInt(byte, 16))
+    );
+  }
+
   private async findRelayInformation(pubkey: string) {
     // This queries ALL relays in parallel and resolves with
     // the first matching event from ANY relay.
@@ -137,11 +143,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
     try {
       const body = JSON.parse(Buffer.from(params.code, 'base64').toString());
 
-      const pubkey = getPublicKey(
-        Uint8Array.from(
-          body.password.match(/.{1,2}/g).map((byte: any) => parseInt(byte, 16))
-        )
-      );
+      const pubkey = getPublicKey(this.secretKey(body.password));
 
       const user = await this.findRelayInformation(pubkey);
 
@@ -182,7 +184,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         tags: [],
         created_at: Math.floor(Date.now() / 1000),
       },
-      password
+      this.secretKey(password)
     );
 
     const eventId = await this.publish(id, textEvent);
@@ -219,7 +221,7 @@ export class NostrProvider extends SocialAbstract implements SocialProvider {
         ],
         created_at: Math.floor(Date.now() / 1000),
       },
-      password
+      this.secretKey(password)
     );
 
     const eventId = await this.publish(id, textEvent);


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend/orchestrator, Nostr provider). In `nostr.provider.ts`, `post()` and `comment()` passed the stored hex private key **string** straight into nostr-tools' `finalizeEvent`, which requires the secret key as a `Uint8Array` — so every Nostr publish crashed with `expected Uint8Array, got type=string` (thrown inside `getPublicKey` → `abytes`). The fix adds a small `secretKey()` helper (hex → `Uint8Array`, the exact conversion `authenticate()` already did inline) and uses it in `authenticate`, `post` and `comment`. Nothing else changed: key storage format, event contents, and the relay publish flow are untouched.

# Why was this change needed?

Nostr publishing was 100% broken in production: every attempt failed with the error above (confirmed in Temporal activity failures on 2026-09-03). Because the error is a plain `Error` (not `bad_body`), the workflow retried it 3 times and then buried it under "Could not publish after several attempts" plus a misleading "we couldn't confirm your post" email — even though nothing was ever published.

# Other information:

The published post's `releaseURL` still ends in `/e/undefined` — a pre-existing quirk (`publish()` rarely captures the relay echo, so the event id comes back empty). Left out of scope to keep this a one-line-class fix; worth a follow-up now that publishing works.

# QA

1. [ ] Connect a Nostr channel (paste the account's hex private key in the credentials modal); the channel connects and shows the profile name (this path already worked)
2. [ ] Schedule a text post on that channel for a couple of minutes ahead
3. [ ] Without the fix, the post ends in ERROR ("Could not publish after several attempts"; Temporal history shows `expected Uint8Array, got type=string` on each postSocialPending attempt)
4. [ ] With the fix, the post flips to PUBLISHED and the note appears on the account (check via a Nostr client such as iris.to or primal.net, or query any of the default relays for the account's latest kind-1 event)

Tested end to end against a real connected Nostr channel: reproduced the pre-fix failure, then verified the post-fix publish — the signed event appeared on the public relays (nos.lol / damus / snort) with matching content and timestamp. Also unit-tested against the repo's nostr-tools: a string key throws exactly the production error, the converted key signs an event that passes `verifyEvent`.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyDRJpL27E7WCK5UGsUope
