### PR TITLE
fix(pinterest): make the numeric board id mapping actually match

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts
@@ -141,7 +141,10 @@ export class PinterestProvider
           'Pinterest was unable to reach the URL provided. Please check the link and try again.',
       };
     }
-    if (body.indexOf(`does not match '^\\\\\\\\\\\\\\\\d+$'`) > -1) {
+    if (
+      body.indexOf("does not match '^") > -1 &&
+      body.indexOf("d+$'") > -1
+    ) {
       return {
         type: 'bad-body' as const,
         value:


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Pinterest provider error mapping). In `handleErrors` of `pinterest.provider.ts`, the branch meant to catch Pinterest's `Invalid request: '<board name>' does not match '^\d+$'` response matched on a template literal with 16 backslashes (8 literal ones), while the raw response text carries 4. The condition now checks two backslash-free fragments of the message, `does not match '^` and `d+$'`, so it matches regardless of escaping. The message ("The board ID must be a numeric string...") and the `bad-body` outcome are unchanged, and no other mapping is touched.

# Why was this change needed?

The mapping has existed since June but never fired. In the last 45 days the production Errors table has 1,319 Pinterest rows whose only message is "Unknown Error"; decoding the raw bodies stored in the failure details shows 637 of them are exactly this response, coming from posts where the board setting holds a board name or a pin.it URL instead of the numeric board id (API and MCP created posts). Users saw "Unknown Error" for a problem that has a clear, actionable message already written.

Of the remaining rows, 547 are the transient "Something went wrong on our end" and spam-block responses that the mappings already on staging turn into retries. The tail still unmapped after this change is small: "We blocked this link because it may lead to spam" (47), "/v5/pins didn't finish after 7 seconds" (29) and "You are not permitted to access that resource" (12).

# Other information:

Verified by running the updated `handleErrors` against every distinct Pinterest "Unknown Error" body from production in the last 45 days: the 637 board-id bodies map to the numeric board id message, the other mapped responses behave as before, and every other body still returns `undefined`. `tsc` on `nestjs-libraries` reports no errors in the file.

# QA

1. [ ] In `libraries/nestjs-libraries/src/integrations/social/pinterest.provider.ts`, call `new PinterestProvider().handleErrors(body, 400)` (for example from a scratch ts-node script at the repo root) with the raw string `{"code":1,"message":"Invalid request: 'Travel Tips' does not match '^\\\\d+$' (constraint: pattern=^\\\\d+$)","details":{"source_field":"board_id"}}` (four backslashes before each `d` in the actual string); expect `type: 'bad-body'` and the "board ID must be a numeric string" message.
2. [ ] Same call with the same message but only two backslashes before each `d`; expect the same result.
3. [ ] Same call with `{"code":9,"message":"Sorry! You've hit a block (Pins) we have in place to combat spam. Please try again later!"}`; expect the pre-existing `retry` result, unchanged.
4. [ ] Same call with `{"code":29,"message":"You are not permitted to access that resource."}`; expect `undefined`.
5. [ ] Optional end to end: via the public API, schedule a Pinterest post whose `board` setting is a board name instead of the numeric id. When it runs, the calendar tooltip shows the numeric board id message instead of "Unknown Error".

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBHogYQMvY5zHT7qkdUQAT
