### PR TITLE
fix(lemmy): surface Lemmy API errors instead of crashing on post_view

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/lemmy.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/lemmy.provider.ts
@@ -6,6 +6,8 @@ import {
 } from '@gitroom/nestjs-libraries/integrations/social/social.integrations.interface';
 import { makeId } from '@gitroom/nestjs-libraries/services/make.is';
 import {
+  BadBody,
+  RefreshToken,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -27,6 +29,65 @@ export class LemmyProvider extends SocialAbstract implements SocialProvider {
     return 10000;
   }
   dto = LemmySettingsDto;
+
+  override handleErrors(
+    body: string,
+    status: number
+  ):
+    | { type: 'refresh-token' | 'bad-body' | 'retry'; value: string }
+    | undefined {
+    if (body.includes('rate_limit_error')) {
+      return {
+        type: 'retry',
+        value: 'Lemmy rate limit reached, please try again later',
+      };
+    }
+
+    if (body.includes('not_logged_in') || body.includes('incorrect_login')) {
+      return {
+        type: 'refresh-token',
+        value: 'Lemmy session is no longer valid, please reconnect the channel',
+      };
+    }
+
+    if (body.includes('site_ban') || body.includes('"error":"banned"')) {
+      return {
+        type: 'bad-body',
+        value: 'This account is banned on the Lemmy instance',
+      };
+    }
+
+    if (body.includes('couldnt_find_community')) {
+      return {
+        type: 'bad-body',
+        value:
+          'The selected Lemmy community no longer exists, please pick another one',
+      };
+    }
+
+    if (body.includes('blocked_url')) {
+      return {
+        type: 'bad-body',
+        value: 'The Lemmy instance blocks the URL in this post',
+      };
+    }
+
+    if (body.includes('"error":"deleted"')) {
+      return {
+        type: 'bad-body',
+        value: 'The selected Lemmy community or post was deleted',
+      };
+    }
+
+    if (body.includes('"error":"locked"')) {
+      return {
+        type: 'bad-body',
+        value: 'This Lemmy post is locked, comments cannot be added',
+      };
+    }
+
+    return undefined;
+  }
 
   override async checkValidity(
     items: Array<ValidityMedia[]>
@@ -149,20 +210,46 @@ export class LemmyProvider extends SocialAbstract implements SocialProvider {
       AuthService.fixedDecryption(integration.customInstanceDetails!)
     );
 
-    const { jwt } = await (
-      await fetch(body.service + '/api/v3/user/login', {
-        // @ts-ignore - undici-only option; blocks SSRF to internal IPs
-        dispatcher: getSsrfSafeDispatcher(),
-        body: JSON.stringify({
-          username_or_email: body.identifier,
-          password: body.password,
-        }),
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-    ).json();
+    const options = {
+      // @ts-ignore - undici-only option; blocks SSRF to internal IPs
+      dispatcher: getSsrfSafeDispatcher(),
+      body: JSON.stringify({
+        username_or_email: body.identifier,
+        password: body.password,
+      }),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    let login: Response;
+    try {
+      login = await this.fetch(body.service + '/api/v3/user/login', options);
+    } catch (err) {
+      // The request body holds the stored password, so the failure is rebuilt
+      // without it before it reaches the Temporal history and the Errors table.
+      const json = (err as any).details?.[0]?.json || '{}';
+      if (err instanceof BadBody) {
+        throw new BadBody(
+          this.identifier,
+          json,
+          {} as BodyInit,
+          err.message || 'Unknown Error'
+        );
+      }
+      if (err instanceof RefreshToken) {
+        throw new RefreshToken(
+          this.identifier,
+          json,
+          {} as BodyInit,
+          err.message || 'Unknown Error'
+        );
+      }
+      throw err;
+    }
+
+    const { jwt } = await login.json();
 
     return { jwt, service: body.service };
   }
@@ -179,18 +266,8 @@ export class LemmyProvider extends SocialAbstract implements SocialProvider {
     const valueArray: PostResponse[] = [];
 
     for (const lemmy of firstPost.settings.subreddit) {
-      console.log({
-        community_id: +lemmy.value.id,
-        name: lemmy.value.title,
-        body: firstPost.message,
-        ...(lemmy.value.url ? { url: lemmy.value.url } : {}),
-        ...(firstPost.media?.length
-          ? { custom_thumbnail: firstPost.media[0].path }
-          : {}),
-        nsfw: false,
-      });
       const { post_view } = await (
-        await fetch(service + '/api/v3/post', {
+        await this.fetch(service + '/api/v3/post', {
           // @ts-ignore - undici-only option; blocks SSRF to internal IPs
           dispatcher: getSsrfSafeDispatcher(),
           body: JSON.stringify({
@@ -253,7 +330,7 @@ export class LemmyProvider extends SocialAbstract implements SocialProvider {
 
     for (const singlePostId of postIds) {
       const { comment_view } = await (
-        await fetch(service + '/api/v3/comment', {
+        await this.fetch(service + '/api/v3/comment', {
           // @ts-ignore - undici-only option; blocks SSRF to internal IPs
           dispatcher: getSsrfSafeDispatcher(),
           body: JSON.stringify({


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (orchestrator, Lemmy provider). `post()`, `comment()` and the per-call login in `getJwtAndService()` in `lemmy.provider.ts` now go through `this.fetch` instead of raw `fetch`, and a `handleErrors` override maps Lemmy's `{"error":"<type>"}` bodies: `rate_limit_error` retries, `not_logged_in` / `incorrect_login` flag the channel for reconnection, and `site_ban`, `banned`, `couldnt_find_community`, `blocked_url`, `deleted` and `locked` fail the post once with a readable message. Unmapped types fall through to the generic `BadBody` with the raw Lemmy body stored in the failure details. The login call rebuilds its `BadBody` / `RefreshToken` without the request body so the stored password never lands in the Temporal history or the `Errors` table. Request bodies sent to Lemmy are unchanged; a leftover `console.log` of the post body was removed.

# Why was this change needed?

Lemmy is the second-largest source of failed posts in production after X: 3,419 `Errors` rows across 688 posts between 2026-01-27 and 2026-08-13, every one of them `Cannot read properties of undefined (reading 'post')` thrown in `post()`. The provider destructured `post_view` / `comment_view` without checking the HTTP status, so any Lemmy rejection (rate limit, ban, unknown community, bad session) crashed with a TypeError. A TypeError is not a `BadBody`, so Temporal retried the activity about five times per post, and the customer saw a JS stack trace instead of the reason.

Lemmy also rate-limits `/api/v3/user/login` under its `register` bucket (10 per hour per IP by default), and the provider logs in on every publish. Before this change a rate-limited login produced `Bearer undefined` on the post call; now it is retried and surfaced as a rate limit.

# Other information:

All QA steps below were run end to end against a local Lemmy 0.19.20 docker instance, with the outcomes checked in the Temporal UI, the `Post` / `Errors` rows and the Lemmy proxy log.

The calendar tooltip still shows the generic "An error occurred while publishing this post" until #1868 (curated tooltip messages) lands; the mapped message is already in `Post.error` and the `Errors` row.

# QA

Needs a local Lemmy instance (official docker compose install, https://join-lemmy.org/docs/administration/install_docker.html) with an admin user, a second non-admin user and one community, connected as a Lemmy channel in a local Postiz (service `http://127.0.0.1:<port>`). Lemmy admin actions below are `POST`/`PUT` calls with the admin JWT.

1. [ ] Schedule a text post with a title to the community and Post now: it publishes and the release URL opens on the instance
2. [ ] Schedule a post with a link URL, an image and one thread comment: the Lemmy post has the url, the image as thumbnail and one comment
3. [ ] Ban the channel user (`POST /api/v3/user/ban` with `ban: true`), republish a post: the post fails after a single activity attempt (Temporal UI shows no retries), `Post.error` message is "This account is banned on the Lemmy instance", and the `Errors` row details contain `{"error":"site_ban"}` with an empty body (no credentials). Unban afterwards
4. [ ] Set the site rate limit to one post per 600s (`PUT /api/v3/site` with `rate_limit_post: 1`, `rate_limit_post_per_second: 600`), publish twice: the second post makes 4 calls to `/api/v3/post` five seconds apart (nginx proxy log) then fails once with "Lemmy rate limit reached, please try again later". Restore the limit
5. [ ] Change the channel user's password on the instance (`PUT /api/v3/user/change_password`), republish: exactly one `/api/v3/user/login` call and no `/api/v3/post` call in the proxy log, the post fails with "Refresh channel needed" and the channel shows "Channel disconnected, click to reconnect"
6. [ ] Lock a published post (`POST /api/v3/post/lock`) and publish a comment to it, or point a post at a non-existent / deleted community id: each fails once with the mapped "locked" / "no longer exists" / "was deleted" message and the raw Lemmy body in the `Errors` row

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP6nXu58HWQAjiyqAf3wdY
