### PR TITLE
fix(auth): align invite and showorg cookie lifetimes with the token expiry

### DIFF
--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -122,7 +122,7 @@ export async function proxy(request: NextRequest) {
               domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
             }
           : {}),
-        expires: new Date(Date.now() + 15 * 60 * 1000),
+        expires: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
       });
       return redirect;
     }
@@ -152,7 +152,7 @@ export async function proxy(request: NextRequest) {
                 domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
               }
             : {}),
-          expires: new Date(Date.now() + 15 * 60 * 1000),
+          expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
         });
       }
       return redirect;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, Next proxy). Two cookie lifetimes in `apps/frontend/src/proxy.ts` change: the `org` cookie that parks the team-invite token while a logged-out visitor goes through login/signup goes from 15 minutes to 2 days, matching the invite link's own expiry from #1643; the `showorg` cookie written after a logged-in user joins an org via the invite link goes from 15 minutes to 365 days, matching what the backend already sets for `showorg` on register, login and change-org. Nothing else in the proxy or the invite flow changes.

# Why was this change needed?

The invite link is valid for 2 days, but once clicked the token only survived 15 minutes in the `org` cookie. An invitee who opened the link, got redirected to the login page, and finished signing up later than that got a plain personal account with no membership, even though their link was still valid. They then had to ask for the invite to be resent.

Similarly, an existing user who joined via the link had the joined org selected for only 15 minutes; after that a reload fell back to the default org, which for a member with an empty personal org means the billing prompt.

Both showed up in a support case on 2026-08-26 where several invitees of a Team-plan org reported not finding or being able to use their invites and being asked to pay. This is complementary to #1643, which extended the token itself, and to the default-org tiebreak in the sibling PR.

# Other information:

Verified locally against the Next proxy and backend: for a logged-out visitor opening the invite URL, the `org` cookie's Expires header moved from 15 minutes to 2 days; registering a new email+password user with that cookie added them to the inviting org with the invite id recorded. For a logged-in non-member opening the invite URL, the `showorg` cookie's Expires header is now 365 days and the user was added to the org. Google sign-in was not exercised.

# QA

1. [ ] As an org owner, invite a new email address from Settings > Teams (send email on).
2. [ ] In a logged-out browser, open the invite link; you land on the login page. In devtools, check the `org` cookie: it should expire about 2 days out (previously 15 minutes).
3. [ ] Wait more than 15 minutes, then register with the invited email address.
4. [ ] The new user should be a member of the inviting org (visible in the owner's Settings > Teams) rather than only owning a fresh personal org.
5. [ ] Invite a second address that already has a Postiz account. Log in as that user first, then open the invite link.
6. [ ] You are redirected to the dashboard with the inviting org selected. In devtools the `showorg` cookie should expire about a year out; after more than 15 minutes a reload keeps the inviting org selected.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.
