### PR TITLE
fix: return 400 for an expired or reused OAuth connect state

### DIFF
--- a/apps/backend/src/api/routes/no.auth.integrations.controller.ts
+++ b/apps/backend/src/api/routes/no.auth.integrations.controller.ts
@@ -62,12 +62,18 @@ export class NoAuthIntegrationsController {
       ? 'none'
       : await ioRedis.get(`login:${body.state}`);
     if (!getCodeVerifier) {
-      throw new Error('Invalid state');
+      throw new HttpException(
+        'This connection link has expired or was already used, please start the connection again',
+        400
+      );
     }
 
     const organization = await ioRedis.get(`organization:${body.state}`);
     if (!organization) {
-      throw new Error('Organization not found');
+      throw new HttpException(
+        'This connection link has expired or was already used, please start the connection again',
+        400
+      );
     }
 
     const org = await this._organizationService.getOrgById(organization);

--- a/apps/frontend/src/components/launches/continue.integration.tsx
+++ b/apps/frontend/src/components/launches/continue.integration.tsx
@@ -114,13 +114,15 @@ export const ContinueIntegration: FC<{
       });
 
       // If public endpoint fails with specific errors, try authenticated endpoint
+      let parsedError: any = null;
       if (data.status === HttpStatusCode.BadRequest) {
-        const errorData = await data.json().catch(() => ({}));
+        parsedError = await data.json().catch(() => ({}));
         // "Invalid connection type" means this wasn't started as a public flow
         if (
-          errorData.message?.includes('Invalid connection type') ||
-          errorData.message?.includes('Invalid or expired state')
+          parsedError.message?.includes('Invalid connection type') ||
+          parsedError.message?.includes('Invalid or expired state')
         ) {
+          parsedError = null;
           data = await fetch(`/integrations/social-connect/${provider}`, {
             method: 'POST',
             body: JSON.stringify({ ...modifiedParams, timezone }),
@@ -148,7 +150,8 @@ export const ContinueIntegration: FC<{
         data.status !== HttpStatusCode.Ok &&
         data.status !== HttpStatusCode.Created
       ) {
-        const errorData = await data.json().catch(() => ({}));
+        const errorData =
+          parsedError ?? (await data.json().catch(() => ({})));
         setErrorMessage(
           errorData.message || errorData.msg || 'Could not add provider'
         );


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend OAuth callback + frontend connect page). In `NoAuthIntegrationsController.connectSocialMedia`, the bare `throw new Error('Invalid state')` / `'Organization not found'` for a missing Redis state key are now a 400 `HttpException` with the message "This connection link has expired or was already used, please start the connection again". In `continue.integration.tsx`, the 400 branch used to read the response body to decide whether to retry and the generic error branch then read it again, which failed on the consumed stream and always fell back to "Could not add provider"; the first parse is now kept and reused. The OAuth flow itself, the single-use deletion of the state key and the 1h TTL are unchanged.

# Why was this change needed?

`Invalid state` is the third most frequent backend error in production: 99 events in the last 24h and 542 in the last 7 days on `POST /integrations/social-connect/:integration` (Sentry CLOUD-EY), spread across 13 providers roughly in proportion to connect volume (YouTube 225, Instagram 90, Facebook 66 over 7d). The state key is deleted after its first use and expires after an hour, so a refreshed, re-opened or bookmarked callback URL legitimately has no key. That is an expected user-side condition, not a server fault, but it surfaced as an unhandled 500 that counts in Sentry and left the user with a dead-end "Could not add provider" screen with no hint to start over.

# Other information:

The frontend double read is likely the same mechanism as the "body stream already read" issues (CLOUD-RY, CLOUD-PG), not verified here.

# QA

1. [ ] With a valid `timezone` in the body, `POST /integrations/social-connect/reddit` with `{"state":"does-not-exist","code":"x","timezone":"0"}` and expect a 400 whose `message` is the new text (was a 500)
2. [ ] Logged in, click Add Channel, pick Reddit, and copy the `state` query param from the Reddit consent URL without clicking Allow
3. [ ] Open `http://localhost:4200/integrations/social/reddit?state=<state>&code=fake-code` once; it consumes the state and shows "Authentication failed" (unchanged behaviour)
4. [ ] Reload the same URL; the network tab shows a 400 and the page shows "Could not add provider." with the new message underneath instead of a repeated "Could not add provider"
5. [ ] Complete a real connect for any OAuth provider and confirm it still succeeds

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g3KqiuR5TT68XdqpTRbZh
