### PR TITLE
fix(x): mark the channel for reconnect on Unauthorized media upload errors

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -232,6 +232,12 @@ export class XProvider extends SocialAbstract implements SocialProvider {
           'The video you are trying to post is longer than 2 minutes, which is not allowed for this account',
       };
     }
+    if (body.includes('"title":"Unauthorized"')) {
+      return {
+        type: 'refresh-token',
+        value: 'X rejected the connected account, please reconnect your account',
+      };
+    }
     return undefined;
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (X provider, token handling). Adds one `refresh-token` branch to `handleErrors` in `libraries/nestjs-libraries/src/integrations/social/x.provider.ts`, matching the `"title":"Unauthorized"` fragment of X's 401 problem response. It is appended as the last branch, so the existing `Unsupported Authentication` and `user-suspended` mappings keep winning for their own responses. Nothing else changes: the generic `fetch` 401 rule, the retry counts, and every other X mapping stay as they are.

# Why was this change needed?

In the last 45 days the production `Errors` table holds 218 X rows across 24 channels where X answered `401 {"title":"Unauthorized","type":"about:blank"}` and the post was failed as `Unknown Error`, with the channel never being flagged for reconnection. Only 4 of those 24 channels are marked `refreshNeeded` today; 13 were reconnected by their owners on their own after repeated failures.

Every one of those rows has the same shape: the 401 is thrown by the `twitter-api-v2` client during media upload (`uploadMediaEntries`, called from `postPending`), and reaches `handleErrors` through `runInConcurrent`, which stringifies the thrown error and calls `handleErrors(body, 200)`. Because the status it passes is 200, the generic "401 with no mapping means RefreshToken" rule in `social.abstract.ts` never fires, and the error degrades to `BadBody('Unknown Error')`. Tweet creation itself goes through the generic `fetch` and already takes the refresh-token path on a 401, so this only affects posts with media.

The X OAuth FAQ (https://docs.x.com/fundamentals/authentication/faq) states that OAuth 1.0a access tokens do not expire but become invalid when the user revokes the app or X suspends it, and that apps should assume a token may become invalid at any time and prompt for re-authorization. Mapping the 401 to `refresh-token` does exactly that: the channel is marked as needing reconnection and the user is told so, instead of every subsequent post silently failing.

Trade-off worth knowing: on one day in the same window seven channels received a single 401 each and kept publishing fine afterwards, so a lone transient 401 will now trigger a reconnect prompt that was not strictly needed. That is the same behaviour tweet creation already has today, and far cheaper than the 200+ silent failures the persistent cases produced.

# Other information:

Sibling PRs from the same investigation: the remaining bad-body mappings, the `Too Many Requests` retry message, and skipping blank thread items. Each is independent.

# QA

1. [ ] Connect an X channel and confirm a post with an image publishes
2. [ ] On x.com, go to Settings > Security and account access > Apps and sessions > Connected apps, and revoke the Postiz app
3. [ ] Schedule a post with an image on that channel and wait for it to run
4. [ ] The post should fail with "X rejected the connected account, please reconnect your account" (not "Unknown Error") and the channel should show the reconnect state in the sidebar
5. [ ] Reconnect the channel and confirm a post with an image publishes again
6. [ ] Schedule a text-only post on a revoked channel and confirm it still lands in the same reconnect state as before this change

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhqXD3mRcYsWMtRJdHZpR
