### PR TITLE
fix(vk): surface VK API errors instead of marking posts completed

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/vk.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/vk.provider.ts
@@ -6,7 +6,11 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import dayjs from 'dayjs';
-import { SocialAbstract } from '@gitroom/nestjs-libraries/integrations/social.abstract';
+import {
+  BadBody,
+  RefreshToken,
+  SocialAbstract,
+} from '@gitroom/nestjs-libraries/integrations/social.abstract';
 import { createHash, randomBytes } from 'crypto';
 import FormDataNew from 'form-data';
 import mime from 'mime-types';
@@ -229,6 +233,23 @@ export class VkProvider extends SocialAbstract implements SocialProvider {
     );
   }
 
+  // VK answers HTTP 200 with { error } instead of { response } on failures,
+  // so this.fetch never sees them and the post used to be marked completed.
+  private checkApiError(all: any) {
+    if (!all?.error) {
+      return;
+    }
+    const json = JSON.stringify(all);
+    const message = all.error.error_msg || 'VK rejected the request';
+    if (all.error.error_code === 5) {
+      throw new RefreshToken(this.identifier, json, Buffer.from('{}'), message);
+    }
+    if ([6, 9, 29].includes(all.error.error_code)) {
+      throw new Error(message);
+    }
+    throw new BadBody(this.identifier, json, Buffer.from('{}'), message);
+  }
+
   async post(
     userId: string,
     accessToken: string,
@@ -249,7 +270,7 @@ export class VkProvider extends SocialAbstract implements SocialProvider {
       );
     }
 
-    const { response } = await (
+    const all = await (
       await this.fetch(
         `https://api.vk.com/method/wall.post?v=5.251&access_token=${accessToken}&client_id=${process.env.VK_ID}`,
         {
@@ -258,6 +279,8 @@ export class VkProvider extends SocialAbstract implements SocialProvider {
         }
       )
     ).json();
+    this.checkApiError(all);
+    const { response } = all;
 
     return [
       {
@@ -293,7 +316,7 @@ export class VkProvider extends SocialAbstract implements SocialProvider {
       );
     }
 
-    const { response } = await (
+    const all = await (
       await this.fetch(
         `https://api.vk.com/method/wall.createComment?v=5.251&access_token=${accessToken}&client_id=${process.env.VK_ID}`,
         {
@@ -302,6 +325,8 @@ export class VkProvider extends SocialAbstract implements SocialProvider {
         }
       )
     ).json();
+    this.checkApiError(all);
+    const { response } = all;
 
     return [
       {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (orchestrator/backend, VK provider). VK's API answers HTTP 200 with `{ error: { error_code, error_msg } }` instead of `{ response }` when a call fails, so `this.fetch` never classified those failures and `post()` / `comment()` in `vk.provider.ts` returned `status: 'completed'` with `postId: "undefined"`. A new private `checkApiError()` now runs on the `wall.post` and `wall.createComment` bodies: code 5 (user authorization failed) throws `RefreshToken`, codes 6/9/29 (per-second limit, flood control, rate limit) throw a plain retryable `Error`, and everything else throws `BadBody` carrying VK's `error_msg`. Auth, media upload and the success path are unchanged.

# Why was this change needed?

A self-hoster (Debian, Docker) reported on 2026-09-08 that VK posts show as published in the dashboard but never appear on VK. With the current code any VK rejection is indistinguishable from success: the post is marked completed and no error is recorded, so neither the user nor we can see what went wrong. After this change the post fails with VK's own message, which also gives us the information needed to root-cause that report.

Error codes are taken from VK's official schema: https://github.com/VKCOM/vk-api-schema/blob/master/errors.json

# Other information:

Same shape as the Reddit 200-with-errors handling in #1837. Note the provider never sends `owner_id`, so posting to VK communities is still unsupported; that is a separate feature request.

# QA

Verified by driving `VkProvider.post()` and `comment()` with a stubbed `fetch` returning canned VK bodies, before and after the change.

1. [ ] Connect a VK channel and schedule a post to it while the VK app lacks the `wall` permission (or use a revoked/expired token)
2. [ ] Before this change the post ends up PUBLISHED with a preview link ending in `_undefined`; after it the post shows an error with VK's message (e.g. "User authorization failed" triggers a channel refresh, "Access to adding post denied" marks the post as failed)
3. [ ] With a valid token and permissions, publish a text post and a post with an image: both land on the VK wall and the preview link opens the post, as before
4. [ ] Add a comment (thread) to the published post: it appears under the VK post, as before

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9bgnuRXzUtoWypb76cBS1
