### PR TITLE
fix(auth): join the invited org on email+password login too

### DIFF
--- a/apps/backend/src/services/auth/auth.service.ts
+++ b/apps/backend/src/services/auth/auth.service.ts
@@ -91,7 +91,17 @@ export class AuthService {
         throw new Error('User is not activated');
       }
 
-      return { addedOrg: false, jwt: await this.jwt(user) };
+      const addedOrg =
+        addToOrg && typeof addToOrg !== 'boolean'
+          ? await this._organizationService.addUserToOrg(
+              user.id,
+              addToOrg.id,
+              addToOrg.orgId,
+              addToOrg.role
+            )
+          : false;
+
+      return { addedOrg, jwt: await this.jwt(user) };
     }
 
     const user = await this.loginOrRegisterProvider(


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, auth). In `routeAuth` in `apps/backend/src/services/auth/auth.service.ts`, the LOCAL provider login branch now applies the pending team invite (`addToOrg`) via `addUserToOrg`, exactly like the LOCAL register branch and the OAuth provider branch already do, and returns the resulting `addedOrg` instead of a hard-coded `false`. The login controller already forwarded the `org` cookie and already sets the `showorg` cookie when `addedOrg` is present, so nothing changes there. Register, OAuth login/register and the logged-in `join-org` path are untouched.

# Why was this change needed?

The three ways an invite token gets consumed were not consistent:

- LOCAL register: joins the inviting org.
- OAuth (Google/GitHub) login or register: joins the inviting org, since `loginOrRegisterProvider` handles both cases and the join runs after it.
- LOCAL login: returned `addedOrg: false` and dropped the invite.

So an existing email+password user who was logged out when they opened a team invite got redirected to login, logged in, and ended up in their own personal org with no membership in the inviting org. The invite only worked if they opened the link again while logged in. Google/GitHub users in the same situation were joined correctly. The asymmetry dates back to the commit that introduced team invites; the local login branch returns early with a bare JWT and never got the join block the other two branches have.

This complements #1643 (2-day invite token), #2022 (default org tiebreak) and #2023 (org/showorg cookie lifetimes), which extended how long the parked invite survives but did not cover this path.

# Other information:

Verified locally against the backend API: owner invited an existing, activated email+password user (send email off); that user logged in with the `org` cookie holding the invite token. The login response now sets `showorg` to the inviting org, the user's organizations list includes the inviting org with role USER, and the owner's team list includes the user. A second login with the same token sets no `showorg` and creates no duplicate membership, since `addUserToOrg` already rejects a used invite id.

# QA

1. [ ] Create user B with email+password, activate it, then log B out.
2. [ ] As org owner A (Team plan), invite B's email from Settings > Teams.
3. [ ] In B's logged-out browser, open the invite link; you land on the login page with an `org` cookie set.
4. [ ] Log in as B with email and password.
5. [ ] B lands on the dashboard with A's org selected (`showorg` cookie set), and A's org appears in B's org switcher.
6. [ ] In A's Settings > Teams, B is listed as a member.
7. [ ] Log B out, open the same invite link again and log in: no error, still exactly one membership.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHSUd5bM9bQjocQt6UTNbq
