### PR TITLE
fix(auth): allow invited users to register with DISABLE_REGISTRATION=true

### DIFF
--- a/apps/backend/src/services/auth/auth.service.ts
+++ b/apps/backend/src/services/auth/auth.service.ts
@@ -52,7 +52,8 @@ export class AuthService {
           throw new Error('Email already exists');
         }
 
-        if (!(await this.canRegister(provider))) {
+        const hasInvite = addToOrg && typeof addToOrg !== 'boolean';
+        if (!(await this.canRegister(provider)) && !hasInvite) {
           throw new Error('Registration is disabled');
         }
 

--- a/apps/frontend/src/app/(app)/auth/page.tsx
+++ b/apps/frontend/src/app/(app)/auth/page.tsx
@@ -2,6 +2,7 @@ import { internalFetch } from '@gitroom/helpers/utils/internal.fetch';
 export const dynamic = 'force-dynamic';
 import { Register } from '@gitroom/frontend/components/auth/register';
 import { Metadata } from 'next';
+import { cookies } from 'next/headers';
 import { isGeneralServerSide } from '@gitroom/helpers/utils/is.general.server.side';
 import Link from 'next/link';
 import { getT } from '@gitroom/react/translation/get.translation.service.backend';
@@ -16,7 +17,12 @@ export default async function Auth(params: {searchParams: Promise<{provider: str
     const canRegister = (
       await (await internalFetch('/auth/can-register')).json()
     ).register;
-    if (!canRegister && !(await params?.searchParams)?.provider) {
+    const orgCookie = (await cookies()).get('org')?.value;
+    if (
+      !canRegister &&
+      !(await params?.searchParams)?.provider &&
+      !orgCookie
+    ) {
       return (
         <>
           <LoginWithOidc />

--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -70,7 +70,7 @@ export async function proxy(request: NextRequest) {
         ? {
             secure: true,
             httpOnly: true,
-            sameSite: false,
+            sameSite: 'none',
           }
         : {}),
       maxAge: -1,
@@ -110,7 +110,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(new URL(`/${url}`, nextUrl.href));
   }
   if (nextUrl.pathname.startsWith('/auth') && !authCookie) {
-    if (org) {
+    if (org && !request.cookies.get('org')) {
       const redirect = NextResponse.redirect(new URL(`/`, nextUrl.href));
       redirect.cookies.set('org', org, {
         ...(!process.env.NOT_SECURED
@@ -118,7 +118,7 @@ export async function proxy(request: NextRequest) {
               path: '/',
               secure: true,
               httpOnly: true,
-              sameSite: false,
+              sameSite: 'none',
               domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
             }
           : {}),
@@ -148,7 +148,7 @@ export async function proxy(request: NextRequest) {
                 path: '/',
                 secure: true,
                 httpOnly: true,
-                sameSite: false,
+                sameSite: 'none',
                 domain: getCookieUrlFromDomain(process.env.FRONTEND_URL!),
               }
             : {}),


### PR DESCRIPTION
## Summary

When `DISABLE_REGISTRATION=true`, the registration page shows `Registration is disabled` even for a user who opened a **valid invite link** (`/?org=<JWT>`). Because of this, an invited user can never create an account, so team invitations are unusable in a self-hosted instance that closes public registration.

This change lets a user with a valid invite token register, while keeping public registration disabled for everyone else.

## Root causes

1. **`auth.service.ts`** — `canRegister()` returns `false` as soon as one organization exists. `routeAuth()` then throws `Registration is disabled` **before it ever checks the invite token** (`addToOrg`), even though `getOrgFromCookie()` already validated that JWT and passed it in.
2. **`proxy.ts`** — the `org` cookie is set with `sameSite: false`, which is not a valid `SameSite` value, so the browser rejects the cookie and the invite token is lost. (`sameSite` must be `'none' | 'lax' | 'strict'`; `'none'` also requires `Secure`, already present.) The middleware also redirects `/` ↔ `/auth` in a loop once the `org` cookie exists.
3. **`auth/page.tsx`** — the register page renders `Registration is disabled` when `canRegister === false`, without checking the `org` invite cookie.

## Changes

- **`auth.service.ts`** — allow registration when `addToOrg` is a valid invite object (`typeof addToOrg !== 'boolean'`), so an invited user can create an account. Public registration stays disabled (no invite → still blocked).
- **`proxy.ts`** — set the `org` cookie with `sameSite: 'none'` (paired with the existing `Secure`), and in the middleware only redirect `/auth` → `/` when the `org` cookie is **not** already set, so the flow no longer loops.
- **`auth/page.tsx`** — render `<Register/>` when a valid `org` invite cookie is present, even with `DISABLE_REGISTRATION=true` and `canRegister === false`.

## Verification

Verified on a self-hosted instance:
- Public registration without an invite → still `Registration is disabled` (HTTP 400).
- Registration with a valid invite token (`org` cookie) → succeeds; the page renders the sign-up form instead of the disabled notice.
- Other flows (login, existing users, channel connections) unaffected.

Fixes #1071
