### PR TITLE
fix(x): map remaining known error responses to readable messages

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -232,6 +232,51 @@ export class XProvider extends SocialAbstract implements SocialProvider {
           'The video you are trying to post is longer than 2 minutes, which is not allowed for this account',
       };
     }
+    if (
+      body.includes(
+        'This user is not allowed to post a video longer than 10 minutes'
+      )
+    ) {
+      return {
+        type: 'bad-body',
+        value:
+          'The video you are trying to post is longer than 10 minutes, which is not allowed for this account',
+      };
+    }
+    if (body.includes('Your account is temporarily locked')) {
+      return {
+        type: 'bad-body',
+        value:
+          'Your X account is temporarily locked, log in to x.com to unlock it and then try again',
+      };
+    }
+    if (body.includes('Crypto addresses are prohibited')) {
+      return {
+        type: 'bad-body',
+        value:
+          'X does not allow crypto addresses in posts for the first 7 days after connecting the account',
+      };
+    }
+    if (body.includes('Your media IDs are invalid')) {
+      return {
+        type: 'bad-body',
+        value:
+          'X rejected the attached media, please re-upload the media and try again',
+      };
+    }
+    if (body.includes('not authorized to create or publish articles')) {
+      return {
+        type: 'bad-body',
+        value: 'Publishing articles on X requires an X Premium subscription',
+      };
+    }
+    if (body.includes('Please include either text or media in your Tweet')) {
+      return {
+        type: 'bad-body',
+        value:
+          'One of the posts in this thread has no text or media, please add some text or remove it',
+      };
+    }
     return undefined;
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (X provider, error mapping). Adds six `body.includes(...)` branches to `handleErrors` in `libraries/nestjs-libraries/src/integrations/social/x.provider.ts`, all `bad-body`: account temporarily locked, crypto addresses in the first 7 days, invalid media IDs, video longer than 10 minutes, articles requiring Premium, and a tweet with neither text nor media. Every existing branch, its wording and its order are untouched; the new branches are appended after them so first-match behaviour for existing responses cannot change. No generic code, no workflow or activity signature is touched.

# Why was this change needed?

X is the largest source of `Unknown Error` rows in the production `Errors` table. Decoding the raw X responses stored inside those rows for the last 45 days (about 1,300 rows) shows X returned a perfectly clear reason that we never mapped, so the customer only saw "Unknown Error" in the calendar tooltip and the API `error` field:

| Rows | X response | HTTP |
|---|---|---|
| 568 | `Your account is temporarily locked. Please log in to https://x.com (or twitter.com) to unlock your account.` | 403 |
| 315 | `Please include either text or media in your Tweet.` | 400 |
| 70 | `Crypto addresses are prohibited for the first 7 days after authentication.` | 403 |
| 25 | `Your media IDs are invalid.` | 400 |
| 23 | `This user is not allowed to post a video longer than 10 minutes.` | 403 |
| 6 | `You are not authorized to create or publish articles. A Premium subscription is required.` | 403 |

None of these are retryable and none invalidate the token, so they map to `bad-body` with a message that tells the user what to do. The locked-account message is matched on its prefix because X emits it with both the `x.com` and the `twitter.com` domain. The Premium branch matches on the article-specific part of the sentence rather than on "A Premium subscription is required", which X also uses for unrelated features. The 10-minute branch is a copy of the existing 2-minute branch with the number changed; per the X developer community even Premium accounts get this via the API, so the message does not suggest upgrading.

The empty-tweet response is a bug on our side (every one of those rows comes from `XProvider.comment` sending `text: ""` for a thread item stored blank in the database). The publishing-side fix is in a separate PR; this mapping is the safety net for whatever still reaches the provider, for example a link-only reply on a channel with link stripping enabled.

# Other information:

Sibling PRs from the same investigation: `Unauthorized` 401 to refresh-token, `Too Many Requests` retry message, and skipping blank thread items when publishing. Each is independent.

The video length message mirrors the wording of the existing 2-minute branch.

# QA

1. [ ] Connect an X channel and schedule a post with a video longer than 10 minutes on an account that is not allowed to post them
2. [ ] Wait for the publish to fail; the calendar error tooltip / public API `error` field should read "The video you are trying to post is longer than 10 minutes, which is not allowed for this account" instead of "Unknown Error"
3. [ ] Schedule a post on an X channel whose account has been temporarily locked by X (log in on x.com to see the lock screen); the failure should read "Your X account is temporarily locked, log in to x.com to unlock it and then try again"
4. [ ] Schedule an X article (post type "article", published) on an account without X Premium; the failure should read "Publishing articles on X requires an X Premium subscription"
5. [ ] Re-run any post that previously failed with an already mapped message (for example a duplicate tweet) and confirm the existing message is unchanged
6. [ ] After deploy, decode the `Errors` rows for platform `x` created after the deploy and confirm none of the six response strings above appear under `"message":"Unknown Error"` any more

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhqXD3mRcYsWMtRJdHZpR
