### PR TITLE
fix(instagram): curate container processing errors, map 2207082 to the silent-video audio hint

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -206,14 +206,6 @@ export class InstagramProvider
       };
     }
 
-    if (body.indexOf('2207082') > -1) {
-      return {
-        type: 'bad-body' as const,
-        value:
-          'Instagram could not process this video. If you attached audio to a video that has no sound track, set the original video volume to 0 and try again',
-      };
-    }
-
     if (body.indexOf('2207023') > -1) {
       return {
         type: 'bad-body' as const,
@@ -371,8 +363,9 @@ export class InstagramProvider
     if (body.indexOf('2207082') > -1) {
       return {
         type: 'retry' as const,
-        value: 'Could not upload your media',
-      }
+        value:
+          'Instagram could not process this video. If you attached audio to a video that has no sound track, set the original video volume to 0 and try again',
+      };
     }
 
     if (body.indexOf('2207077') > -1) {

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -206,6 +206,14 @@ export class InstagramProvider
       };
     }
 
+    if (body.indexOf('2207082') > -1) {
+      return {
+        type: 'bad-body' as const,
+        value:
+          'Instagram could not process this video. If you attached audio to a video that has no sound track, set the original video volume to 0 and try again',
+      };
+    }
+
     if (body.indexOf('2207023') > -1) {
       return {
         type: 'bad-body' as const,
@@ -631,11 +639,12 @@ export class InstagramProvider
     ).json();
 
     if (status_code === 'ERROR' || status_code === 'EXPIRED') {
+      const handleError = this.handleErrors(status || '', 200);
       throw new BadBody(
         this.identifier,
         JSON.stringify({ status_code, status }),
         '{}',
-        status || 'Instagram could not process the media'
+        handleError?.value || status || 'Instagram could not process the media'
       );
     }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Instagram provider via Facebook Login). `igContainerStatus` in `instagram.provider.ts` now runs the container's `status` text through `handleErrors` before throwing `BadBody`, so the curated message is what reaches the calendar tooltip, falling back to Meta's raw status text as before. The existing `2207082` entry in the Instagram `handleErrors` table keeps its `retry` type but its text now tells the user to set the original video volume to 0 when audio is attached to a video that has no sound track. The polling flow, the HTTP-path retries and every other mapping are unchanged.

# Why was this change needed?

A customer reported that every Instagram Reel with an audio track attached failed with the generic "An error occurred while publishing this post", while the same video published fine without audio. The stored failure was Meta's container status `Media upload has failed with error code 2207082`, which is not documented by Meta.

Investigation across recent Cloud posts showed the cause: the uploaded videos had no audio stream, and Meta fails to mix an attached track into a silent video unless the original video volume is 0. Every silent-video-plus-audio post with the volume unset or above 0 failed with 2207082, every one with volume 0 published, and videos with an audio track published either way. Setting "Original video volume" to 0 is a working workaround, but nothing told the user that.

The message could not be fixed by editing the mapping alone: the container status poll returns HTTP 200 with the failure inside the body, so `this.fetch` never classifies it and none of the existing `2207xxx` mappings, including the one for `2207082`, applied to that path. The `tiktok.provider.ts` and `tiktok.business.provider.ts` `checkPostStatus` implementations already handle their `FAILED` poll body by calling `this.handleErrors` on it, so this PR follows the same precedent for Instagram. As a side effect the existing `2207053` and `2207077` mappings now apply to container failures too.

Instagram Standalone and Threads were checked and left alone: Meta returns a bare `ERROR` / `UNKNOWN` on their polls with no subcode, so there is nothing to map.

# Other information:

Code `2207085` also surfaces on this path in production and remains unmapped until its cause is understood.

# QA

1. [ ] Connect an Instagram channel through Facebook Login (not Instagram Login).
2. [ ] Export a short vertical mp4 with no audio stream, e.g. `ffmpeg -i in.mp4 -an silent.mp4`, and upload it as the only media of a new Instagram post.
3. [ ] Open the post's Instagram settings, click "Add audio", pick any track, and leave "Original video volume" at its default of 100.
4. [ ] Publish now. The post should fail, and the calendar tooltip should read "Instagram could not process this video. If you attached audio to a video that has no sound track, set the original video volume to 0 and try again" instead of the raw "Media upload has failed with error code 2207082".
5. [ ] Duplicate the post, drag "Original video volume" to 0, publish again. The Reel should publish with the chosen audio.
6. [ ] Publish a normal Instagram video post with no audio setting. It should publish as before, confirming the happy path is untouched.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [X] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [X] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [X] I checked that there were no similar issues or PRs already open for this.
- [X] This PR fixes just ONE issue
- [X] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeqHwX9oRV6UGgDpm6dVKB
