### PR TITLE
fix(auth): prefer an org with a subscription as the default active org

### DIFF
--- a/apps/backend/src/services/auth/auth.middleware.ts
+++ b/apps/backend/src/services/auth/auth.middleware.ts
@@ -105,7 +105,9 @@ export class AuthMiddleware implements NestMiddleware {
         await this._organizationService.getOrgsByUserId(user.id)
       ).filter((f) => !f.users[0].disabled);
       const setOrg =
-        organization.find((org) => org.id === orgHeader) || organization[0];
+        organization.find((org) => org.id === orgHeader) ||
+        organization.find((org) => org.subscription) ||
+        organization[0];
 
       if (!organization) {
         throw new HttpForbiddenException();


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, auth middleware). When no `showorg` cookie is present (or it no longer matches one of the user's orgs), `AuthMiddleware` in `apps/backend/src/services/auth/auth.middleware.ts` picked `organization[0]` from an unordered `getOrgsByUserId` query as the active org. It now prefers an org that has a subscription before falling back to the first one. An explicit `showorg` cookie still wins, the org switcher and every other path are unchanged, and there is no schema change.

# Why was this change needed?

A team member who accepts an invite also owns the empty personal org that signup auto-creates. With no cookie, the fallback is effectively random, so on a fresh login they can land in their own free org behind the paywall instead of the paid team org they just joined.

This is what happened in a support case on 2026-08-26: three people invited to a Team-plan org all joined successfully via the invite link (memberships and invite ids present in the DB), yet each reported that the app was "asking them to pay". They were being dropped into their personal org and had to discover the org switcher to get to the team.

With this change, a user without a persisted cookie lands in the subscribed org, which is the one they can actually use. Users with a single org, or with a cookie, see no difference.

# Other information:

#1745 (persist the last selected org on the user) will be restacked on top of this branch. It adds a persisted `lastSelectedOrgId` lookup between the cookie and this tiebreak, and needs a schema change, so it ships separately.

Verified locally against the running middleware with a user in two orgs (personal org created first, team org with a subscription created second): before the change the self endpoint returned the personal FREE org; after it returned the TEAM org; with a `showorg` cookie pointing at the personal org it returned the personal org.

# QA

1. [ ] Create user A with a paid org (any org with a `Subscription` row) and user B with a fresh account, so B owns an empty personal org.
2. [ ] As A, invite B from Settings > Teams and, as B, accept the invite so B is a member of both orgs.
3. [ ] As B, log out, clear cookies for the app domain, and log in again.
4. [ ] B should land in A's paid org (the org switcher in the top right shows it selected) instead of the empty personal org with the billing prompt.
5. [ ] As B, switch to the personal org via the org switcher and reload: the personal org stays selected, so the cookie still takes precedence.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
