### PR TITLE
fix(frontend): honor the AM/PM date metric in the post date picker time input

### DIFF
--- a/apps/frontend/src/components/launches/helpers/date.picker.tsx
+++ b/apps/frontend/src/components/launches/helpers/date.picker.tsx
@@ -73,6 +73,7 @@ export const DatePicker: FC<{
           />
           <TimeInput
             onChange={changeDate('time')}
+            format={isUSCitizen() ? '12' : '24'}
             label="Pick time"
             classNames={{
               label: 'text-textColor py-[12px]',


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, post editor date picker). The "Pick time" field inside the scheduling popup of the post editor is a Mantine `TimeInput` rendered without a `format` prop, so it always showed 24-hour time even when Settings > Date Metrics is set to AM:PM. This PR passes `format={isUSCitizen() ? '12' : '24'}` to that `TimeInput` in `date.picker.tsx`, matching the format the date button next to it already uses. The change handler, the calendar, and the 24-hour path are unchanged.

# Why was this change needed?

A customer reported on 2026-09-04 that with Date Metrics set to AM:PM, the calendar and the editor's date button show "3:19 PM" while the time field inside the scheduling popup shows "15:19", so the UI mixes both formats. The setting is meant to apply to every time display.

# Other information:

Support initially told the customer the 24-hour field was intentional to avoid overlapping schedules; nothing in the code supports that, the prop was simply never set.

# QA

1. [ ] Go to Settings > Global Settings and set Date Metrics to AM:PM
2. [ ] Open the calendar, click Create Post, then click the date button at the bottom of the editor
3. [ ] The "Pick time" field in the popup should show 12-hour time with an am/pm segment (e.g. "01 : 40 pm"), matching the date button
4. [ ] Change the hour to 03 pm and close the popup; the date button should read "... 03:40 PM"
5. [ ] Set Date Metrics back to 24 hours, reopen the popup; the field should show 24-hour time (e.g. "13 : 40") as before

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139MFpBVVACikM4kMYZ1F9F
