### PR TITLE
fix(x): chunk ids into <=100 per v2.tweets analytics call

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -1456,12 +1456,17 @@ export class XProvider extends SocialAbstract implements SocialProvider {
         return [];
       }
 
-      const data = await client.v2.tweets(
-        tweets.map((p) => p.id),
-        {
+      // X's GET /2/tweets accepts at most 100 ids per request — batch them.
+      const allIds = tweets.map((p) => p.id);
+      const data = { data: [] as TweetV2[] };
+      for (let i = 0; i < allIds.length; i += 100) {
+        const page = await client.v2.tweets(allIds.slice(i, i + 100), {
           'tweet.fields': ['public_metrics'],
+        });
+        if (page?.data) {
+          data.data.push(...page.data);
         }
-      );
+      }
 
       const metrics = data.data.reduce(
         (all, current) => {


### PR DESCRIPTION
## What

`XProvider.analytics` collects all of a channel's tweets for the lookback window via `loadAllTweets` (paginated, 100/page — correct), then passes **every** id to a single `client.v2.tweets(ids)` call to fetch `public_metrics`.

X's `GET /2/tweets` endpoint accepts **at most 100 ids** per request. For any channel with more than 100 tweets in the window, the call fails:

```
400 Invalid Request — "The number of values in the `ids` query parameter
list [209] is not between 1 and 100"
```

`data.data` then comes back undefined, `reduce`/`not iterable` throws, and the analytics tab shows "This channel needs to be refreshed" forever — retrying just repeats the same failing call.

## Fix

Batch the ids into slices of 100, call `client.v2.tweets` per batch, and merge the results — same downstream shape (`data.data` array), no other behavior change.

Observed on a self-hosted instance: one channel (~fewer tweets) rendered analytics fine while two channels with >100 tweets in the window both failed with the 400 above.

## Test plan

- [ ] Connect an X channel with >100 tweets in the last `date` days and open Analytics — stats should render instead of the refresh prompt
- [ ] A channel with ≤100 tweets still renders identically
- [ ] A channel with 0 tweets still returns `[]`

Generated with [Devin](https://devin.ai)