### PR TITLE
fix(linkedin): use REST organization ACLs for Company Pages

### DIFF
--- a/jest.linkedin.config.cjs
+++ b/jest.linkedin.config.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  displayName: 'linkedin-page',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/libraries/nestjs-libraries/src/integrations/social'],
+  testMatch: ['**/*.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.base.json',
+        isolatedModules: true,
+        diagnostics: false,
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^@gitroom/nestjs-libraries/(.*)$':
+      '<rootDir>/libraries/nestjs-libraries/src/$1',
+    '^@gitroom/helpers/(.*)$': '<rootDir>/libraries/helpers/src/$1',
+    '^@gitroom/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.ts
+++ b/libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.ts
@@ -1,4 +1,69 @@
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Matches,
+  Validate,
+  ValidateNested,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+export type LinkedinOrganicTargeting = {
+  geoLocations?: string[];
+  interfaceLocales?: LinkedinInterfaceLocale[];
+};
+
+export type LinkedinInterfaceLocale = {
+  language: string;
+  country?: string;
+};
+
+@ValidatorConstraint({ name: 'hasOrganicTargetingFacet', async: false })
+class HasOrganicTargetingFacet implements ValidatorConstraintInterface {
+  validate(value: LinkedinOrganicTargeting): boolean {
+    return Boolean(
+      value?.geoLocations?.length || value?.interfaceLocales?.length
+    );
+  }
+
+  defaultMessage(): string {
+    return 'organic_targeting must include geoLocations or interfaceLocales';
+  }
+}
+
+export class LinkedinInterfaceLocaleDto implements LinkedinInterfaceLocale {
+  @IsString()
+  @Matches(/^[a-z]{2}$/)
+  language: string;
+
+  @IsString()
+  @Matches(/^[A-Z]{2}$/)
+  @IsOptional()
+  country?: string;
+}
+
+export class LinkedinOrganicTargetingDto implements LinkedinOrganicTargeting {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(150)
+  @IsString({ each: true })
+  @Matches(/^urn:li:geo:\d+$/, { each: true })
+  @IsOptional()
+  geoLocations?: string[];
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(10)
+  @ValidateNested({ each: true })
+  @Type(() => LinkedinInterfaceLocaleDto)
+  @IsOptional()
+  interfaceLocales?: LinkedinInterfaceLocaleDto[];
+}
 
 export class LinkedinDto {
   @IsBoolean()
@@ -8,4 +73,10 @@ export class LinkedinDto {
   @IsString()
   @IsOptional()
   carousel_name?: string;
+
+  @Type(() => LinkedinOrganicTargetingDto)
+  @ValidateNested()
+  @Validate(HasOrganicTargetingFacet)
+  @IsOptional()
+  organic_targeting?: LinkedinOrganicTargetingDto;
 }

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.spec.ts
@@ -1,0 +1,236 @@
+jest.mock('./linkedin.provider', () => ({
+  LinkedinProvider: class LinkedinProvider {
+    checkScopes(required: string[], got: string | string[]) {
+      const scopes = Array.isArray(got) ? got : got.split(' ');
+      if (!required.every((scope) => scopes.includes(scope))) {
+        throw new Error('missing scope');
+      }
+    }
+  },
+}));
+
+import { LinkedinPageProvider } from './linkedin.page.provider';
+
+const fetchMock = jest.fn();
+
+const jsonResponse = (body: unknown) => ({
+  json: jest.fn().mockResolvedValue(body),
+});
+
+describe('LinkedinPageProvider', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    process.env.LINKEDIN_CLIENT_ID = 'client-id';
+    process.env.FRONTEND_URL = 'https://postiz.example.com';
+  });
+
+  it('uses Community Management scopes without OIDC or silent authorization', async () => {
+    const { url } = await new LinkedinPageProvider().generateAuthUrl();
+    const authorization = new URL(url);
+
+    expect(authorization.searchParams.get('scope')?.split(' ')).toEqual([
+      'w_member_social',
+      'r_basicprofile',
+      'rw_organization_admin',
+      'w_organization_social',
+      'r_organization_social',
+    ]);
+    const scopes = authorization.searchParams.get('scope')?.split(' ') || [];
+    expect(scopes).not.toContain('openid');
+    expect(scopes).not.toContain('profile');
+    expect(authorization.searchParams.has('prompt')).toBe(false);
+  });
+
+  it('authenticates a page admin through the Community Management profile endpoint', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          access_token: 'access-token',
+          expires_in: 3600,
+          refresh_token: 'refresh-token',
+          scope:
+            'w_member_social r_basicprofile rw_organization_admin w_organization_social r_organization_social',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 'member-101',
+          localizedFirstName: 'Yan',
+          localizedLastName: 'Lai',
+          vanityName: 'laiyanlong_',
+        })
+      );
+
+    await expect(
+      new LinkedinPageProvider().authenticate({
+        code: 'authorization-code',
+        codeVerifier: 'code-verifier',
+      })
+    ).resolves.toEqual({
+      id: 'member-101',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresIn: 3600,
+      name: 'Yan Lai',
+      picture: '',
+      username: 'laiyanlong_',
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.linkedin.com/v2/me',
+      {
+        headers: {
+          Authorization: 'Bearer access-token',
+        },
+      }
+    );
+  });
+
+  it('loads approved organization admins from the REST organization ACL API', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          elements: [
+            {
+              role: 'ADMINISTRATOR',
+              organization: 'urn:li:organization:101',
+            },
+            {
+              role: 'CONTENT_ADMIN',
+              organization: 'urn:li:organization:202',
+            },
+            {
+              role: 'CONTENT_ADMINISTRATOR',
+              organizationTarget: 'urn:li:organization:202',
+            },
+            {
+              role: 'ANALYST',
+              organization: 'urn:li:organization:303',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          results: {
+            '101': {
+              id: 101,
+              localizedName: 'DappGo',
+              vanityName: 'dappgo',
+              logoV2: {
+                'original~': {
+                  elements: [
+                    {
+                      identifiers: [
+                        { identifier: 'https://example.com/logo.png' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+            '202': {
+              id: 202,
+              name: { localized: { en_US: 'DappGo Research' } },
+              vanityName: 'dappgo-research',
+            },
+          },
+        })
+      );
+
+    await expect(
+      new LinkedinPageProvider().companies('access-token')
+    ).resolves.toEqual([
+      {
+        id: '101',
+        page: '101',
+        username: 'dappgo',
+        name: 'DappGo',
+        picture: 'https://example.com/logo.png',
+      },
+      {
+        id: '202',
+        page: '202',
+        username: 'dappgo-research',
+        name: 'DappGo Research',
+        picture: undefined,
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED',
+      {
+        headers: {
+          Authorization: 'Bearer access-token',
+          'X-Restli-Protocol-Version': '2.0.0',
+          'LinkedIn-Version': '202601',
+        },
+      }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.linkedin.com/rest/organizations?ids=List(101,202)',
+      {
+        headers: {
+          Authorization: 'Bearer access-token',
+          'X-Restli-Protocol-Version': '2.0.0',
+          'LinkedIn-Version': '202601',
+        },
+      }
+    );
+  });
+
+  it('does not make an organization lookup when no approved admin role is present', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        elements: [
+          {
+            role: 'ANALYST',
+            organization: 'urn:li:organization:303',
+          },
+        ],
+      })
+    );
+
+    await expect(
+      new LinkedinPageProvider().companies('access-token')
+    ).resolves.toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the REST organization lookup when reconnecting a page', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        id: 101,
+        localizedName: 'DappGo',
+        vanityName: 'dappgo',
+      })
+    );
+
+    await expect(
+      new LinkedinPageProvider().fetchPageInformation('access-token', {
+        page: '101',
+      })
+    ).resolves.toEqual({
+      id: 101,
+      name: 'DappGo',
+      access_token: 'access-token',
+      picture: undefined,
+      username: 'dappgo',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.linkedin.com/rest/organizations/101',
+      {
+        headers: {
+          Authorization: 'Bearer access-token',
+          'X-Restli-Protocol-Version': '2.0.0',
+          'LinkedIn-Version': '202601',
+        },
+      }
+    );
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -13,6 +13,59 @@ import { Plug } from '@gitroom/helpers/decorators/plug.decorator';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
 
+const LINKEDIN_VERSION = '202601';
+const LINKEDIN_PAGE_SCOPES = [
+  'w_member_social',
+  'r_basicprofile',
+  'rw_organization_admin',
+  'w_organization_social',
+  'r_organization_social',
+];
+const LINKEDIN_ORGANIZATION_ROLES = new Set([
+  'ADMINISTRATOR',
+  'CONTENT_ADMIN',
+  'CONTENT_ADMINISTRATOR',
+]);
+
+const linkedinRestHeaders = (accessToken: string) => ({
+  Authorization: `Bearer ${accessToken}`,
+  'X-Restli-Protocol-Version': '2.0.0',
+  'LinkedIn-Version': LINKEDIN_VERSION,
+});
+
+const linkedinOrganizationId = (urn?: string) =>
+  urn?.match(/^urn:li:organization:(\d+)$/)?.[1];
+
+const linkedinOrganizationPicture = (organization: any) =>
+  organization?.logoV2?.['original~']?.elements?.[0]?.identifiers?.[0]
+    ?.identifier;
+
+const linkedinOrganizationName = (organization: any) =>
+  organization?.localizedName ||
+  Object.values(organization?.name?.localized || {})[0] ||
+  '';
+
+const linkedinMemberProfile = async (accessToken: string) => {
+  const profile = await (
+    await fetch('https://api.linkedin.com/v2/me', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+  ).json();
+
+  return {
+    id: profile.id,
+    name: [profile.localizedFirstName, profile.localizedLastName]
+      .filter(Boolean)
+      .join(' '),
+    picture:
+      profile.profilePicture?.['displayImage~']?.elements?.[0]?.identifiers?.[0]
+        ?.identifier || '',
+    username: profile.vanityName,
+  };
+};
+
 @Rules(
   'LinkedIn can have maximum one attachment when selecting video, when choosing a carousel on LinkedIn minimum amount of attachment must be two, and only pictures, if uploading a video, LinkedIn can have only one attachment'
 )
@@ -25,15 +78,9 @@ export class LinkedinPageProvider
   override isBetweenSteps = true;
   override refreshWait = true;
   override maxConcurrentJob = 2; // LinkedIn Page has professional posting limits
-  override scopes = [
-    'openid',
-    'profile',
-    'w_member_social',
-    'r_basicprofile',
-    'rw_organization_admin',
-    'w_organization_social',
-    'r_organization_social',
-  ];
+  // Company Page OAuth uses Community Management API permissions. OIDC is a
+  // mutually exclusive LinkedIn product and is only needed for member login.
+  override scopes = LINKEDIN_PAGE_SCOPES;
 
   override editor = 'normal' as const;
 
@@ -59,34 +106,16 @@ export class LinkedinPageProvider
       })
     ).json();
 
-    const { vanityName } = await (
-      await fetch('https://api.linkedin.com/v2/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
-
-    const {
-      name,
-      sub: id,
-      picture,
-    } = await (
-      await fetch('https://api.linkedin.com/v2/userinfo', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
+    const profile = await linkedinMemberProfile(accessToken);
 
     return {
-      id,
+      id: profile.id,
       accessToken,
       refreshToken,
       expiresIn: expires_in,
-      name,
-      picture,
-      username: vanityName,
+      name: profile.name,
+      picture: profile.picture,
+      username: profile.username,
     };
   }
 
@@ -94,7 +123,7 @@ export class LinkedinPageProvider
     integration: Integration,
     originalIntegration: Integration,
     postId: string,
-    information: any,
+    information: any
   ) {
     return super.addComment(
       integration,
@@ -123,7 +152,9 @@ export class LinkedinPageProvider
   override async generateAuthUrl() {
     const state = makeId(6);
     const codeVerifier = makeId(30);
-    const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&prompt=none&client_id=${
+    // Do not use prompt=none here: a first authorization has no existing
+    // grant and LinkedIn returns a generic error instead of a consent screen.
+    const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${
       process.env.LINKEDIN_CLIENT_ID
     }&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin-page`
@@ -136,33 +167,54 @@ export class LinkedinPageProvider
   }
 
   async companies(accessToken: string) {
-    const { elements, ...all } = await (
+    const { elements = [] } = await (
       await fetch(
-        'https://api.linkedin.com/v2/organizationalEntityAcls?q=roleAssignee&state=APPROVED&projection=(elements*(role,organizationalTarget~(localizedName,vanityName,logoV2(original~:playableStreams))))',
+        'https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED',
         {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'X-Restli-Protocol-Version': '2.0.0',
-            'LinkedIn-Version': '202601',
-          },
+          headers: linkedinRestHeaders(accessToken),
         }
       )
     ).json();
 
-    return (elements || [])
-      .filter(
-        (e: any) =>
-          e['organizationalTarget~'] &&
-          ['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR'].includes(e.role)
+    const organizationIds: string[] = Array.from(
+      new Set(
+        elements
+          .filter((element: any) =>
+            LINKEDIN_ORGANIZATION_ROLES.has(element.role)
+          )
+          .map((element: any) =>
+            linkedinOrganizationId(
+              element.organization || element.organizationTarget
+            )
+          )
+          .filter((id: string | undefined): id is string => Boolean(id))
       )
-      .map((e: any) => ({
-        id: e.organizationalTarget.split(':').pop(),
-        page: e.organizationalTarget.split(':').pop(),
-        username: e['organizationalTarget~'].vanityName,
-        name: e['organizationalTarget~'].localizedName,
-        picture:
-          e['organizationalTarget~'].logoV2?.['original~']?.elements?.[0]
-            ?.identifiers?.[0]?.identifier,
+    );
+
+    if (!organizationIds.length) {
+      return [];
+    }
+
+    const { results = {} }: { results: Record<string, any> } = await (
+      await fetch(
+        `https://api.linkedin.com/rest/organizations?ids=List(${organizationIds.join(
+          ','
+        )})`,
+        {
+          headers: linkedinRestHeaders(accessToken),
+        }
+      )
+    ).json();
+
+    return organizationIds
+      .map((id) => results[id])
+      .filter(Boolean)
+      .map((organization: any) => ({
+        id: String(organization.id),
+        page: String(organization.id),
+        username: organization.vanityName,
+        name: linkedinOrganizationName(organization),
+        picture: linkedinOrganizationPicture(organization),
       }));
   }
 
@@ -187,22 +239,16 @@ export class LinkedinPageProvider
   async fetchPageInformation(accessToken: string, params: { page: string }) {
     const pageId = params.page;
     const data = await (
-      await fetch(
-        `https://api.linkedin.com/v2/organizations/${pageId}?projection=(id,localizedName,vanityName,logoV2(original~:playableStreams))`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        }
-      )
+      await fetch(`https://api.linkedin.com/rest/organizations/${pageId}`, {
+        headers: linkedinRestHeaders(accessToken),
+      })
     ).json();
 
     return {
-      id: data.id,
-      name: data.localizedName,
+      id: data.id || pageId,
+      name: linkedinOrganizationName(data),
       access_token: accessToken,
-      picture:
-        data?.logoV2?.['original~']?.elements?.[0]?.identifiers?.[0].identifier,
+      picture: linkedinOrganizationPicture(data),
       username: data.vanityName,
     };
   }
@@ -239,34 +285,16 @@ export class LinkedinPageProvider
 
     this.checkScopes(this.scopes, scope);
 
-    const {
-      name,
-      sub: id,
-      picture,
-    } = await (
-      await fetch('https://api.linkedin.com/v2/userinfo', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
-
-    const { vanityName } = await (
-      await fetch('https://api.linkedin.com/v2/me', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-    ).json();
+    const profile = await linkedinMemberProfile(accessToken);
 
     return {
-      id: id,
+      id: profile.id,
       accessToken,
       refreshToken,
       expiresIn,
-      name,
-      picture,
-      username: vanityName,
+      name: profile.name,
+      picture: profile.picture,
+      username: profile.username,
     };
   }
 
@@ -452,7 +480,9 @@ export class LinkedinPageProvider
     // Fetch share statistics for the specific post
     const shareStatsUrl = `https://api.linkedin.com/v2/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=${encodeURIComponent(
       `urn:li:organization:${integrationId}`
-    )}&shares=List(${encodeURIComponent(postId)})&timeIntervals=(timeRange:(start:${startDate},end:${endDate}),timeGranularityType:DAY)`;
+    )}&shares=List(${encodeURIComponent(
+      postId
+    )})&timeIntervals=(timeRange:(start:${startDate},end:${endDate}),timeGranularityType:DAY)`;
 
     const { elements: shareElements }: { elements: PostShareStatElement[] } =
       await (

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.spec.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.spec.ts
@@ -1,0 +1,116 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+  LinkedinDto,
+  LinkedinOrganicTargeting,
+} from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/linkedin.dto';
+import { LinkedinProvider } from './linkedin.provider';
+
+describe('LinkedinProvider organic targeting', () => {
+  const targeting: LinkedinOrganicTargeting = {
+    geoLocations: ['urn:li:geo:103644278'],
+    interfaceLocales: [{ language: 'en', country: 'US' }],
+  };
+
+  it('validates supported target facets and rejects an empty target', async () => {
+    const valid = plainToInstance(LinkedinDto, {
+      organic_targeting: targeting,
+    });
+    await expect(validate(valid)).resolves.toHaveLength(0);
+
+    const invalid = plainToInstance(LinkedinDto, {
+      organic_targeting: {},
+    });
+    await expect(validate(invalid)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'organic_targeting' }),
+      ])
+    );
+
+    const invalidLocale = plainToInstance(LinkedinDto, {
+      organic_targeting: {
+        geoLocations: ['urn:li:geo:103644278'],
+        interfaceLocales: [{ language: 'EN', country: 'usa' }],
+      },
+    });
+    await expect(validate(invalidLocale)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'organic_targeting' }),
+      ])
+    );
+  });
+
+  it('carries targeting through pending state into the REST posts payload', async () => {
+    const provider = new LinkedinProvider();
+    const [pending] = await provider.postPending(
+      '5515715',
+      'access-token',
+      [
+        {
+          id: 'post-1',
+          message: 'Targeted market update',
+          settings: { organic_targeting: targeting },
+          media: [],
+        },
+      ],
+      {} as any,
+      'company'
+    );
+
+    expect(pending.pendingData.organicTargeting).toEqual(targeting);
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      status: 201,
+      headers: { get: () => 'urn:li:share:123' },
+    });
+    (provider as any).fetch = fetchMock;
+
+    const result = await provider.finalizePost(
+      'access-token',
+      {
+        ...pending.pendingData,
+        attempting: true,
+        confirmed: true,
+      },
+      {} as any
+    );
+
+    expect(result).toEqual({
+      status: 'completed',
+      postId: 'urn:li:share:123',
+      releaseURL: 'https://www.linkedin.com/feed/update/urn:li:share:123',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.linkedin.com/rest/posts',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(String),
+      })
+    );
+    const request = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(request.distribution.targetEntities).toEqual([targeting]);
+    expect(request.author).toBe('urn:li:organization:5515715');
+  });
+
+  it('does not allow organic targeting for a personal LinkedIn post', async () => {
+    await expect(
+      new LinkedinProvider().postPending(
+        'member-101',
+        'access-token',
+        [
+          {
+            id: 'post-1',
+            message: 'Targeted market update',
+            settings: { organic_targeting: targeting },
+            media: [],
+          },
+        ],
+        {} as any,
+        'personal'
+      )
+    ).rejects.toThrow(
+      'Organic targeting is only supported for LinkedIn Company Pages'
+    );
+  });
+});

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -19,7 +19,10 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { Integration } from '@prisma/client';
 import { PostPlug } from '@gitroom/helpers/decorators/post.plug';
-import { LinkedinDto } from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/linkedin.dto';
+import {
+  LinkedinDto,
+  LinkedinOrganicTargeting,
+} from '@gitroom/nestjs-libraries/dtos/posts/providers-settings/linkedin.dto';
 import imageToPDF from 'image-to-pdf';
 import { Readable } from 'stream';
 import { Rules } from '@gitroom/nestjs-libraries/chat/rules.description.decorator';
@@ -33,6 +36,7 @@ type LinkedinPendingData = {
   message: string;
   isPdf: boolean;
   pdfTitle?: string;
+  organicTargeting?: LinkedinOrganicTargeting;
   mediaIds: string[];
   // Media whose processing status can be read via GET: videos for every token,
   // images/documents only for organization tokens.
@@ -716,7 +720,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     message: string,
     mediaIds: string[],
     isPdf: boolean,
-    pdfTitle?: string
+    pdfTitle?: string,
+    organicTargeting?: LinkedinOrganicTargeting
   ) {
     const author =
       type === 'personal' ? `urn:li:person:${id}` : `urn:li:organization:${id}`;
@@ -727,7 +732,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       visibility: 'PUBLIC',
       distribution: {
         feedDistribution: 'MAIN_FEED',
-        targetEntities: [] as string[],
+        targetEntities: organicTargeting ? [organicTargeting] : [],
         thirdPartyDistributionChannels: [] as string[],
       },
       ...this.buildPostContent(isPdf, mediaIds, pdfTitle),
@@ -743,7 +748,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     mediaIds: string[],
     type: 'company' | 'personal',
     isPdf: boolean,
-    pdfTitle?: string
+    pdfTitle?: string,
+    organicTargeting?: LinkedinOrganicTargeting
   ): Promise<string> {
     const postPayload = this.createLinkedInPostPayload(
       authorId,
@@ -751,7 +757,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       message,
       mediaIds,
       isPdf,
-      pdfTitle
+      pdfTitle,
+      organicTargeting
     );
 
     const response = await this.fetch(`https://api.linkedin.com/rest/posts`, {
@@ -839,7 +846,19 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
   ): Promise<PostResponse[]> {
     let processedPostDetails = postDetails;
     const [firstPost] = postDetails;
-    const isPdf = this.assetBoolean(firstPost.settings?.post_as_images_carousel);
+    const isPdf = this.assetBoolean(
+      firstPost.settings?.post_as_images_carousel
+    );
+    const organicTargeting = firstPost.settings?.organic_targeting;
+
+    if (organicTargeting && type !== 'company') {
+      throw new BadBody(
+        this.identifier,
+        '{}',
+        '{}',
+        'Organic targeting is only supported for LinkedIn Company Pages'
+      );
+    }
 
     // Check if we should convert images to PDF carousel
     if (isPdf) {
@@ -875,6 +894,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
           ...(isPdf
             ? { pdfTitle: firstPost.settings?.carousel_name || 'slides' }
             : {}),
+          ...(organicTargeting ? { organicTargeting } : {}),
           mediaIds: (mediaUploads[processedFirstPost.id] || []).filter(Boolean),
           poll,
           graceChecks,
@@ -1025,7 +1045,8 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       (pendingData.mediaIds || []).filter(Boolean),
       pendingData.postType,
       pendingData.isPdf,
-      pendingData.pdfTitle
+      pendingData.pdfTitle,
+      pendingData.organicTargeting
     );
 
     return {

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -119,7 +119,10 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       };
     }
 
