### PR TITLE
fix(threads): retry publish when Threads has not found the container yet (4279009)

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/threads.provider.ts
@@ -40,7 +40,7 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
 
   override handleErrors(body: string):
     | {
-        type: 'refresh-token' | 'bad-body';
+        type: 'refresh-token' | 'bad-body' | 'retry';
         value: string;
       }
     | undefined {
@@ -69,6 +69,13 @@ export class ThreadsProvider extends SocialAbstract implements SocialProvider {
         type: 'bad-body',
         value:
           "One of the media URLs is invalid or inaccessible, make sure it's being uploaded to Postiz first",
+      };
+    }
+    if (body.includes('4279009')) {
+      return {
+        type: 'retry',
+        value:
+          'Threads could not find the media container yet, please try again in a few seconds',
       };
     }
     if (body.includes('text must be at most 500 characters')) {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Threads provider error mapping). Adds a branch to `handleErrors` in `threads.provider.ts` that maps Meta error subcode `4279009` ("The requested resource does not exist" / "Media Not Found: The media with id ... cannot be found") to `type: 'retry'`, and adds `retry` to the method's return union. Through the generic `fetch` in `social.abstract.ts` a `retry` mapping re-issues the same call up to three times, 5 seconds apart, before failing with the mapped message. The publish endpoint, the container status polling and the pending workflow are unchanged.

# Why was this change needed?

In the last 45 days the production Errors table has 584 Threads rows whose only message is "Unknown Error". Decoding the raw bodies stored in the failure details shows 210 of them are this single response, thrown from `finalizePost` when it calls `threads_publish` with the container id that `post()` created moments earlier. The median gap between the post's publish date and the error is about 7 seconds, so the container is new, not expired (Meta expires containers after 24 hours).

Meta's Threads posting docs recommend waiting on average 30 seconds before publishing a container "to give our server enough time to fully process the upload" (https://developers.facebook.com/docs/threads/posts). Since the pending-post workflow (v1.0.6) replaced the provider's own polling loop, the first status check runs immediately after container creation and, when it reports FINISHED, publish fires with no delay at all. The weekly count of this error went from 1 before that change to 79 the first full week after, and it has stayed in the tens per week since.

Marking the response retryable gives the publish call a further 15 seconds spread over three attempts, which is the smallest change that gets us near the recommended wait without touching the workflow. The 8 posts in this set that ended up with a release URL show the container does become publishable shortly after.

# Other information:

Verified by running the updated `handleErrors` against every distinct Threads "Unknown Error" body from production in the last 45 days: all 210 subcode 4279009 bodies map to `retry`, and every other body still returns `undefined`. `tsc` on `nestjs-libraries` reports no errors in the file.

A follow-up worth considering separately is a short delay before the first status check in the Threads pending flow, which would also cover the case where three retries are not enough.

# QA

1. [ ] In `libraries/nestjs-libraries/src/integrations/social/threads.provider.ts`, call `new ThreadsProvider().handleErrors(body)` (for example from a scratch ts-node script at the repo root) with `{"error":{"message":"The requested resource does not exist","type":"OAuthException","code":24,"error_subcode":4279009,"is_transient":false,"error_user_title":"Media Not Found","error_user_msg":"The media with id 1 cannot be found."}}`; expect `type: 'retry'` and a message saying Threads could not find the media container yet.
2. [ ] Same call with `{"error":{"message":"Invalid parameter","code":100,"error_subcode":4279111}}`; expect `undefined`.
3. [ ] Same call with `{"error":{"message":"Error validating access token","code":190}}`; expect the pre-existing `refresh-token` result, unchanged.
4. [ ] Optional end to end: with the orchestrator running locally and a connected Threads channel, temporarily edit `finalizePost` to publish with a made-up `creation_id` and schedule a post. The activity should log three retried publish attempts about 5 seconds apart before failing with the new message, instead of failing immediately with "Unknown Error". Revert the edit afterwards.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBHogYQMvY5zHT7qkdUQAT
