### PR TITLE
fix(telegram): map Telegram 400 rejections to non-retryable BadBody errors

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
@@ -6,7 +6,10 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
-import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import {
+  BadBody,
+  SocialAbstract,
+} from '@gitroom/nestjs-libraries/integrations/social.abstract';
 //@ts-ignore
 import mime from 'mime';
 import TelegramBot from 'node-telegram-bot-api';
@@ -169,6 +172,40 @@ export class TelegramProvider extends SocialAbstract implements SocialProvider {
   }
 
   private async sendMessage(
+    accessToken: string,
+    message: PostDetails,
+    replyToMessageId?: number
+  ): Promise<number | null> {
+    try {
+      return await this.sendMessageInternal(
+        accessToken,
+        message,
+        replyToMessageId
+      );
+    } catch (error: any) {
+      // A Telegram 400 is a permanent rejection of this request (caption too
+      // long, media Telegram could not download, ...): retrying it can never
+      // succeed, so surface it to the user instead.
+      const body = error?.response?.body;
+      if (error?.code === 'ETELEGRAM' && body?.error_code === 400) {
+        const description = (body.description || '').replace(
+          'Bad Request: ',
+          ''
+        );
+        throw new BadBody(
+          'telegram-error',
+          JSON.stringify(body),
+          Buffer.from(JSON.stringify(body)),
+          description === 'failed to get HTTP URL content'
+            ? 'Telegram could not download your media file, please check the file and try again'
+            : `Telegram rejected the post: ${description}`
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async sendMessageInternal(
     accessToken: string,
     message: PostDetails,
     replyToMessageId?: number


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend/orchestrator, Telegram provider). In `telegram.provider.ts`, `sendMessage` now wraps the send in a try/catch that maps node-telegram-bot-api errors with `code === 'ETELEGRAM'` and `error_code === 400` to a non-retryable `BadBody` (identifier `telegram-error`, raw Telegram response preserved in the failure details), with a human message: "Telegram could not download your media file, please check the file and try again" for `failed to get HTTP URL content`, and "Telegram rejected the post: <description>" for every other 400. Both `post` and `comment` go through this path. Deliberately unchanged: non-400 errors (including 429 rate limits and network failures) still propagate as before and remain retryable, and the send logic itself (`sendMessageInternal`) is untouched.

# Why was this change needed?

Telegram 400s are permanent rejections of the request, but they surfaced as plain errors the post workflow classifies as unknown: it retried them 3 times, then recorded "Could not publish after several attempts" and sent the "we couldn't confirm your post" email — wrong on both counts, since retrying a 400 can never succeed and nothing was ever published. Seen in production on 2026-09-03: several Telegram posts failed this way with `ETELEGRAM: 400 Bad Request: message caption is too long` and `ETELEGRAM: 400 Bad Request: failed to get HTTP URL content` on every attempt (visible only in the Temporal activity failures, never to the user). This aligns Telegram with the existing provider convention (Instagram, TikTok, GMB) of mapping permanent platform rejections to `BadBody`.

# Other information:

The caption-too-long case will additionally be prevented at composition time by #1947 (Telegram 1024-char caption limit); this mapping still covers it until then and keeps the honest error for anything that slips through. Converting the provider to multipart upload (pushing bytes instead of having Telegram fetch the URL, which would eliminate the `failed to get HTTP URL content` class entirely) is under team discussion and intentionally out of scope here.

# QA

1. [ ] Connect a Telegram channel and create a post on it with one image attached and a caption longer than 1024 characters
2. [ ] Publish it (Post now or a near-future schedule)
3. [ ] Without the fix, the post retries 3 times and ends in ERROR with "Could not publish after several attempts", plus a "We couldn't confirm your post on Telegram" email
4. [ ] With the fix, the post fails after a single attempt with "Telegram rejected the post: message caption is too long", and the in-app/email notification is the regular "Error posting on telegram" one
5. [ ] Optional: in the Temporal UI, the workflow history shows one postSocialPending attempt with retryState NON_RETRYABLE_FAILURE

Tested end to end against a real connected Telegram channel: the caption-too-long post failed once (single postSocialPending in the Temporal history, retryState NON_RETRYABLE_FAILURE) with the mapped message and the bad-body notification path. The media-fetch branch goes through the same mapped code path but was not triggered live, since it requires Telegram's own fetcher to fail against a valid media URL.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyDRJpL27E7WCK5UGsUope
