### PR TITLE
fix: treat failing reConnect as a refresh failure (YouTube 'Channel not found')

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -88,30 +88,7 @@ export class RefreshIntegrationService {
       });
 
     if (!refresh || !refresh.accessToken) {
-      await this._integrationService.refreshNeeded(
-        integration.organizationId,
-        integration.id
-      );
-
-      await this._integrationService.informAboutRefreshError(
-        integration.organizationId,
-        integration,
-        cause
-      );
-
-      await this._integrationService.disconnectChannel(
-        integration.organizationId,
-        integration
-      );
-
-      logger.error('provider_channel_disconnected', {
-        provider: integration.providerIdentifier,
-        integration_id: integration.id,
-        org_id: integration.organizationId,
-        reason: cause,
-      });
-
-      return false;
+      return this.markRefreshFailed(integration, cause);
     }
 
     if (
@@ -121,15 +98,57 @@ export class RefreshIntegrationService {
       return refresh;
     }
 
-    const reConnect = await socialProvider.reConnect(
-      integration.rootInternalId,
-      integration.internalId,
-      refresh.accessToken
-    );
+    const reConnect = await socialProvider
+      .reConnect(
+        integration.rootInternalId,
+        integration.internalId,
+        refresh.accessToken
+      )
+      .catch((err) => {
+        logger.error('provider_reconnect_failed', {
+          provider: integration.providerIdentifier,
+          integration_id: integration.id,
+          org_id: integration.organizationId,
+          error_type: errorType(err),
+          reason: cause,
+        });
+        return false as const;
+      });
+
+    if (!reConnect) {
+      return this.markRefreshFailed(integration, cause);
+    }
 
     return {
       ...refresh,
       ...reConnect,
     };
+  }
+
+  private async markRefreshFailed(integration: Integration, cause: string) {
+    await this._integrationService.refreshNeeded(
+      integration.organizationId,
+      integration.id
+    );
+
+    await this._integrationService.informAboutRefreshError(
+      integration.organizationId,
+      integration,
+      cause
+    );
+
+    await this._integrationService.disconnectChannel(
+      integration.organizationId,
+      integration
+    );
+
+    logger.error('provider_channel_disconnected', {
+      provider: integration.providerIdentifier,
+      integration_id: integration.id,
+      org_id: integration.organizationId,
+      reason: cause,
+    });
+
+    return false as const;
   }
 }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, token refresh / YouTube). In `RefreshIntegrationService.refreshProcess`, a provider `reConnect` that throws is now caught and handled the same way as a failed `refreshToken`: the channel is marked as needing a refresh, the org is notified, the channel is disconnected, and the refresh returns `false`. The existing failure branch was moved into a private `markRefreshFailed` helper and reused. A new `provider_reconnect_failed` log line with the error type is emitted before that. Callers of `refresh` (post analytics, channel analytics, the refresh workflow) already handle `false`, so they now return an empty result instead of a 500. No provider code changed.

# Why was this change needed?

In production, `YoutubeProvider.reConnect` throwing `Channel not found` is currently the second most frequent backend error: 215 events in the last 24h and 2,457 in the last 7 days, all on `GET /public/v1/analytics/post/:postId` (Sentry CLOUD-A9). The stored channel is no longer in the list returned for the refreshed token, so every analytics call for that channel re-runs the refresh, hits the throw, and surfaces an unhandled exception to the API caller, who keeps retrying. Treating it as a refresh failure surfaces the "reconnect your channel" state to the user and stops the loop, matching what already happens when the token refresh itself fails.

# Other information:

Not tested locally. The behaviour on failure is the existing refresh-failure path, only reached from one more place.

# QA

1. [ ] Connect a YouTube channel that belongs to a Google account with more than one channel, so `rootInternalId` differs from `internalId`
2. [ ] Publish a post to it, then in the DB set the integration's `tokenExpiration` to a past date and change its `internalId` to a channel id the account does not own
3. [ ] Call `GET /public/v1/analytics/post/<postId>?date=7` with the org's API key
4. [ ] Expect a 200 with an empty array instead of a 500, the channel shown as disconnected / needing reconnect in the calendar, and an in-app notification about the refresh failure
5. [ ] Reconnect the channel and confirm the same call returns analytics again

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g3KqiuR5TT68XdqpTRbZh