-    if (body.indexOf('resource is forbidden') > -1 || body.indexOf('Service Unavailable') > -1) {
+    if (
+      body.indexOf('resource is forbidden') > -1 ||
+      body.indexOf('Service Unavailable') > -1
+    ) {
       return {
         type: 'retry',
         value: 'Resource is forbidden',
@@ -558,10 +561,10 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
 
     // Create a PDF sized to the largest image; it fills the page,
     // smaller images are fitted and centered within the same dimensions
-    const pdfStream = imageToPDF(
-      imageBuffers,
-      [largest.width, largest.height]
-    ) as unknown as Readable;
+    const pdfStream = imageToPDF(imageBuffers, [
+      largest.width,
+      largest.height,
+    ]) as unknown as Readable;
     const pdfBuffer = await this.streamToBuffer(pdfStream);
 
     // Replace the first post's media with the single PDF
@@ -679,7 +682,9 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     // DISABLE_IMAGE_COMPRESSION=true, where the frontend no longer shrinks
     // uploads and full-size images reach LinkedIn directly. Do not remove it on
     // the assumption that the frontend compression already caps dimensions.
-    const pipeline = sharp(await readOrFetch(mediaUrl), { animated: false }).resize({
+    const pipeline = sharp(await readOrFetch(mediaUrl), {
+      animated: false,
+    }).resize({
       width: 6000,
       height: 6000,
       fit: 'inside',
@@ -689,7 +694,11 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     return await (keepFormat ? pipeline : pipeline.toFormat('jpeg')).toBuffer();
   }
 
-  private buildPostContent(isPdf: boolean, mediaIds: string[], pdfTitle?: string) {
+  private buildPostContent(
+    isPdf: boolean,
+    mediaIds: string[],
+    pdfTitle?: string
+  ) {
     if (mediaIds.length === 0) {
       return {};
     }
@@ -801,9 +810,9 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
       {
         method: 'POST',
         headers: {
-        'LinkedIn-Version': '202306',
-        'X-Restli-Protocol-Version': '2.0.0',
-        'Content-Type': 'application/json',
+          'LinkedIn-Version': '202306',
+          'X-Restli-Protocol-Version': '2.0.0',
+          'Content-Type': 'application/json',
           Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify({

--- a/scripts/deploy-linkedin-oauth-hotfix.sh
+++ b/scripts/deploy-linkedin-oauth-hotfix.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+# Deploy the already-built LinkedIn Page provider overlay to the public
+# Docker Compose Postiz instance. This script deliberately does not read,
+# print, or copy the Compose .env contents.
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "Run this script with sudo: sudo $0" >&2
+  exit 1
+fi
+
+RELEASE_DIR="${POSTIZ_RELEASE_DIR:-/home/ubuntu/a001/releases/ai001-mkt-005-linkedin-oauth-20260828T183841Z}"
+OVERLAY_DIR="${POSTIZ_OVERLAY_DIR:-$RELEASE_DIR/overlay}"
+COMPOSE_DIR="${POSTIZ_COMPOSE_DIR:-/home/ubuntu/a001/git/dappgo-marketing-agent/runtime/postiz-docker-compose}"
+
+SERVICE="postiz"
+BASE_IMAGE="${POSTIZ_BASE_IMAGE:-ghcr.io/gitroomhq/postiz-app@sha256:785f97312f66a347fb96cdccc4ded5a33ced69a672c89a9adc8054e7d6a21dc5}"
+IMAGE_TAG="${POSTIZ_IMAGE_TAG:-dappgo/postiz:ai001-mkt-005-linkedin-oauth-841f4d8b}"
+
+BACKEND_PROVIDER="$OVERLAY_DIR/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
+ORCHESTRATOR_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
+
+COMPOSE_BASE="$COMPOSE_DIR/docker-compose.yaml"
+COMPOSE_OVERRIDE="$COMPOSE_DIR/docker-compose.override.yml"
+COMPOSE_ENV="$COMPOSE_DIR/.env"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing command: $1"
+}
+
+require_command docker
+require_command curl
+require_command grep
+require_command awk
+require_command sed
+require_command timeout
+
+[[ -d "$RELEASE_DIR" ]] || die "release directory not found: $RELEASE_DIR"
+[[ -d "$OVERLAY_DIR" ]] || die "overlay directory not found: $OVERLAY_DIR"
+[[ -f "$COMPOSE_BASE" ]] || die "Compose file not found: $COMPOSE_BASE"
+[[ -f "$COMPOSE_OVERRIDE" ]] || die "Compose override not found: $COMPOSE_OVERRIDE"
+[[ -f "$COMPOSE_ENV" ]] || die "Compose .env not found: $COMPOSE_ENV"
+
+validate_provider() {
+  local provider="$1"
+  [[ -s "$provider" ]] || die "compiled provider not found: $provider"
+  grep -Fq 'rest/organizationAcls' "$provider" || die "organizationAcls endpoint missing: $provider"
+  grep -Fq 'api.linkedin.com/v2/me' "$provider" || die "Community Management profile endpoint missing: $provider"
+  if grep -Fq 'prompt=none' "$provider"; then
+    die "silent OAuth prompt is still present: $provider"
+  fi
+  if grep -Fq 'api.linkedin.com/v2/userinfo' "$provider"; then
+    die "OIDC userinfo endpoint is still present: $provider"
+  fi
+}
+
+validate_provider "$BACKEND_PROVIDER"
+validate_provider "$ORCHESTRATOR_PROVIDER"
+echo "SOURCE_CHECK_OK"
+
+OLD_IMAGE="$(docker inspect "$SERVICE" --format '{{.Config.Image}}')"
+OLD_STATE="$(docker inspect "$SERVICE" --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}')"
+
+BACKUP_DIR="$RELEASE_DIR/backup-linkedin-oauth-$(date -u +%Y%m%dT%H%M%SZ)"
+install -d -m 700 "$BACKUP_DIR"
+printf 'image=%s\nstate=%s\n' "$OLD_IMAGE" "$OLD_STATE" > "$BACKUP_DIR/postiz-before.txt"
+docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' > "$BACKUP_DIR/containers-before.txt"
+
+WORK_DIR="$(mktemp -d "$RELEASE_DIR/deploy.XXXXXX")"
+BUILD_DOCKERFILE="$WORK_DIR/Dockerfile"
+NEW_OVERRIDE="$WORK_DIR/docker-compose.linkedin-image.yaml"
+ROLLBACK_OVERRIDE="$WORK_DIR/docker-compose.rollback-image.yaml"
+
+cleanup() {
+  rm -f "$BUILD_DOCKERFILE" "$NEW_OVERRIDE" "$ROLLBACK_OVERRIDE"
+  rmdir "$WORK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+printf '%s\n' \
+  "FROM $BASE_IMAGE" \
+  'COPY apps/backend/dist/ /app/apps/backend/dist/' \
+  'COPY apps/orchestrator/dist/ /app/apps/orchestrator/dist/' \
+  > "$BUILD_DOCKERFILE"
+
+echo "BUILDING_IMAGE=$IMAGE_TAG"
+timeout --foreground 600s docker build --pull=false -f "$BUILD_DOCKERFILE" -t "$IMAGE_TAG" "$OVERLAY_DIR"
+docker image inspect "$IMAGE_TAG" >/dev/null
+echo "IMAGE_CREATED=$IMAGE_TAG"
+
+write_image_override() {
+  local path="$1"
+  local image="$2"
+  printf '%s\n' \
+    'services:' \
+    '  postiz:' \
+    "    image: $image" \
+    > "$path"
+}
+
+compose_with_override() {
+  local override="$1"
+  shift
+  docker compose \
+    --project-directory "$COMPOSE_DIR" \
+    --env-file "$COMPOSE_ENV" \
+    -f "$COMPOSE_BASE" \
+    -f "$COMPOSE_OVERRIDE" \
+    -f "$override" \
+    "$@"
+}
+
+wait_for_healthy() {
+  local deadline=$((SECONDS + 180))
+  local state
+  while (( SECONDS < deadline )); do
+    state="$(docker inspect "$SERVICE" --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' 2>/dev/null || true)"
+    echo "POSTIZ_STATUS=$state"
+    [[ "$state" == "running healthy" ]] && return 0
+    sleep 5
+  done
+  return 1
+}
+
+rollback() {
+  echo "ROLLBACK_IMAGE=$OLD_IMAGE" >&2
+  write_image_override "$ROLLBACK_OVERRIDE" "$OLD_IMAGE"
+  compose_with_override "$ROLLBACK_OVERRIDE" up -d --no-deps --force-recreate "$SERVICE" >/dev/null
+  wait_for_healthy || true
+  echo "ROLLBACK_ATTEMPTED" >&2
+}
+
+write_image_override "$NEW_OVERRIDE" "$IMAGE_TAG"
+compose_with_override "$NEW_OVERRIDE" config --images | grep -Fxq "$IMAGE_TAG" \
+  || die "Compose did not resolve the requested Postiz image"
+
+echo "RECREATING_SERVICE=$SERVICE"
+compose_with_override "$NEW_OVERRIDE" up -d --no-deps --force-recreate "$SERVICE"
+
+if ! wait_for_healthy; then
+  echo "Postiz did not become healthy; rolling back" >&2
+  rollback
+  exit 1
+fi
+
+CURRENT_IMAGE="$(docker inspect "$SERVICE" --format '{{.Config.Image}}')"
+if [[ "$CURRENT_IMAGE" != "$IMAGE_TAG" ]]; then
+  echo "Postiz is using unexpected image: $CURRENT_IMAGE" >&2
+  rollback
+  exit 1
+fi
+
+docker exec "$SERVICE" sh -lc '
+set -eu
+for P in \
+  /app/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js \
+  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js
+do
+  test -s "$P"
+  grep -Fq "rest/organizationAcls" "$P"
+  grep -Fq "api.linkedin.com/v2/me" "$P"
+  ! grep -Fq "prompt=none" "$P"
+  ! grep -Fq "api.linkedin.com/v2/userinfo" "$P"
+done
+echo CONTAINER_CODE_CHECK_OK
+'
+
+HTTP_CODE="$(curl -sS --max-time 20 -o /dev/null -w '%{http_code}' https://postiz.dappgo.com/)"
+if [[ ! "$HTTP_CODE" =~ ^[23][0-9][0-9]$ ]]; then
+  echo "Public Postiz returned HTTP $HTTP_CODE; rolling back" >&2
+  rollback
+  exit 1
+fi
+
+echo "PUBLIC_HTTP=$HTTP_CODE"
+echo "SERVICES"
+docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | grep -E '^(postiz|postiz-caddy|n8n-)' || true
+
+echo "DEPLOY_OK image=$CURRENT_IMAGE backup=$BACKUP_DIR"

--- a/scripts/deploy-linkedin-oauth-hotfix.sh
+++ b/scripts/deploy-linkedin-oauth-hotfix.sh
@@ -2,7 +2,7 @@
 
 set -Eeuo pipefail
 
-# Deploy only the already-built LinkedIn Page provider files to the public
+# Deploy only the already-built LinkedIn Page provider and targeting files to the public
 # Docker Compose Postiz instance. Keeping the rest of the official image
 # intact is important: it preserves the matching Prisma Client/runtime.
 # This script deliberately does not read, print, or copy the Compose .env.
@@ -12,20 +12,23 @@ if [[ ${EUID} -ne 0 ]]; then
   exit 1
 fi
 
-RELEASE_DIR="${POSTIZ_RELEASE_DIR:-/home/ubuntu/a001/releases/ai001-mkt-005-linkedin-oauth-20260828T183841Z}"
+RELEASE_DIR="${POSTIZ_RELEASE_DIR:-/home/ubuntu/a001/releases/ai001-mkt-006-provider-aware-targeting-20260828T183841Z}"
 OVERLAY_DIR="${POSTIZ_OVERLAY_DIR:-$RELEASE_DIR/overlay}"
 COMPOSE_DIR="${POSTIZ_COMPOSE_DIR:-/home/ubuntu/a001/git/dappgo-marketing-agent/runtime/postiz-docker-compose}"
 
 SERVICE="postiz"
 BASE_IMAGE="${POSTIZ_BASE_IMAGE:-ghcr.io/gitroomhq/postiz-app@sha256:785f97312f66a347fb96cdccc4ded5a33ced69a672c89a9adc8054e7d6a21dc5}"
-IMAGE_TAG="${POSTIZ_IMAGE_TAG:-dappgo/postiz:ai001-mkt-005-linkedin-oauth-841f4d8b-v2}"
+IMAGE_TAG="${POSTIZ_IMAGE_TAG:-dappgo/postiz:ai001-mkt-006-provider-aware-targeting-2eae3a9a}"
 
 PROVIDER_RELATIVE="libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
 COMMON_PROVIDER_RELATIVE="libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js"
+DTO_RELATIVE="libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.js"
 BACKEND_PROVIDER="$OVERLAY_DIR/apps/backend/dist/$PROVIDER_RELATIVE"
 ORCHESTRATOR_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/$PROVIDER_RELATIVE"
 BACKEND_COMMON_PROVIDER="$OVERLAY_DIR/apps/backend/dist/$COMMON_PROVIDER_RELATIVE"
 ORCHESTRATOR_COMMON_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/$COMMON_PROVIDER_RELATIVE"
+BACKEND_DTO="$OVERLAY_DIR/apps/backend/dist/$DTO_RELATIVE"
+ORCHESTRATOR_DTO="$OVERLAY_DIR/apps/orchestrator/dist/$DTO_RELATIVE"
 
 COMPOSE_BASE="$COMPOSE_DIR/docker-compose.yaml"
 COMPOSE_OVERRIDE="$COMPOSE_DIR/docker-compose.override.yml"
@@ -74,10 +77,19 @@ validate_common_provider() {
     || die "shared LinkedIn pending provider method missing: $provider"
 }
 
+validate_dto() {
+  local dto="$1"
+  [[ -s "$dto" ]] || die "compiled LinkedIn DTO not found: $dto"
+  grep -Fq 'organic_targeting' "$dto" || die "organic_targeting DTO field missing: $dto"
+  grep -Fq 'geoLocations' "$dto" || die "geoLocations DTO field missing: $dto"
+}
+
 validate_page_provider "$BACKEND_PROVIDER"
 validate_page_provider "$ORCHESTRATOR_PROVIDER"
 validate_common_provider "$BACKEND_COMMON_PROVIDER"
 validate_common_provider "$ORCHESTRATOR_COMMON_PROVIDER"
+validate_dto "$BACKEND_DTO"
+validate_dto "$ORCHESTRATOR_DTO"
 echo "SOURCE_CHECK_OK"
 
 OLD_IMAGE="$(docker inspect "$SERVICE" --format '{{.Config.Image}}')"
@@ -127,6 +139,10 @@ install -D -o 0 -g 0 -m 0644 "$BACKEND_COMMON_PROVIDER" \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$COMMON_PROVIDER_RELATIVE"
 install -D -o 0 -g 0 -m 0644 "$ORCHESTRATOR_COMMON_PROVIDER" \
   "$SNAPSHOT_UPPER/app/apps/orchestrator/dist/$COMMON_PROVIDER_RELATIVE"
+install -D -o 0 -g 0 -m 0644 "$BACKEND_DTO" \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$DTO_RELATIVE"
+install -D -o 0 -g 0 -m 0644 "$ORCHESTRATOR_DTO" \
+  "$SNAPSHOT_UPPER/app/apps/orchestrator/dist/$DTO_RELATIVE"
 
 grep -Fq 'rest/organizationAcls' \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
@@ -134,7 +150,9 @@ grep -Fq 'api.linkedin.com/v2/me' \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
 grep -Fq 'postPending' \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$COMMON_PROVIDER_RELATIVE"
-echo "PROVIDER_FILES_COPIED"
+grep -Fq 'organic_targeting' \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$DTO_RELATIVE"
+echo "PROVIDER_AND_TARGETING_FILES_COPIED"
 
 docker commit \
   --pause=false \
@@ -216,8 +234,10 @@ set -eu
 for P in \
   /app/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js \
   /app/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js \
+  /app/apps/backend/dist/libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.js \
   /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js \
-  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js
+  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js \
+  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.js
 do
   test -s "$P"
   case "$P" in
@@ -232,6 +252,10 @@ do
       ;;
   esac
 done
+grep -Fq "organic_targeting" \
+  /app/apps/backend/dist/libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.js
+grep -Fq "organic_targeting" \
+  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/dtos/posts/providers-settings/linkedin.dto.js
 echo CONTAINER_CODE_CHECK_OK
 '
 

--- a/scripts/deploy-linkedin-oauth-hotfix.sh
+++ b/scripts/deploy-linkedin-oauth-hotfix.sh
@@ -43,6 +43,7 @@ require_command grep
 require_command awk
 require_command sed
 require_command timeout
+require_command install
 
 [[ -d "$RELEASE_DIR" ]] || die "release directory not found: $RELEASE_DIR"
 [[ -d "$OVERLAY_DIR" ]] || die "overlay directory not found: $OVERLAY_DIR"
@@ -76,24 +77,50 @@ printf 'image=%s\nstate=%s\n' "$OLD_IMAGE" "$OLD_STATE" > "$BACKUP_DIR/postiz-be
 docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' > "$BACKUP_DIR/containers-before.txt"
 
 WORK_DIR="$(mktemp -d "$RELEASE_DIR/deploy.XXXXXX")"
-BUILD_DOCKERFILE="$WORK_DIR/Dockerfile"
 NEW_OVERRIDE="$WORK_DIR/docker-compose.linkedin-image.yaml"
 ROLLBACK_OVERRIDE="$WORK_DIR/docker-compose.rollback-image.yaml"
+TEMP_CONTAINER="postiz-linkedin-overlay-841f4d8b"
+TEMP_CREATED=0
 
 cleanup() {
-  rm -f "$BUILD_DOCKERFILE" "$NEW_OVERRIDE" "$ROLLBACK_OVERRIDE"
+  if (( TEMP_CREATED )); then
+    timeout --foreground 20s docker rm -f "$TEMP_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  rm -f "$NEW_OVERRIDE" "$ROLLBACK_OVERRIDE"
   rmdir "$WORK_DIR" 2>/dev/null || true
 }
 trap cleanup EXIT
 
-printf '%s\n' \
-  "FROM $BASE_IMAGE" \
-  "COPY apps/backend/dist/$PROVIDER_RELATIVE /app/apps/backend/dist/$PROVIDER_RELATIVE" \
-  "COPY apps/orchestrator/dist/$PROVIDER_RELATIVE /app/apps/orchestrator/dist/$PROVIDER_RELATIVE" \
-  > "$BUILD_DOCKERFILE"
+echo "CREATING_PROVIDER_OVERLAY=$IMAGE_TAG"
+docker rm -f "$TEMP_CONTAINER" >/dev/null 2>&1 || true
+docker create --name "$TEMP_CONTAINER" --entrypoint sh "$BASE_IMAGE" -c 'sleep 600' >/dev/null
+TEMP_CREATED=1
+docker start "$TEMP_CONTAINER" >/dev/null
 
-echo "BUILDING_IMAGE=$IMAGE_TAG"
-timeout --foreground 600s docker build --pull=false -f "$BUILD_DOCKERFILE" -t "$IMAGE_TAG" "$OVERLAY_DIR"
+TEMP_PID="$(docker inspect --format '{{.State.Pid}}' "$TEMP_CONTAINER")"
+[[ "$TEMP_PID" =~ ^[0-9]+$ ]] || die "could not resolve temporary container PID"
+SNAPSHOT_UPPER="$(sed -n 's/.*upperdir=\([^,]*\).*/\1/p' "/proc/$TEMP_PID/mountinfo" | head -1)"
+case "$SNAPSHOT_UPPER" in
+  /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/*/fs) ;;
+  *) die "unexpected Docker snapshot path: $SNAPSHOT_UPPER" ;;
+esac
+[[ -d "$SNAPSHOT_UPPER" ]] || die "Docker snapshot directory is not available"
+
+docker stop "$TEMP_CONTAINER" >/dev/null
+install -D -o 0 -g 0 -m 0644 "$BACKEND_PROVIDER" \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
+install -D -o 0 -g 0 -m 0644 "$ORCHESTRATOR_PROVIDER" \
+  "$SNAPSHOT_UPPER/app/apps/orchestrator/dist/$PROVIDER_RELATIVE"
+
+grep -Fq 'rest/organizationAcls' \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
+grep -Fq 'api.linkedin.com/v2/me' \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
+echo "PROVIDER_FILES_COPIED"
+
+docker commit --pause=false "$TEMP_CONTAINER" "$IMAGE_TAG" >/dev/null
+docker rm "$TEMP_CONTAINER" >/dev/null
+TEMP_CREATED=0
 docker image inspect "$IMAGE_TAG" >/dev/null
 echo "IMAGE_CREATED=$IMAGE_TAG"
 

--- a/scripts/deploy-linkedin-oauth-hotfix.sh
+++ b/scripts/deploy-linkedin-oauth-hotfix.sh
@@ -118,10 +118,17 @@ grep -Fq 'api.linkedin.com/v2/me' \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
 echo "PROVIDER_FILES_COPIED"
 
-docker commit --pause=false "$TEMP_CONTAINER" "$IMAGE_TAG" >/dev/null
+docker commit \
+  --pause=false \
+  --change 'ENTRYPOINT ["docker-entrypoint.sh"]' \
+  --change 'CMD ["sh","-c","nginx && pnpm run pm2"]' \
+  "$TEMP_CONTAINER" "$IMAGE_TAG" >/dev/null
 docker rm "$TEMP_CONTAINER" >/dev/null
 TEMP_CREATED=0
 docker image inspect "$IMAGE_TAG" >/dev/null
+IMAGE_CONFIG="$(docker image inspect "$IMAGE_TAG" --format '{{json .Config.Entrypoint}}|{{json .Config.Cmd}}')"
+[[ "$IMAGE_CONFIG" == '["docker-entrypoint.sh"]|["sh","-c","nginx && pnpm run pm2"]' ]] \
+  || die "official Postiz entrypoint/cmd was not preserved: $IMAGE_CONFIG"
 echo "IMAGE_CREATED=$IMAGE_TAG"
 
 write_image_override() {

--- a/scripts/deploy-linkedin-oauth-hotfix.sh
+++ b/scripts/deploy-linkedin-oauth-hotfix.sh
@@ -18,11 +18,14 @@ COMPOSE_DIR="${POSTIZ_COMPOSE_DIR:-/home/ubuntu/a001/git/dappgo-marketing-agent/
 
 SERVICE="postiz"
 BASE_IMAGE="${POSTIZ_BASE_IMAGE:-ghcr.io/gitroomhq/postiz-app@sha256:785f97312f66a347fb96cdccc4ded5a33ced69a672c89a9adc8054e7d6a21dc5}"
-IMAGE_TAG="${POSTIZ_IMAGE_TAG:-dappgo/postiz:ai001-mkt-005-linkedin-oauth-841f4d8b}"
+IMAGE_TAG="${POSTIZ_IMAGE_TAG:-dappgo/postiz:ai001-mkt-005-linkedin-oauth-841f4d8b-v2}"
 
 PROVIDER_RELATIVE="libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
+COMMON_PROVIDER_RELATIVE="libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js"
 BACKEND_PROVIDER="$OVERLAY_DIR/apps/backend/dist/$PROVIDER_RELATIVE"
 ORCHESTRATOR_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/$PROVIDER_RELATIVE"
+BACKEND_COMMON_PROVIDER="$OVERLAY_DIR/apps/backend/dist/$COMMON_PROVIDER_RELATIVE"
+ORCHESTRATOR_COMMON_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/$COMMON_PROVIDER_RELATIVE"
 
 COMPOSE_BASE="$COMPOSE_DIR/docker-compose.yaml"
 COMPOSE_OVERRIDE="$COMPOSE_DIR/docker-compose.override.yml"
@@ -51,7 +54,7 @@ require_command install
 [[ -f "$COMPOSE_OVERRIDE" ]] || die "Compose override not found: $COMPOSE_OVERRIDE"
 [[ -f "$COMPOSE_ENV" ]] || die "Compose .env not found: $COMPOSE_ENV"
 
-validate_provider() {
+validate_page_provider() {
   local provider="$1"
   [[ -s "$provider" ]] || die "compiled provider not found: $provider"
   grep -Fq 'rest/organizationAcls' "$provider" || die "organizationAcls endpoint missing: $provider"
@@ -64,8 +67,17 @@ validate_provider() {
   fi
 }
 
-validate_provider "$BACKEND_PROVIDER"
-validate_provider "$ORCHESTRATOR_PROVIDER"
+validate_common_provider() {
+  local provider="$1"
+  [[ -s "$provider" ]] || die "compiled shared provider not found: $provider"
+  grep -Fq 'postPending' "$provider" \
+    || die "shared LinkedIn pending provider method missing: $provider"
+}
+
+validate_page_provider "$BACKEND_PROVIDER"
+validate_page_provider "$ORCHESTRATOR_PROVIDER"
+validate_common_provider "$BACKEND_COMMON_PROVIDER"
+validate_common_provider "$ORCHESTRATOR_COMMON_PROVIDER"
 echo "SOURCE_CHECK_OK"
 
 OLD_IMAGE="$(docker inspect "$SERVICE" --format '{{.Config.Image}}')"
@@ -79,7 +91,7 @@ docker ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' > "$BACKUP_DIR/containe
 WORK_DIR="$(mktemp -d "$RELEASE_DIR/deploy.XXXXXX")"
 NEW_OVERRIDE="$WORK_DIR/docker-compose.linkedin-image.yaml"
 ROLLBACK_OVERRIDE="$WORK_DIR/docker-compose.rollback-image.yaml"
-TEMP_CONTAINER="postiz-linkedin-overlay-841f4d8b"
+TEMP_CONTAINER="postiz-linkedin-overlay-841f4d8b-v2"
 TEMP_CREATED=0
 
 cleanup() {
@@ -111,11 +123,17 @@ install -D -o 0 -g 0 -m 0644 "$BACKEND_PROVIDER" \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
 install -D -o 0 -g 0 -m 0644 "$ORCHESTRATOR_PROVIDER" \
   "$SNAPSHOT_UPPER/app/apps/orchestrator/dist/$PROVIDER_RELATIVE"
+install -D -o 0 -g 0 -m 0644 "$BACKEND_COMMON_PROVIDER" \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$COMMON_PROVIDER_RELATIVE"
+install -D -o 0 -g 0 -m 0644 "$ORCHESTRATOR_COMMON_PROVIDER" \
+  "$SNAPSHOT_UPPER/app/apps/orchestrator/dist/$COMMON_PROVIDER_RELATIVE"
 
 grep -Fq 'rest/organizationAcls' \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
 grep -Fq 'api.linkedin.com/v2/me' \
   "$SNAPSHOT_UPPER/app/apps/backend/dist/$PROVIDER_RELATIVE"
+grep -Fq 'postPending' \
+  "$SNAPSHOT_UPPER/app/apps/backend/dist/$COMMON_PROVIDER_RELATIVE"
 echo "PROVIDER_FILES_COPIED"
 
 docker commit \
@@ -197,13 +215,22 @@ docker exec "$SERVICE" sh -lc '
 set -eu
 for P in \
   /app/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js \
-  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js
+  /app/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js \
+  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js \
+  /app/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.js
 do
   test -s "$P"
-  grep -Fq "rest/organizationAcls" "$P"
-  grep -Fq "api.linkedin.com/v2/me" "$P"
-  ! grep -Fq "prompt=none" "$P"
-  ! grep -Fq "api.linkedin.com/v2/userinfo" "$P"
+  case "$P" in
+    *linkedin.page.provider.js)
+    grep -Fq "rest/organizationAcls" "$P"
+    grep -Fq "api.linkedin.com/v2/me" "$P"
+    ! grep -Fq "prompt=none" "$P"
+    ! grep -Fq "api.linkedin.com/v2/userinfo" "$P"
+      ;;
+    *)
+    grep -Fq "postPending" "$P"
+      ;;
+  esac
 done
 echo CONTAINER_CODE_CHECK_OK
 '

--- a/scripts/deploy-linkedin-oauth-hotfix.sh
+++ b/scripts/deploy-linkedin-oauth-hotfix.sh
@@ -2,9 +2,10 @@
 
 set -Eeuo pipefail
 
-# Deploy the already-built LinkedIn Page provider overlay to the public
-# Docker Compose Postiz instance. This script deliberately does not read,
-# print, or copy the Compose .env contents.
+# Deploy only the already-built LinkedIn Page provider files to the public
+# Docker Compose Postiz instance. Keeping the rest of the official image
+# intact is important: it preserves the matching Prisma Client/runtime.
+# This script deliberately does not read, print, or copy the Compose .env.
 
 if [[ ${EUID} -ne 0 ]]; then
   echo "Run this script with sudo: sudo $0" >&2
@@ -19,8 +20,9 @@ SERVICE="postiz"
 BASE_IMAGE="${POSTIZ_BASE_IMAGE:-ghcr.io/gitroomhq/postiz-app@sha256:785f97312f66a347fb96cdccc4ded5a33ced69a672c89a9adc8054e7d6a21dc5}"
 IMAGE_TAG="${POSTIZ_IMAGE_TAG:-dappgo/postiz:ai001-mkt-005-linkedin-oauth-841f4d8b}"
 
-BACKEND_PROVIDER="$OVERLAY_DIR/apps/backend/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
-ORCHESTRATOR_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
+PROVIDER_RELATIVE="libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.js"
+BACKEND_PROVIDER="$OVERLAY_DIR/apps/backend/dist/$PROVIDER_RELATIVE"
+ORCHESTRATOR_PROVIDER="$OVERLAY_DIR/apps/orchestrator/dist/$PROVIDER_RELATIVE"
 
 COMPOSE_BASE="$COMPOSE_DIR/docker-compose.yaml"
 COMPOSE_OVERRIDE="$COMPOSE_DIR/docker-compose.override.yml"
@@ -86,8 +88,8 @@ trap cleanup EXIT
 
 printf '%s\n' \
   "FROM $BASE_IMAGE" \
-  'COPY apps/backend/dist/ /app/apps/backend/dist/' \
-  'COPY apps/orchestrator/dist/ /app/apps/orchestrator/dist/' \
+  "COPY apps/backend/dist/$PROVIDER_RELATIVE /app/apps/backend/dist/$PROVIDER_RELATIVE" \
+  "COPY apps/orchestrator/dist/$PROVIDER_RELATIVE /app/apps/orchestrator/dist/$PROVIDER_RELATIVE" \
   > "$BUILD_DOCKERFILE"
 
 echo "BUILDING_IMAGE=$IMAGE_TAG"


### PR DESCRIPTION
## Summary\n- use Community Management scopes and `/v2/me` for LinkedIn Company Page OAuth\n- replace deprecated organization ACL lookup with `/rest/organizationAcls` and `/rest/organizations`\n- add validated organic targeting DTOs for Company Pages only\n- preserve member-page behavior and add focused provider contract tests\n\n## Verification\n- LinkedIn provider suites: 2 suites, 8 tests passed\n- backend build passed\n- orchestrator build passed\n- Prettier and diff checks passed\n\nThe self-hosted deployment helper remains in the branch for the existing private deployment workflow; it does not change the official Postiz entrypoint or Prisma runtime.