### PR TITLE
fix(dribbble): map 4xx shot rejections to non-retryable BadBody errors

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/dribbble.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/dribbble.provider.ts
@@ -8,6 +8,7 @@ import {
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import FormData from 'form-data';
 import {
+  BadBody,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -180,16 +181,31 @@ export class DribbbleProvider extends SocialAbstract implements SocialProvider {
     formData.append('title', postDetails[0].settings.title);
     formData.append('description', postDetails[0].message);
 
-    const data2 = await this.getSsrfSafeAxios().post(
-      'https://api.dribbble.com/v2/shots',
-      formData,
-      {
-        headers: {
-          ...formData.getHeaders(),
-          Authorization: `Bearer ${accessToken}`,
-        },
+    let data2;
+    try {
+      data2 = await this.getSsrfSafeAxios().post(
+        'https://api.dribbble.com/v2/shots',
+        formData,
+        {
+          headers: {
+            ...formData.getHeaders(),
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+    } catch (err: any) {
+      const status = err?.response?.status;
+      if (status >= 400 && status < 500 && status !== 429) {
+        throw new BadBody(
+          this.identifier,
+          JSON.stringify(err?.response?.data ?? {}),
+          '{}',
+          err?.response?.data?.message ||
+            `Dribbble rejected the shot with status ${status}`
+        );
       }
-    );
+      throw err;
+    }
 
     const location = data2.headers['location'];
     const newId = location.split('/').at(-1);


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (orchestrator/backend, Dribbble provider). In `dribbble.provider.ts`, the `POST https://api.dribbble.com/v2/shots` call in `post` is now wrapped in a try/catch that maps 4xx responses (except 429) to a non-retryable `BadBody` failure: the user-facing message is Dribbble's own `response.data.message` when present (generic "Dribbble rejected the shot with status N" otherwise), and the full response body is preserved in the failure details, which we persist to the Errors table. Deliberately unchanged: 429 and 5xx (and network errors) still propagate as plain errors and remain retryable, and the media download step before the upload is untouched.

# Why was this change needed?

Dribbble 4xx responses are permanent rejections, but they surfaced as plain AxiosErrors the post workflow classifies as unknown: it retried them for the full workflow loop and then recorded "Could not publish after several attempts", leaving the customer with an unverified publish status after a long wait. In the 4 days since 2026-09-03 this was the single most impactful error feeding that markUnconfirmed path (23 of 44 affected posts, all Dribbble 422s). The "we couldn't confirm your post" outcome is exactly what we want to avoid, and it also undermines the AI/automation-friendly approach: an agent scheduling via the API gets an ambiguous verdict instead of an actionable rejection. On top of that, axios does not serialize the response body, so Dribbble's actual rejection reason was thrown away; in the production case the image met Dribbble's documented 400x300/800x600 requirement, and without the body we cannot tell what Dribbble is rejecting. With this mapping the post fails once, with the honest reason, and the reason is recorded for follow-up.

This aligns Dribbble with the existing provider convention (Instagram, TikTok, GMB) of mapping permanent platform rejections to `BadBody`.

# QA

1. [ ] Connect a Dribbble account that is not upload-eligible (no Player/Team subscription), or otherwise arrange a 4xx from the shots endpoint (e.g. an expired/revoked token yields 401)
2. [ ] Create a post for the Dribbble channel with one 800x600 image and a title, and publish it
3. [ ] Without the fix, the post retries repeatedly and ends in ERROR with "Could not publish after several attempts"
4. [ ] With the fix, the post fails after a single attempt with Dribbble's own error message (or "Dribbble rejected the shot with status N"), and the Errors row for the post contains Dribbble's response body in the failure details
5. [ ] Optional: in the Temporal UI, the workflow history shows one postSocialPending attempt with retryState NON_RETRYABLE_FAILURE

The mapped path was not triggered against a live Dribbble account (shot creation requires a Player/Team subscription we do not have); the change follows the same mapping pattern verified live for other providers, and type-checks cleanly.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188yxtbWi6wtfJg7ydjUpfG