### PR TITLE
Add media folder management

### DIFF
--- a/apps/backend/src/api/routes/media.controller.ts
+++ b/apps/backend/src/api/routes/media.controller.ts
@@ -25,6 +25,9 @@ import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
 import { SaveMediaInformationDto } from '@gitroom/nestjs-libraries/dtos/media/save.media.information.dto';
 import { VideoDto } from '@gitroom/nestjs-libraries/dtos/videos/video.dto';
 import { VideoFunctionDto } from '@gitroom/nestjs-libraries/dtos/videos/video.function.dto';
+import { CreateMediaFolderDto } from '@gitroom/nestjs-libraries/dtos/media/create.media.folder.dto';
+import { RenameMediaFolderDto } from '@gitroom/nestjs-libraries/dtos/media/rename.media.folder.dto';
+import { MoveMediaDto } from '@gitroom/nestjs-libraries/dtos/media/move.media.dto';
 
 @ApiTags('Media')
 @Controller('/media')
@@ -32,7 +35,7 @@ export class MediaController {
   private storage = UploadFactory.createStorage();
   constructor(
     private _mediaService: MediaService,
-    private _subscriptionService: SubscriptionService
+    private _subscriptionService: SubscriptionService,
   ) {}
 
   @Delete('/:id')
@@ -43,7 +46,7 @@ export class MediaController {
   @Post('/generate-video')
   generateVideo(
     @GetOrgFromRequest() org: Organization,
-    @Body() body: VideoDto
+    @Body() body: VideoDto,
   ) {
     console.log('hello');
     return this._mediaService.generateVideo(org, body);
@@ -54,7 +57,7 @@ export class MediaController {
     @GetOrgFromRequest() org: Organization,
     @Req() req: Request,
     @Body('prompt') prompt: string,
-    isPicturePrompt = false
+    isPicturePrompt = false,
   ) {
     const total = await this._subscriptionService.checkCredits(org);
     if (process.env.STRIPE_PUBLISHABLE_KEY && total.credits <= 0) {
@@ -72,7 +75,7 @@ export class MediaController {
   async generateImageFromText(
     @GetOrgFromRequest() org: Organization,
     @Req() req: Request,
-    @Body('prompt') prompt: string
+    @Body('prompt') prompt: string,
   ) {
     const image = await this.generateImage(org, req, prompt, true);
     if (!image) {
@@ -89,7 +92,7 @@ export class MediaController {
   @UsePipes(new CustomFileValidationPipe())
   async uploadServer(
     @GetOrgFromRequest() org: Organization,
-    @UploadedFile() file: Express.Multer.File
+    @UploadedFile() file: Express.Multer.File,
   ) {
     const originalName = file?.originalname || '';
     const uploadedFile = await this.storage.uploadFile(file);
@@ -97,7 +100,7 @@ export class MediaController {
       org.id,
       uploadedFile.originalname,
       uploadedFile.path,
-      originalName
+      originalName,
     );
   }
 
@@ -106,7 +109,7 @@ export class MediaController {
     @GetOrgFromRequest() org: Organization,
     @Req() req: Request,
     @Body('name') name: string,
-    @Body('originalName') originalName: string
+    @Body('originalName') originalName: string,
   ) {
     if (!name) {
       return false;
@@ -115,14 +118,14 @@ export class MediaController {
       org.id,
       name,
       process.env.CLOUDFLARE_BUCKET_URL + '/' + name,
-      originalName || undefined
+      originalName || undefined,
     );
   }
 
   @Post('/information')
   saveMediaInformation(
     @GetOrgFromRequest() org: Organization,
-    @Body() body: SaveMediaInformationDto
+    @Body() body: SaveMediaInformationDto,
   ) {
     return this._mediaService.saveMediaInformation(org.id, body);
   }
@@ -133,7 +136,7 @@ export class MediaController {
   async uploadSimple(
     @GetOrgFromRequest() org: Organization,
     @UploadedFile('file') file: Express.Multer.File,
-    @Body('preventSave') preventSave: string = 'false'
+    @Body('preventSave') preventSave: string = 'false',
   ) {
     const originalName = file.originalname;
     const getFile = await this.storage.uploadFile(file);
@@ -147,8 +150,46 @@ export class MediaController {
       org.id,
       getFile.originalname,
       getFile.path,
-      originalName
+      originalName,
     );
+  }
+
+  @Get('/folders')
+  getFolders(@GetOrgFromRequest() org: Organization) {
+    return this._mediaService.getFolders(org.id);
+  }
+
+  @Post('/folders')
+  createFolder(
+    @GetOrgFromRequest() org: Organization,
+    @Body() body: CreateMediaFolderDto,
+  ) {
+    return this._mediaService.createFolder(org.id, body);
+  }
+
+  @Post('/folders/:id')
+  renameFolder(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string,
+    @Body() body: RenameMediaFolderDto,
+  ) {
+    return this._mediaService.renameFolder(org.id, id, body);
+  }
+
+  @Delete('/folders/:id')
+  deleteFolder(
+    @GetOrgFromRequest() org: Organization,
+    @Param('id') id: string,
+  ) {
+    return this._mediaService.deleteFolder(org.id, id);
+  }
+
+  @Post('/move')
+  moveMedia(
+    @GetOrgFromRequest() org: Organization,
+    @Body() body: MoveMediaDto,
+  ) {
+    return this._mediaService.moveMedia(org.id, body.id, body.folderId);
   }
 
   @Post('/:endpoint')
@@ -156,7 +197,7 @@ export class MediaController {
     @GetOrgFromRequest() org: Organization,
     @Req() req: Request,
     @Res() res: Response,
-    @Param('endpoint') endpoint: string
+    @Param('endpoint') endpoint: string,
   ) {
     const upload = await handleR2Upload(endpoint, req, res);
     if (endpoint !== 'complete-multipart-upload') {
@@ -172,7 +213,7 @@ export class MediaController {
       name,
       // @ts-ignore
       upload.Location,
-      originalName || undefined
+      originalName || undefined,
     );
 
     res.status(200).json({ ...upload, saved: saveFile });
@@ -182,9 +223,10 @@ export class MediaController {
   getMedia(
     @GetOrgFromRequest() org: Organization,
     @Query('page') page: number,
-    @Query('search') search?: string
+    @Query('search') search?: string,
+    @Query('folderId') folderId?: string,
   ) {
-    return this._mediaService.getMedia(org.id, page, search);
+    return this._mediaService.getMedia(org.id, page, search, folderId);
   }
 
   @Get('/video-options')
@@ -193,16 +235,18 @@ export class MediaController {
   }
 
   @Post('/video/function')
-  videoFunction(
-    @Body() body: VideoFunctionDto
-  ) {
-    return this._mediaService.videoFunction(body.identifier, body.functionName, body.params);
+  videoFunction(@Body() body: VideoFunctionDto) {
+    return this._mediaService.videoFunction(
+      body.identifier,
+      body.functionName,
+      body.params,
+    );
   }
 
   @Get('/generate-video/:type/allowed')
   generateVideoAllowed(
     @GetOrgFromRequest() org: Organization,
-    @Param('type') type: string
+    @Param('type') type: string,
   ) {
     return this._mediaService.generateVideoAllowed(org, type);
   }

--- a/apps/frontend/src/components/media/media.component.tsx
+++ b/apps/frontend/src/components/media/media.component.tsx
@@ -53,8 +53,9 @@ import { useLaunchStore } from '@gitroom/frontend/components/new-launch/store';
 import { useShallow } from 'zustand/react/shallow';
 import { LoadingComponent } from '@gitroom/frontend/components/layout/loading';
 import { useDebounce } from 'use-debounce';
+import { MediaFoldersSidebar } from '@gitroom/frontend/components/media/media.folders';
 const Polonto = dynamic(
-  () => import('@gitroom/frontend/components/launches/polonto')
+  () => import('@gitroom/frontend/components/launches/polonto'),
 );
 const showModalEmitter = new EventEmitter();
 export const Pagination: FC<{
@@ -144,7 +145,7 @@ export const Pagination: FC<{
                 'cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border hover:bg-forth h-10 w-10 hover:text-white border-newBorder',
                 current === item - 1
                   ? 'bg-forth !text-white'
-                  : 'text-textColor hover:text-white'
+                  : 'text-textColor hover:text-white',
               )}
             >
               {item}
@@ -154,7 +155,7 @@ export const Pagination: FC<{
       ))}
       <li
         className={clsx(
-          current + 1 === totalPages && 'opacity-20 pointer-events-none'
+          current + 1 === totalPages && 'opacity-20 pointer-events-none',
         )}
       >
         <a
@@ -167,6 +168,36 @@ export const Pagination: FC<{
         </a>
       </li>
     </ul>
+  );
+};
+const MoveToFolderControl: FC<{
+  media: any;
+  moveToFolder: (folderId: string) => void;
+}> = ({ media, moveToFolder }) => {
+  const fetch = useFetch();
+  const t = useT();
+  const loadFolders = useCallback(async () => {
+    return (await fetch('/media/folders')).json();
+  }, []);
+  const { data: folders } = useSWR('get-media-folders', loadFolders);
+  if (!folders?.length) return null;
+  return (
+    <select
+      value={media.folderId || ''}
+      onClick={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        e.stopPropagation();
+        moveToFolder(e.target.value);
+      }}
+      className="absolute top-[5px] start-[5px] z-[100] hidden group-hover:block text-[10px] bg-black/60 text-white rounded-[4px] outline-none max-w-[80px]"
+    >
+      <option value="">{t('no_folder', 'No folder')}</option>
+      {folders.map((folder: any) => (
+        <option key={folder.id} value={folder.id}>
+          {folder.name}
+        </option>
+      ))}
+    </select>
   );
 };
 export const ShowMediaBoxModal: FC = () => {
@@ -194,7 +225,7 @@ export const ShowMediaBoxModal: FC = () => {
   );
 };
 export const showMediaBox = (
-  callback: (params: { id: string; path: string }) => void
+  callback: (params: { id: string; path: string }) => void,
 ) => {
   showModalEmitter.emit('show-modal', callback);
 };
@@ -209,22 +240,36 @@ export const MediaBox: FC<{
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState('');
   const [debouncedSearch] = useDebounce(search, 300);
+  const [selectedFolder, setSelectedFolder] = useState<string | undefined>();
   const fetch = useFetch();
   const modals = useModals();
   const toaster = useToaster();
   useEffect(() => {
     setPage(0);
-  }, [debouncedSearch]);
+  }, [debouncedSearch, selectedFolder]);
   const loadMedia = useCallback(async () => {
     const params = new URLSearchParams({ page: String(page + 1) });
     if (debouncedSearch.trim()) {
       params.set('search', debouncedSearch.trim());
     }
+    if (selectedFolder) {
+      params.set('folderId', selectedFolder);
+    }
     return (await fetch(`/media?${params.toString()}`)).json();
-  }, [page, debouncedSearch]);
+  }, [page, debouncedSearch, selectedFolder]);
   const { data, mutate, isLoading } = useSWR(
-    `get-media-${page}-${debouncedSearch}`,
-    loadMedia
+    `get-media-${page}-${debouncedSearch}-${selectedFolder}`,
+    loadMedia,
+  );
+  const moveToFolder = useCallback(
+    (media: Media) => async (folderId: string) => {
+      await fetch('/media/move', {
+        method: 'POST',
+        body: JSON.stringify({ id: media.id, folderId: folderId || undefined }),
+      });
+      mutate();
+    },
+    [mutate],
   );
   const [selected, setSelected] = useState([]);
   const t = useT();
@@ -237,8 +282,8 @@ export const MediaBox: FC<{
       type == 'image'
         ? 'image/*'
         : type == 'video'
-        ? 'video/mp4'
-        : 'image/*,video/mp4',
+          ? 'video/mp4'
+          : 'image/*,video/mp4',
     onUploadSuccess: async (arr) => {
       await mutate();
       if (standalone) {
@@ -264,7 +309,7 @@ export const MediaBox: FC<{
       }
       setSelected([...selected, media]);
     },
-    [selected]
+    [selected],
   );
 
   const addMedia = useCallback(async () => {
@@ -285,9 +330,9 @@ export const MediaBox: FC<{
         toaster.show(
           t(
             'upload_size_limit_exceeded',
-            'Upload size limit exceeded. Maximum 1 GB per upload session.'
+            'Upload size limit exceeded. Maximum 1 GB per upload session.',
           ),
-          'warning'
+          'warning',
         );
         return;
       }
@@ -297,7 +342,7 @@ export const MediaBox: FC<{
       // @ts-ignore
       uppy.addFiles(files);
     },
-    [toaster, t]
+    [toaster, t],
   );
 
   const dragAndDrop = useCallback(
@@ -328,9 +373,9 @@ export const MediaBox: FC<{
         toaster.show(
           t(
             'upload_size_limit_exceeded',
-            'Upload size limit exceeded. Maximum 1 GB per upload session.'
+            'Upload size limit exceeded. Maximum 1 GB per upload session.',
           ),
-          'warning'
+          'warning',
         );
         return;
       }
@@ -341,7 +386,7 @@ export const MediaBox: FC<{
         uppy.addFile(file);
       }
     },
-    [toaster, t]
+    [toaster, t],
   );
 
   const maximize = useCallback(
@@ -370,7 +415,7 @@ export const MediaBox: FC<{
         ),
       });
     },
-    []
+    [],
   );
 
   const deleteImage = useCallback(
@@ -380,8 +425,8 @@ export const MediaBox: FC<{
         !(await deleteDialog(
           t(
             'are_you_sure_you_want_to_delete_the_image',
-            'Are you sure you want to delete the image?'
-          )
+            'Are you sure you want to delete the image?',
+          ),
         ))
       ) {
         return;
@@ -391,7 +436,7 @@ export const MediaBox: FC<{
       });
       mutate();
     },
-    [mutate]
+    [mutate],
   );
 
   const btn = useMemo(() => {
@@ -408,13 +453,23 @@ export const MediaBox: FC<{
         ) : (
           <PlusIcon size={14} />
         )}
-        <div className={loading ? 'invisible' : undefined}>{t('upload', 'Upload')}</div>
+        <div className={loading ? 'invisible' : undefined}>
+          {t('upload', 'Upload')}
+        </div>
       </button>
     );
   }, [t, loading]);
 
   return (
-    <DropFiles disabled={loading} className="flex flex-col flex-1" onDrop={dragAndDrop}>
+    <DropFiles
+      disabled={loading}
+      className="flex flex-row flex-1"
+      onDrop={dragAndDrop}
+    >
+      <MediaFoldersSidebar
+        selectedFolder={selectedFolder}
+        setSelectedFolder={setSelectedFolder}
+      />
       <div className="flex flex-col flex-1">
         <div
           className={clsx(
@@ -422,7 +477,7 @@ export const MediaBox: FC<{
             !isLoading &&
               !data?.results?.length &&
               !debouncedSearch &&
-              'hidden'
+              'hidden',
           )}
         >
           <div className="flex-1">
@@ -467,7 +522,7 @@ export const MediaBox: FC<{
             'flex-1 relative',
             !isLoading &&
               !data?.results?.length &&
-              'bg-newTextColor/[0.02] rounded-[12px]'
+              'bg-newTextColor/[0.02] rounded-[12px]',
           )}
         >
           <div
@@ -475,7 +530,7 @@ export const MediaBox: FC<{
               'absolute -left-[3px] -top-[3px] withp3 h-full overflow-x-hidden overflow-y-auto scrollbar scrollbar-thumb-newColColor scrollbar-track-newBgColorInner',
               !isLoading &&
                 !data?.results?.length &&
-                'flex justify-center items-center gap-[20px] flex-col'
+                'flex justify-center items-center gap-[20px] flex-col',
             )}
           >
             {!isLoading && !data?.results?.length && (
@@ -483,24 +538,21 @@ export const MediaBox: FC<{
                 <NoMediaIcon />
                 <div className="text-[20px] font-[600]">
                   {debouncedSearch
-                    ? t(
-                        'no_media_match_search',
-                        'No media matches your search'
-                      )
+                    ? t('no_media_match_search', 'No media matches your search')
                     : t(
                         'you_dont_have_any_media_yet',
-                        "You don't have any media yet"
+                        "You don't have any media yet",
                       )}
                 </div>
                 <div className="whitespace-pre-line text-newTextColor/[0.6] text-center">
                   {t(
                     'select_or_upload_pictures_max_1gb',
-                    'Select or upload pictures (maximum 1 GB per upload).'
+                    'Select or upload pictures (maximum 1 GB per upload).',
                   )}{' '}
                   {'\n'}
                   {t(
                     'you_can_drag_drop_pictures',
-                    'You can also drag & drop pictures.'
+                    'You can also drag & drop pictures.',
                   )}
                 </div>
                 <div className="forceChange flex gap-[8px]">
@@ -514,7 +566,7 @@ export const MediaBox: FC<{
                 {[...new Array(16)].map((_, i) => (
                   <div
                     className={clsx(
-                      'px-[3px] py-[3px] float-left rounded-[6px] cursor-pointer w8-max aspect-square'
+                      'px-[3px] py-[3px] float-left rounded-[6px] cursor-pointer w8-max aspect-square',
                     )}
                     key={i}
                   >
@@ -536,7 +588,7 @@ export const MediaBox: FC<{
                 <div
                   className={clsx(
                     'group px-[3px] py-[3px] float-left rounded-[6px] w8-max aspect-square',
-                    !standalone && 'cursor-pointer'
+                    !standalone && 'cursor-pointer',
                   )}
                   key={media.id}
                 >
@@ -545,7 +597,7 @@ export const MediaBox: FC<{
                       'w-full h-full rounded-[6px] border-[4px] relative',
                       !!selected.find((p) => p.id === media.id)
                         ? 'border-[#612BD3]'
-                        : 'border-transparent'
+                        : 'border-transparent',
                     )}
                     onClick={addRemoveSelected(media)}
                   >
@@ -559,7 +611,13 @@ export const MediaBox: FC<{
                         onClick={deleteImage(media)}
                       />
                     )}
-                    <div className="absolute bottom-[10px] end-[10px] z-[100]">{media.originalName}</div>
+                    <div className="absolute bottom-[10px] end-[10px] z-[100]">
+                      {media.originalName}
+                    </div>
+                    <MoveToFolderControl
+                      media={media}
+                      moveToFolder={moveToFolder(media)}
+                    />
                     <div className="w-full h-full rounded-[6px] overflow-hidden relative">
                       <div className="absolute z-[20] left-[50%] top-[50%] -translate-x-[50%] -translate-y-[50%]">
                         <div
@@ -697,7 +755,7 @@ export const MultiMediaComponent: FC<{
         | {
             path: string;
             id: string;
-          }[]
+          }[],
     ) => {
       const mediaArray = Array.isArray(m) ? m : [m];
       const newMedia = [...(currentMedia || []), ...mediaArray];
@@ -709,7 +767,7 @@ export const MultiMediaComponent: FC<{
         },
       });
     },
-    [currentMedia]
+    [currentMedia],
   );
   const showModal = useCallback(() => {
     modals.openModal({
@@ -736,7 +794,7 @@ export const MultiMediaComponent: FC<{
         },
       });
     },
-    [currentMedia]
+    [currentMedia],
   );
 
   const designMedia = useCallback(() => {
@@ -768,57 +826,60 @@ export const MultiMediaComponent: FC<{
               handle=".dragging"
             >
               {currentMedia.map((media, index) => (
-                  <div key={media.id} className="cursor-pointer rounded-[5px] w-[40px] h-[40px] border-2 border-tableBorder relative flex transition-all">
-                    <DragHandleIcon className="z-[20] dragging absolute pe-[1px] pb-[3px] -start-[4px] -top-[4px] cursor-move" />
+                <div
+                  key={media.id}
+                  className="cursor-pointer rounded-[5px] w-[40px] h-[40px] border-2 border-tableBorder relative flex transition-all"
+                >
+                  <DragHandleIcon className="z-[20] dragging absolute pe-[1px] pb-[3px] -start-[4px] -top-[4px] cursor-move" />
 
-                    <div className="w-full h-full relative group">
-                      <div
-                        onClick={async () => {
-                          modals.openModal({
-                            title: t('media_settings', 'Media Settings'),
-                            children: (close) => (
-                              <MediaComponentInner
-                                media={media as any}
-                                onClose={close}
-                                onSelect={(value: any) => {
-                                  onChange({
-                                    target: {
-                                      name: 'upload',
-                                      value: currentMedia.map((p) => {
-                                        if (p.id === media.id) {
-                                          return {
-                                            ...p,
-                                            ...value,
-                                          };
-                                        }
-                                        return p;
-                                      }),
-                                    },
-                                  });
-                                }}
-                              />
-                            ),
-                          });
-                        }}
-                        className="absolute top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] bg-black/80 rounded-[10px] opacity-0 group-hover:opacity-100 transition-opacity z-[9]"
-                      >
-                        <MediaSettingsIcon className="cursor-pointer relative z-[200]" />
-                      </div>
-                      {hasExtension(media?.path, 'mp4') ? (
-                        <VideoFrame url={mediaDirectory.set(media?.path)} />
-                      ) : (
-                        <img
-                          className="w-full h-full object-cover rounded-[4px]"
-                          src={mediaDirectory.set(media?.path)}
-                        />
-                      )}
+                  <div className="w-full h-full relative group">
+                    <div
+                      onClick={async () => {
+                        modals.openModal({
+                          title: t('media_settings', 'Media Settings'),
+                          children: (close) => (
+                            <MediaComponentInner
+                              media={media as any}
+                              onClose={close}
+                              onSelect={(value: any) => {
+                                onChange({
+                                  target: {
+                                    name: 'upload',
+                                    value: currentMedia.map((p) => {
+                                      if (p.id === media.id) {
+                                        return {
+                                          ...p,
+                                          ...value,
+                                        };
+                                      }
+                                      return p;
+                                    }),
+                                  },
+                                });
+                              }}
+                            />
+                          ),
+                        });
+                      }}
+                      className="absolute top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] bg-black/80 rounded-[10px] opacity-0 group-hover:opacity-100 transition-opacity z-[9]"
+                    >
+                      <MediaSettingsIcon className="cursor-pointer relative z-[200]" />
                     </div>
-
-                    <CloseCircleIcon
-                      onClick={clearMedia(index)}
-                      className="absolute -end-[4px] -top-[4px] z-[20] rounded-full bg-white"
-                    />
+                    {hasExtension(media?.path, 'mp4') ? (
+                      <VideoFrame url={mediaDirectory.set(media?.path)} />
+                    ) : (
+                      <img
+                        className="w-full h-full object-cover rounded-[4px]"
+                        src={mediaDirectory.set(media?.path)}
+                      />
+                    )}
                   </div>
+
+                  <CloseCircleIcon
+                    onClick={clearMedia(index)}
+                    className="absolute -end-[4px] -top-[4px] z-[20] rounded-full bg-white"
+                  />
+                </div>
               ))}
             </ReactSortable>
           )}

--- a/apps/frontend/src/components/media/media.folders.tsx
+++ b/apps/frontend/src/components/media/media.folders.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { FC, useCallback, useState } from 'react';
+import useSWR from 'swr';
+import clsx from 'clsx';
+import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
+import { deleteDialog } from '@gitroom/react/helpers/delete.dialog';
+import { useT } from '@gitroom/react/translation/get.transation.service.client';
+
+export interface MediaFolder {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
+export const MediaFoldersSidebar: FC<{
+  selectedFolder?: string;
+  setSelectedFolder: (folderId?: string) => void;
+}> = ({ selectedFolder, setSelectedFolder }) => {
+  const fetch = useFetch();
+  const t = useT();
+  const [creating, setCreating] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+  const [renamingId, setRenamingId] = useState<string | undefined>();
+  const [renameValue, setRenameValue] = useState('');
+
+  const loadFolders = useCallback(async () => {
+    return (await fetch('/media/folders')).json();
+  }, []);
+
+  const { data: folders, mutate } = useSWR<MediaFolder[]>(
+    'get-media-folders',
+    loadFolders,
+  );
+
+  const createFolder = useCallback(async () => {
+    const name = newFolderName.trim();
+    if (!name) {
+      setCreating(false);
+      return;
+    }
+    await fetch('/media/folders', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+    setNewFolderName('');
+    setCreating(false);
+    mutate();
+  }, [newFolderName, mutate]);
+
+  const renameFolder = useCallback(
+    async (id: string) => {
+      const name = renameValue.trim();
+      setRenamingId(undefined);
+      if (!name) {
+        return;
+      }
+      await fetch(`/media/folders/${id}`, {
+        method: 'POST',
+        body: JSON.stringify({ name }),
+      });
+      mutate();
+    },
+    [renameValue, mutate],
+  );
+
+  const deleteFolder = useCallback(
+    (id: string) => async () => {
+      if (
+        !(await deleteDialog(
+          t(
+            'are_you_sure_you_want_to_delete_the_folder',
+            'Are you sure you want to delete the folder? Media inside will not be deleted.',
+          ),
+        ))
+      ) {
+        return;
+      }
+      await fetch(`/media/folders/${id}`, {
+        method: 'DELETE',
+      });
+      if (selectedFolder === id) {
+        setSelectedFolder(undefined);
+      }
+      mutate();
+    },
+    [mutate, selectedFolder, setSelectedFolder],
+  );
+
+  return (
+    <div className="flex flex-col gap-[4px] w-[200px] shrink-0 pe-[12px] border-e border-newColColor">
+      <div
+        onClick={() => setSelectedFolder(undefined)}
+        className={clsx(
+          'cursor-pointer px-[10px] py-[8px] rounded-[6px] text-[14px]',
+          !selectedFolder ? 'bg-forth text-white' : 'hover:bg-forth/50',
+        )}
+      >
+        {t('all_media', 'All media')}
+      </div>
+      {(folders || []).map((folder) => (
+        <div
+          key={folder.id}
+          className={clsx(
+            'group flex items-center gap-[6px] px-[10px] py-[8px] rounded-[6px] text-[14px]',
+            selectedFolder === folder.id
+              ? 'bg-forth text-white'
+              : 'hover:bg-forth/50',
+          )}
+        >
+          {renamingId === folder.id ? (
+            <input
+              autoFocus
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onBlur={() => renameFolder(folder.id)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') renameFolder(folder.id);
+                if (e.key === 'Escape') setRenamingId(undefined);
+              }}
+              className="flex-1 bg-transparent outline-none border-b border-newColColor text-[14px]"
+            />
+          ) : (
+            <>
+              <div
+                className="flex-1 truncate cursor-pointer"
+                onClick={() => setSelectedFolder(folder.id)}
+              >
+                {folder.name}
+              </div>
+              <div
+                className="hidden group-hover:block cursor-pointer text-[12px] opacity-70 hover:opacity-100"
+                onClick={() => {
+                  setRenamingId(folder.id);
+                  setRenameValue(folder.name);
+                }}
+              >
+                {t('rename', 'Rename')}
+              </div>
+              <div
+                className="hidden group-hover:block cursor-pointer text-[12px] opacity-70 hover:opacity-100"
+                onClick={deleteFolder(folder.id)}
+              >
+                {t('delete', 'Delete')}
+              </div>
+            </>
+          )}
+        </div>
+      ))}
+      {creating ? (
+        <input
+          autoFocus
+          value={newFolderName}
+          onChange={(e) => setNewFolderName(e.target.value)}
+          onBlur={createFolder}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') createFolder();
+            if (e.key === 'Escape') setCreating(false);
+          }}
+          placeholder={t('folder_name', 'Folder name')}
+          className="px-[10px] py-[8px] rounded-[6px] text-[14px] bg-newBgColorInner border border-newColColor outline-none"
+        />
+      ) : (
+        <div
+          onClick={() => setCreating(true)}
+          className="cursor-pointer px-[10px] py-[8px] rounded-[6px] text-[14px] text-newTextColor/[0.6] hover:text-newTextColor"
+        >
+          + {t('new_folder', 'New folder')}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/libraries/nestjs-libraries/src/database/prisma/media/media.repository.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/media/media.repository.ts
@@ -1,12 +1,22 @@
 import { PrismaRepository } from '@gitroom/nestjs-libraries/database/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
 import { SaveMediaInformationDto } from '@gitroom/nestjs-libraries/dtos/media/save.media.information.dto';
+import { CreateMediaFolderDto } from '@gitroom/nestjs-libraries/dtos/media/create.media.folder.dto';
+import { RenameMediaFolderDto } from '@gitroom/nestjs-libraries/dtos/media/rename.media.folder.dto';
 
 @Injectable()
 export class MediaRepository {
-  constructor(private _media: PrismaRepository<'media'>) {}
+  constructor(
+    private _media: PrismaRepository<'media'>,
+    private _mediaFolder: PrismaRepository<'mediaFolder'>,
+  ) {}
 
-  saveFile(org: string, fileName: string, filePath: string, originalName?: string) {
+  saveFile(
+    org: string,
+    fileName: string,
+    filePath: string,
+    originalName?: string,
+  ) {
     return this._media.model.media.create({
       data: {
         organization: {
@@ -72,7 +82,12 @@ export class MediaRepository {
     });
   }
 
-  async getMedia(org: string, page: number, search?: string) {
+  async getMedia(
+    org: string,
+    page: number,
+    search?: string,
+    folderId?: string,
+  ) {
     const pageNum = (page || 1) - 1;
     const trimmedSearch = search?.trim();
     const searchFilter = trimmedSearch
@@ -83,6 +98,7 @@ export class MediaRepository {
           },
         }
       : {};
+    const folderFilter = folderId ? { folderId } : {};
     const query = {
       where: {
         organization: {
@@ -90,6 +106,7 @@ export class MediaRepository {
         },
         deletedAt: null,
         ...searchFilter,
+        ...folderFilter,
       },
     };
     const pages = Math.ceil((await this._media.model.media.count(query)) / 18);
@@ -98,6 +115,7 @@ export class MediaRepository {
         organizationId: org,
         deletedAt: null,
         ...searchFilter,
+        ...folderFilter,
       },
       orderBy: {
         createdAt: 'desc',
@@ -110,6 +128,7 @@ export class MediaRepository {
         thumbnail: true,
         alt: true,
         thumbnailTimestamp: true,
+        folderId: true,
       },
       skip: pageNum * 18,
       take: 18,
@@ -119,5 +138,77 @@ export class MediaRepository {
       pages,
       results,
     };
+  }
+
+  getFolders(org: string) {
+    return this._mediaFolder.model.mediaFolder.findMany({
+      where: {
+        organizationId: org,
+        deletedAt: null,
+      },
+      orderBy: {
+        name: 'asc',
+      },
+    });
+  }
+
+  createFolder(org: string, data: CreateMediaFolderDto) {
+    return this._mediaFolder.model.mediaFolder.create({
+      data: {
+        name: data.name,
+        parentId: data.parentId || null,
+        organization: {
+          connect: {
+            id: org,
+          },
+        },
+      },
+    });
+  }
+
+  renameFolder(org: string, id: string, data: RenameMediaFolderDto) {
+    return this._mediaFolder.model.mediaFolder.update({
+      where: {
+        id,
+        organizationId: org,
+      },
+      data: {
+        name: data.name,
+      },
+    });
+  }
+
+  async deleteFolder(org: string, id: string) {
+    await this._media.model.media.updateMany({
+      where: {
+        folderId: id,
+        organizationId: org,
+      },
+      data: {
+        folderId: null,
+      },
+    });
+
+    return this._mediaFolder.model.mediaFolder.update({
+      where: {
+        id,
+        organizationId: org,
+      },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+  }
+
+  moveMedia(org: string, id: string, folderId?: string) {
+    return this._media.model.media.update({
+      where: {
+        id,
+        organizationId: org,
+      },
+      data: {
+        folderId: folderId || null,
+      },
+    });
   }
 }

--- a/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
@@ -5,6 +5,8 @@ import { generationError } from '@gitroom/nestjs-libraries/openai/generation.err
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
 import { Organization } from '@prisma/client';
 import { SaveMediaInformationDto } from '@gitroom/nestjs-libraries/dtos/media/save.media.information.dto';
+import { CreateMediaFolderDto } from '@gitroom/nestjs-libraries/dtos/media/create.media.folder.dto';
+import { RenameMediaFolderDto } from '@gitroom/nestjs-libraries/dtos/media/rename.media.folder.dto';
 import { VideoManager } from '@gitroom/nestjs-libraries/videos/video.manager';
 import { VideoDto } from '@gitroom/nestjs-libraries/dtos/videos/video.dto';
 import { UploadFactory } from '@gitroom/nestjs-libraries/upload/upload.factory';
@@ -27,7 +29,7 @@ export class MediaService {
     private _openAi: OpenaiService,
     private _subscriptionService: SubscriptionService,
     private _videoManager: VideoManager,
-    private _temporalService: TemporalService
+    private _temporalService: TemporalService,
   ) {}
 
   async deleteMedia(org: string, id: string) {
@@ -41,7 +43,7 @@ export class MediaService {
   async generateImage(
     prompt: string,
     org: Organization,
-    generatePromptFirst?: boolean
+    generatePromptFirst?: boolean,
   ) {
     try {
       const generating = await this._subscriptionService.useCredit(
@@ -53,7 +55,7 @@ export class MediaService {
             console.log('Prompt:', prompt);
           }
           return this._openAi.generateImage(prompt);
-        }
+        },
       );
 
       return generating;
@@ -62,16 +64,46 @@ export class MediaService {
     }
   }
 
-  saveFile(org: string, fileName: string, filePath: string, originalName?: string) {
-    return this._mediaRepository.saveFile(org, fileName, filePath, originalName);
+  saveFile(
+    org: string,
+    fileName: string,
+    filePath: string,
+    originalName?: string,
+  ) {
+    return this._mediaRepository.saveFile(
+      org,
+      fileName,
+      filePath,
+      originalName,
+    );
   }
 
-  getMedia(org: string, page: number, search?: string) {
-    return this._mediaRepository.getMedia(org, page, search);
+  getMedia(org: string, page: number, search?: string, folderId?: string) {
+    return this._mediaRepository.getMedia(org, page, search, folderId);
   }
 
   saveMediaInformation(org: string, data: SaveMediaInformationDto) {
     return this._mediaRepository.saveMediaInformation(org, data);
+  }
+
+  getFolders(org: string) {
+    return this._mediaRepository.getFolders(org);
+  }
+
+  createFolder(org: string, data: CreateMediaFolderDto) {
+    return this._mediaRepository.createFolder(org, data);
+  }
+
+  renameFolder(org: string, id: string, data: RenameMediaFolderDto) {
+    return this._mediaRepository.renameFolder(org, id, data);
+  }
+
+  deleteFolder(org: string, id: string) {
+    return this._mediaRepository.deleteFolder(org, id);
+  }
+
+  moveMedia(org: string, id: string, folderId?: string) {
+    return this._mediaRepository.moveMedia(org, id, folderId);
   }
 
   getVideoOptions() {
@@ -94,7 +126,7 @@ export class MediaService {
   private async validateVideoRequest(org: Organization, body: VideoDto) {
     const totalCredits = await this._subscriptionService.checkCredits(
       org,
-      'ai_videos'
+      'ai_videos',
     );
 
     if (totalCredits.credits <= 0) {
@@ -127,12 +159,12 @@ export class MediaService {
         async () => {
           const loadedData = await video.instance.process(
             body.output,
-            body.customParams
+            body.customParams,
           );
 
           const file = await this.storage.uploadSimple(loadedData);
           return this.saveFile(org.id, file.split('/').pop(), file);
-        }
+        },
       );
     } catch (err) {
       throw generationError(err);
@@ -177,7 +209,7 @@ export class MediaService {
 
   async getGenerateVideoStatus(
     org: Organization,
-    jobId: string
+    jobId: string,
   ): Promise<{
     status: 'pending' | 'completed' | 'failed';
     id?: string;
@@ -233,7 +265,7 @@ export class MediaService {
     ) {
       throw new HttpException(
         `Function ${functionName} not found on video instance`,
-        400
+        400,
       );
     }
 

--- a/libraries/nestjs-libraries/src/database/prisma/schema.prisma
+++ b/libraries/nestjs-libraries/src/database/prisma/schema.prisma
@@ -29,6 +29,7 @@ model Organization {
   github              GitHub[]
   Integration         Integration[]
   media               Media[]
+  mediaFolders        MediaFolder[]
   buyerOrganization   MessagesGroup[]
   notifications       Notifications[]
   plugs               Plugs[]
@@ -216,6 +217,7 @@ model Media {
   originalName       String?
   path               String
   organizationId     String
+  folderId           String?
   createdAt          DateTime            @default(now())
   updatedAt          DateTime            @updatedAt
   deletedAt          DateTime?
@@ -225,6 +227,7 @@ model Media {
   alt                String?
   thumbnailTimestamp Int?
   organization       Organization        @relation(fields: [organizationId], references: [id])
+  folder             MediaFolder?        @relation(fields: [folderId], references: [id])
   agencies           SocialMediaAgency[]
   userPicture        User[]
   oauthApps          OAuthApp[]
@@ -232,6 +235,25 @@ model Media {
   @@index([name])
   @@index([organizationId])
   @@index([type])
+  @@index([folderId])
+}
+
+model MediaFolder {
+  id             String       @id @default(uuid())
+  name           String
+  organizationId String
+  parentId       String?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  deletedAt      DateTime?
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  parent         MediaFolder? @relation("MediaFolderToMediaFolder", fields: [parentId], references: [id])
+  children       MediaFolder[] @relation("MediaFolderToMediaFolder")
+  media          Media[]
+
+  @@index([organizationId])
+  @@index([parentId])
+  @@index([deletedAt])
 }
 
 model SocialMediaAgency {

--- a/libraries/nestjs-libraries/src/dtos/media/create.media.folder.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/media/create.media.folder.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateMediaFolderDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  parentId?: string;
+}

--- a/libraries/nestjs-libraries/src/dtos/media/move.media.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/media/move.media.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class MoveMediaDto {
+  @IsString()
+  id: string;
+
+  @IsOptional()
+  @IsString()
+  folderId?: string;
+}

--- a/libraries/nestjs-libraries/src/dtos/media/rename.media.folder.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/media/rename.media.folder.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class RenameMediaFolderDto {
+  @IsString()
+  name: string;
+}


### PR DESCRIPTION
## Summary
- Add a `MediaFolder` model (org-scoped, optional `parentId` for nested folders) and a nullable `folderId` on `Media`.
- Backend: `GET/POST /media/folders`, `POST /media/folders/:id` (rename), `DELETE /media/folders/:id`, `POST /media/move` to move a file between folders. `GET /media` accepts an optional `folderId` filter.
- Frontend: media library gets a folder sidebar (create, rename, delete) and each media item gets a "move to folder" control. Deleting a folder unassigns its media rather than deleting the files.

## Test plan
- [x] `tsc --noEmit` clean on `apps/backend` and `apps/frontend`
- [x] `prisma generate` succeeds with the new schema
- [ ] Manual verification against a running instance (create folder, upload/move media, filter by folder, rename/delete folder)