### PR TITLE
fix(gmb): keep pending channels pending on refresh/reconnect, guard posts without a location

### DIFF
--- a/apps/backend/src/api/routes/no.auth.integrations.controller.ts
+++ b/apps/backend/src/api/routes/no.auth.integrations.controller.ts
@@ -243,7 +243,7 @@ export class NoAuthIntegrationsController {
         expiresIn,
         username,
         refresh ? false : integrationProvider.isBetweenSteps,
-        body.refresh,
+        refresh || body.refresh,
         +body.timezone,
         details
           ? AuthService.fixedEncryption(details)
@@ -264,9 +264,13 @@ export class NoAuthIntegrationsController {
         console.log(err);
       });
 
-    // Fetch pages if this is a two-step provider and not a refresh
+    // Fetch pages if this is a two-step provider and not a refresh, or a
+    // refresh of a channel that never finished picking its page
     let pages: any[] = [];
-    if (integrationProvider.isBetweenSteps && !refresh) {
+    if (
+      integrationProvider.isBetweenSteps &&
+      (!refresh || createUpdate.inBetweenSteps)
+    ) {
       try {
         // Check which method the provider uses (pages or companies)
         const fetchMethod =

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -17,6 +17,7 @@ import dayjs from 'dayjs';
 import { timer } from '@gitroom/helpers/utils/timer';
 import { ioRedis } from '@gitroom/nestjs-libraries/redis/redis.service';
 import {
+  Disconnect,
   NotEnoughScopes,
   RefreshToken,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -510,6 +511,11 @@ export class IntegrationService {
         );
         return loadAnalytics;
       } catch (e) {
+        if (e instanceof Disconnect) {
+          await this.disconnectChannel(org.id, getIntegration, e.message);
+          return [];
+        }
+
         if (e instanceof RefreshToken) {
           return this.checkAnalytics(org, integration, date, true);
         }

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -355,7 +355,9 @@ export class IntegrationService {
         integration.providerIdentifier,
         accessToken,
         refreshToken,
-        expiresIn
+        expiresIn,
+        undefined,
+        integration.inBetweenSteps
       );
     }
   }

--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -39,7 +39,9 @@ export class RefreshIntegrationService {
       integration.providerIdentifier,
       refresh.accessToken,
       refresh.refreshToken,
-      refresh.expiresIn
+      refresh.expiresIn,
+      undefined,
+      integration.inBetweenSteps
     );
 
     return refresh;

--- a/libraries/nestjs-libraries/src/integrations/social/gmb.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/gmb.provider.ts
@@ -10,6 +10,7 @@ import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library/build/src/auth/oauth2client';
 import {
   BadBody,
+  Disconnect,
   SocialAbstract,
   ValidityMedia,
 } from '@gitroom/nestjs-libraries/integrations/social.abstract';
@@ -80,12 +81,33 @@ export class GmbProvider extends SocialAbstract implements SocialProvider {
     return true;
   }
 
+  // A channel that never finished the location step still carries the Google
+  // user id as its id; v4/<userId>/localPosts is not a resource Google knows.
+  private checkLocationId(id: string) {
+    if (!id.startsWith('accounts/')) {
+      throw new Disconnect(
+        this.identifier,
+        JSON.stringify({ id }),
+        '{}',
+        'This channel is not linked to a business location. Please reconnect it and choose a business location.'
+      );
+    }
+  }
+
   override handleErrors(body: string):
     | {
         type: 'refresh-token' | 'bad-body';
         value: string;
       }
     | undefined {
+    if (body.includes('Error 404 (Not Found)')) {
+      return {
+        type: 'bad-body',
+        value:
+          'The business location for this channel could not be found. Please reconnect the channel and choose a business location.',
+      };
+    }
+
     if (body.includes('UNAUTHENTICATED') || body.includes('invalid_grant')) {
       return {
         type: 'refresh-token',
@@ -414,6 +436,8 @@ export class GmbProvider extends SocialAbstract implements SocialProvider {
     const [firstPost] = postDetails;
     const { settings } = firstPost;
 
+    this.checkLocationId(id);
+
     // Build the local post request body
     const postBody: any = {
       languageCode: 'en',
@@ -555,6 +579,8 @@ export class GmbProvider extends SocialAbstract implements SocialProvider {
     accessToken: string,
     date: number
   ): Promise<AnalyticsData[]> {
+    this.checkLocationId(id);
+
     try {
       const endDate = dayjs().format('YYYY-MM-DD');
       const startDate = dayjs().subtract(date, 'day').format('YYYY-MM-DD');


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, Google My Business provider and the integration refresh/reconnect path). Three things changed:

1. `createOrUpdateIntegration` callers no longer clear a channel's `inBetweenSteps` flag as a side effect. The two token-refresh callers (`RefreshIntegrationService.refresh` and `IntegrationService.refreshTokens`) now pass the row's existing `inBetweenSteps` instead of the default `false`, and the reconnect handler in `no.auth.integrations.controller.ts` passes the Redis-side `refresh` marker to the upsert so the update branch skips the flag. When a reconnected two-step channel is still pending, the handler now also fetches its pages so the picker is offered again.
2. `GmbProvider.post()` and `GmbProvider.analytics()` fail fast with a curated `Disconnect` error when the channel id does not start with `accounts/` (a channel that never picked a business location), instead of calling `v4/<userId>/localPosts`.
3. `GmbProvider.handleErrors` maps Google's HTML "Error 404 (Not Found)" page to a bad-body error telling the user to reconnect and pick a location, instead of the generic "Unknown Error".
4. `IntegrationService.checkAnalytics` now catches `Disconnect` from a provider's `analytics()`, flags the channel for reconnect via `disconnectChannel` and returns an empty result, the same way the provider-function endpoint already handles it. Before, the exception fell through the existing catch and returned an empty result without flagging the channel.

The upsert signature, the update branch in `integration.repository.ts`, the GMB pages/location step, and every other provider stayed the same. The prefix check cannot affect channels that completed the location step, whose ids all start with `accounts/`.

# Why was this change needed?

GMB is a two-step provider: the OAuth callback stores the Google user id as the channel id with `inBetweenSteps = true`, and picking a location replaces the id with `accounts/{accountId}/locations/{locationId}` and clears the flag. Several paths cleared the flag without replacing the id: reconnecting a channel that never finished step 2 (the upsert finds the pending row by the same Google user id and flips the flag), and both token-refresh callers (they leave `isBetweenSteps` at its default `false`). The result is a channel that looks connected, whose posts go to `v4/<userId>/localPosts`, and Google answers with its HTML 404 page, which none of the JSON error mappings recognise, so the user sees "Unknown Error".

Production shape on 2026-09-09 (no identifiers): 1244 GMB channels with an `accounts/` id and 5491 posts published in the last 30 days; 53 numeric-id channels still pending (harmless, cannot post); 16 numeric-id channels not pending, none of which has ever published a post. In the last 7 days, 83 GMB post failures carried Google's HTML 404 page, all from 4 of those 16 channels, and every one reached the user as "Unknown Error".

# Other information:

Observed in production on 2026-09-09 (worker logs 07:00-07:10 UTC and the Errors table, no identifiers): every GMB failure carrying Google's HTML 404 page came from channels in the "numeric id, not pending" group, and each reached the user as "Unknown Error". The 16 existing rows in that group are left as they are; with this change their next post fails fast with the reconnect message and the channel is flagged for reconnect, and once the user reconnects and picks a location the row gets a proper `accounts/...` id.

Testing done:
- Service layer, GMB provider driven directly: a numeric id throws `Disconnect` with the reconnect message from both `post()` and `analytics()` before any request is made; an `accounts/` id with a simulated Google HTML 404 response fails on the first call with the new bad-body message instead of retrying into "Unknown Error"; a simulated 200 `{ name, state: 'LIVE' }` still returns the same success shape and `releaseURL`; `handleErrors` with a `NOT_FOUND` JSON body still returns the existing message.
- Local database, repository upsert with a seeded pending numeric-id GMB row: the old refresh-caller argument shape set `inBetweenSteps` to false; the new shape keeps it true while still updating the tokens.
- Backend type-check passes for the changed files. The reconnect flow with a real Google account was not exercised.

Not touched: reconnecting a GMB channel that already completed the location step (id `accounts/...`) currently ends in `migrateIntegration` throwing "Please refresh the channel that needs to be refreshed", because the OAuth callback returns the numeric user id, which differs from the stored id. That is a separate pre-existing issue.

# QA

1. [ ] Seed a `gmb` integration row with a numeric `internalId` (e.g. `123456789`) and `inBetweenSteps = true`, then run the token-refresh path for it (call `RefreshIntegrationService.refresh` with the row, or let the hourly `refreshTokens` pick it up with an expired `tokenExpiration`). Expected: tokens are updated and `inBetweenSteps` stays `true`. Before this change it was set to `false`.
2. [ ] With a plain Google account that has no business listing, connect GMB, confirm the row is pending with a numeric id and the location picker is empty, then click reconnect on the channel and complete Google's consent again. Expected: the row keeps `inBetweenSteps = true` and the location picker is shown again (empty for this account). Before this change the flag flipped to `false` and the channel appeared connected.
3. [ ] Seed a `gmb` row with a numeric `internalId` and `inBetweenSteps = false`, and schedule a post on it. Expected: the post fails immediately with "This channel is not linked to a business location. Please reconnect it and choose a business location." and the channel is marked as needing a reconnect; no request is sent to Google.
4. [ ] Call `GmbProvider.handleErrors` with a body containing `Error 404 (Not Found)!!1` (Google's HTML page). Expected: `{ type: 'bad-body', value: 'The business location for this channel could not be found. Please reconnect the channel and choose a business location.' }`. A body containing `NOT_FOUND` still maps to the existing "Business location not found" message.
5. [ ] Open the analytics page for the channel from step 3 (numeric id, not pending). Expected: analytics show empty and the channel becomes marked as needing a reconnect; no 500 response.
6. [ ] Drive `GmbProvider.post` with an `accounts/1/locations/2` id and a mocked 200 response `{ name: 'accounts/1/locations/2/localPosts/9', state: 'LIVE' }`. Expected: success with `releaseURL` `https://business.google.com/locations/2`, unchanged from before.

# Checklist:

Put a "X" in the boxes below to indicate you have followed the checklist;

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhrPvHvFDB2cjc1JGVzxj4
