### PR TITLE
fix: keep the original file name on API, MCP and agent uploads

### DIFF
--- a/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
+++ b/apps/backend/src/public-api/routes/v1/public.integrations.controller.ts
@@ -94,11 +94,13 @@ export class PublicIntegrationsController {
       throw new HttpException({ msg: 'No file provided' }, 400);
     }
 
+    const originalName = file.originalname;
     const getFile = await this.storage.uploadFile(file);
     return this._mediaService.saveFile(
       org.id,
       getFile.originalname,
-      getFile.path
+      getFile.path,
+      originalName
     );
   }
 
@@ -162,7 +164,8 @@ export class PublicIntegrationsController {
     return this._mediaService.saveFile(
       org.id,
       getFile.originalname,
-      getFile.path
+      getFile.path,
+      new URL(body.url).pathname.split('/').pop() || undefined
     );
   }
 

--- a/apps/frontend/src/components/media/media.component.tsx
+++ b/apps/frontend/src/components/media/media.component.tsx
@@ -559,7 +559,12 @@ export const MediaBox: FC<{
                         onClick={deleteImage(media)}
                       />
                     )}
-                    <div className="absolute bottom-[10px] end-[10px] z-[100]">{media.originalName}</div>
+                    <div
+                      className="absolute bottom-[10px] start-[10px] end-[10px] z-[100] truncate"
+                      title={media.originalName}
+                    >
+                      {media.originalName}
+                    </div>
                     <div className="w-full h-full rounded-[6px] overflow-hidden relative">
                       <div className="absolute z-[20] left-[50%] top-[50%] -translate-x-[50%] -translate-y-[50%]">
                         <div

--- a/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
+++ b/libraries/nestjs-libraries/src/agent/agent.graph.service.ts
@@ -347,7 +347,10 @@ export class AgentGraphService {
           const uploadWithId = await this._mediaService.saveFile(
             state.orgId,
             name,
-            upload
+            upload,
+            p.image.startsWith('data:')
+              ? undefined
+              : new URL(p.image).pathname.split('/').pop() || undefined
           );
 
           return {

--- a/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
+++ b/libraries/nestjs-libraries/src/chat/tools/upload.from.url.tool.ts
@@ -118,7 +118,8 @@ so the attachment passes the upload-domain validation. Returns the hosted media 
           return await this._mediaService.saveFile(
             org.id,
             getFile.originalname,
-            getFile.path
+            getFile.path,
+            new URL(inputData.url).pathname.split('/').pop() || undefined
           );
         } catch (err) {
           // undici's fetch rejects with a generic TypeError('fetch failed')


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend public API, MCP tool, chat agent) plus a small frontend tweak (Media tab tile).
`MediaService.saveFile` accepts an `originalName` argument, but only the web-app upload passed it. Every other upload path (`POST /public/v1/upload`, `POST /public/v1/upload-from-url`, the MCP `uploadFromUrlTool`, and the chat agent's image upload in `agent.graph.service.ts`) now passes it too: the incoming `file.originalname` for multipart, or the URL's last path segment (query string and hash stripped) for URL-based uploads. Storage naming, the schema, existing rows and the media list endpoints are unchanged.
On the Media tab, the tile name now truncates with an ellipsis and shows the full name on hover instead of overflowing into neighbouring tiles.

# Why was this change needed?

A customer who uploads all of their videos through the Postiz agent (MCP) reported that videos in the Media tab show no file name at all, so they cannot tell dozens of similar thumbnails apart, and asked for a way to map their original file names to Postiz media so the agent can find a video by name. The name was simply never stored for API-driven uploads. With this change it is stored the same way as for web-app uploads, so it renders in the Media tab and becomes searchable via the media list search by `originalName`.

# Other information:

URL-derived names are not percent-decoded on purpose: `decodeURIComponent` throws on malformed escapes and in the public API path that would fail after the file was already uploaded to storage. Rows uploaded before this change keep a null name; no backfill.

# QA

1. [ ] With a public API key, run `curl -F "file=@./my-test-video.mp4" -H "Authorization: <key>" <backend>/public/v1/upload` and confirm the response and the new `Media` row have `originalName` = `my-test-video.mp4`.
2. [ ] `POST <backend>/public/v1/upload-from-url` with `{"url":"https://<host>/path/sample-clip.mp4"}`; expect `originalName` = `sample-clip.mp4`.
3. [ ] Repeat with `.../sample-clip.mp4?token=abc#frag`; expect `sample-clip.mp4` (query and hash dropped).
4. [ ] Call the MCP `uploadFromUrlTool` with the URL from step 2; expect the same `originalName` on the created row.
5. [ ] Open the Media tab: the new tiles show their names, long names end with an ellipsis, and hovering a tile shows the full name. Rows uploaded before this change still show no name.
6. [ ] Upload a file through the Media tab's Upload button; its name still shows as before.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113mrwSKBb9jhocwHmgxpJJ
