### PR TITLE
fix(orchestrator): skip blank thread items when publishing

### DIFF
--- a/apps/orchestrator/src/activities/post.activity.ts
+++ b/apps/orchestrator/src/activities/post.activity.ts
@@ -193,7 +193,15 @@ export class PostActivity {
     // only the root drives the pre-publish sleep and the repeat schedule,
     // the rest are comments
     const [root, ...comments] = getPosts.map(slimPost);
-    return [reanchorInterval(root), ...comments];
+
+    // a thread item with no text and no media has nothing to publish
+    const publishable = comments.filter(
+      (comment) =>
+        JSON.parse(comment.image || '[]').length ||
+        stripHtmlValidation('normal', comment.content || '', true).trim()
+    );
+
+    return [reanchorInterval(root), ...publishable];
   }
 
   @ActivityMethod()


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (orchestrator, publishing). `getPostsList` in `apps/orchestrator/src/activities/post.activity.ts`, the activity that hands the post workflow the root post plus its thread items, now leaves out any thread item that has no media and whose content strips to empty text (same `stripHtmlValidation` the publish path applies). The root post is never filtered, the activity's parameters and return shape are unchanged, and no workflow file is touched, so every workflow version keeps working.

# Why was this change needed?

In the last 45 days the production `Errors` table has 315 X rows where X answered `Please include either text or media in your Tweet.` and the post failed as `Unknown Error`. Every one of them comes from `XProvider.comment` sending `text: ""` with no media. Looking at the posts behind them: the failing thread item is stored blank in the database, either an empty string or a bare `<p></p>`, with no image, created in the same request as its parent. About 250 such rows across 63 organizations, arriving through the public API, the CLI, the MCP tools and the dashboard alike, still a few every week.

All of those create paths validate for exactly this (the `emptyContent` check in `validatePosts`, the public API's `ValidContent` DTO validator, the MCP schedule tool) and reject a blank item when exercised locally, so how they get in is not established yet. What is established is that once such an item exists, the whole thread fails at publish time with a message the user cannot act on: X rejects the empty reply, and other platforms would reject it the same way.

Dropping blank items from the publish list fixes the symptom for every provider at once, in generic code, without deciding anything provider-specific. A blank item with no media has nothing to publish, so nothing is lost. The dropped item stays in the database as it was (the workflow only updates the posts it publishes), which is the same state it would have been left in after the failed run.

# Other information:

Sibling PRs from the same investigation map the remaining X error responses (including a bad-body mapping for this X response as a safety net, for example for a link-only reply on a channel with link stripping enabled), the `Unauthorized` refresh-token mapping, and the `Too Many Requests` retry message. Each is independent.

Verified by running the activity method against posts holding a blank second item and a media-only second item: the blank one is dropped from the returned list, the media-only one is kept.

# QA

1. [ ] Connect any channel that supports thread replies (X, Threads, Bluesky, Mastodon)
2. [ ] Create a post with a second thread item whose editor content is only a non-breaking space (type a space with the editor, or send `<p>&nbsp;</p>` as the second `value` item through the public API); this is currently the only blank form the create validation lets through
3. [ ] Schedule it for a minute ahead and wait
4. [ ] Before this change the whole post fails (on X with "Unknown Error", the response being "Please include either text or media in your Tweet."); after it, the first item publishes and the blank item is skipped
5. [ ] Repeat with a second item that has an image but no text: it must still be published as a reply
6. [ ] Repeat with a normal text reply: it must still be published

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhqXD3mRcYsWMtRJdHZpR
