### PR TITLE
Fix backend hanging on cold boot by waiting for Temporal healthcheck

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -132,6 +132,8 @@ services:
         condition: service_healthy
       postiz-redis:
         condition: service_healthy
+      temporal:
+        condition: service_healthy
 
   postiz-postgres:
     image: postgres:17-alpine
@@ -207,15 +209,23 @@ services:
       - 5432
     volumes:
       - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U temporal"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
 
   temporal:
     container_name: temporal
     ports:
       - '7233:7233'
     image: temporalio/auto-setup:1.28.1
+    restart: on-failure
     depends_on:
-      - temporal-postgresql
-      - temporal-elasticsearch
+      temporal-postgresql:
+        condition: service_healthy
+      temporal-elasticsearch:
+        condition: service_started
     environment:
       - DB=postgres12
       - DB_PORT=5432
@@ -233,6 +243,12 @@ services:
       - ./dynamicconfig:/etc/temporal/config/dynamicconfig
     labels:
       kompose.volume.type: configMap
+    healthcheck:
+      test: ["CMD-SHELL", "tctl --address temporal:7233 cluster health | grep -q SERVING"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
   temporal-admin-tools:
     container_name: temporal-admin-tools


### PR DESCRIPTION
Fixes #2026

## Problem

On a cold start (or any `docker compose down && up -d` that recreates all
containers), the backend sometimes hangs indefinitely: pm2 shows `backend`
as "online", but it never binds port 3000, and the app returns 502 Bad
Gateway. No error or crash is logged.

## Root cause

`postiz`'s `depends_on` only waits on `postiz-postgres` and `postiz-redis`
being healthy — not on `temporal`. `apps/backend/src/main.js` builds the
whole Nest app (including the Temporal client wiring) inside
`NestFactory.create(AppModule, ...)`, before `app.listen()` is called. If
`temporal:7233` isn't reachable yet, that connection blocks silently with
no timeout, so `app.listen()` never runs.

Separately, `temporal` itself only had an order-only `depends_on` on
`temporal-postgresql`, so on a genuinely cold boot it could lose its own
race against Postgres and `exit(1)` with no restart policy to recover it.

## Fix

- Added a `healthcheck` to `temporal-postgresql` (`pg_isready`).
- Added a `healthcheck` to `temporal`
  (`tctl --address temporal:7233 cluster health | grep -q SERVING`),
  changed its `depends_on` on `temporal-postgresql` to
  `condition: service_healthy`, and added `restart: on-failure`.
- Added `temporal: condition: service_healthy` to `postiz`'s `depends_on`.

## Testing

Verified with a full `docker compose down && docker compose up -d` on a
real deployment: all containers came up in the correct order, `temporal`
reported healthy before `postiz` started, and the backend bound port 3000
within ~15s with no manual intervention. Previously this required a
manual `docker exec postiz pm2 restart backend` after every cold restart.