### PR TITLE
fix: return 4xx for missing post/media/integration and bad OAuth login callbacks

### DIFF
--- a/apps/backend/src/services/auth/auth.service.ts
+++ b/apps/backend/src/services/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { Provider, User } from '@prisma/client';
 import { CreateOrgUserDto } from '@gitroom/nestjs-libraries/dtos/auth/create.org.user.dto';
 import { LoginUserDto } from '@gitroom/nestjs-libraries/dtos/auth/login.user.dto';
@@ -335,14 +335,21 @@ export class AuthService {
       !redirectUri &&
       (!state || state !== stateCookie)
     ) {
-      throw new Error('Invalid state');
+      throw new HttpException('Invalid state', 400);
     }
 
     const providerInstance = this._providerManager.getProvider(provider);
-    const token = await providerInstance.getToken(code, redirectUri);
+    const token = await providerInstance
+      .getToken(code, redirectUri)
+      .catch((err) => {
+        if (String(err?.message).includes('invalid_grant')) {
+          throw new HttpException('Invalid or expired authorization code', 400);
+        }
+        throw err;
+      });
     const user = await providerInstance.getUser(token);
     if (!user) {
-      throw new Error('Invalid user');
+      throw new HttpException('Invalid user', 400);
     }
     const checkExists = await this._userService.getUserByProvider(
       user.id,

--- a/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/integrations/integration.service.ts
@@ -448,7 +448,7 @@ export class IntegrationService {
     const getIntegration = await this.getIntegrationById(org.id, integration);
 
     if (!getIntegration) {
-      throw new Error('Invalid integration');
+      throw new HttpException('Integration not found', HttpStatus.NOT_FOUND);
     }
 
     if (getIntegration.type !== 'social') {

--- a/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/media/media.service.ts
@@ -70,7 +70,11 @@ export class MediaService {
     return this._mediaRepository.getMedia(org, page, search);
   }
 
-  saveMediaInformation(org: string, data: SaveMediaInformationDto) {
+  async saveMediaInformation(org: string, data: SaveMediaInformationDto) {
+    const media = await this._mediaRepository.getMediaById(data.id);
+    if (!media || media.organizationId !== org) {
+      throw new HttpException('Media not found', 404);
+    }
     return this._mediaRepository.saveMediaInformation(org, data);
   }
 

--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -148,6 +148,13 @@ export class PostsService {
   }
 
   async updateReleaseId(orgId: string, postId: string, releaseId: string) {
+    const post = await this._postRepository.getPostById(postId, orgId);
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
+    if (post.releaseId !== 'missing') {
+      throw new BadRequestException('Post already has a release id');
+    }
     return this._postRepository.updateReleaseId(postId, orgId, releaseId);
   }
 


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, public API + auth). Four expected-failure paths that surfaced as unhandled 500s now return a 4xx with a message:

- `PostsService.updateReleaseId` looks the post up first: unknown post gives 404 "Post not found", a post whose release id is no longer `missing` gives 400 "Post already has a release id" (the update only matches rows still marked missing, so Prisma threw record-not-found).
- `MediaService.saveMediaInformation` looks the media row up and checks the org: unknown or foreign id gives 404 "Media not found".
- `IntegrationService.checkAnalytics` throws `HttpException('Integration not found', 404)` instead of a bare `Error('Invalid integration')`.
- `AuthService.checkExists` throws 400 for a bad state nonce and for a missing user, and maps a provider token exchange failing with the OAuth `invalid_grant` code to 400 "Invalid or expired authorization code". Any other token-exchange error is rethrown unchanged so provider outages still surface as 500s.

The DB writes, the analytics flow and the login flow are otherwise unchanged.

# Why was this change needed?

These were four of the recurring backend errors in production over the last 24h / 7d (Sentry):

- CLOUD-9X, Prisma "Record to update not found": 26 / 24h on `PUT /public/v1/posts/:id/release-id` (21) and `POST /media/information` (5).
- CLOUD-E4, `Invalid integration` in `checkAnalytics`: 12 / 24h on `GET /public/v1/analytics/:integration`.
- CLOUD-1S2, `Invalid state` in `checkExists`: 41 / 24h on `POST /auth/oauth/:provider/exists`.
- CLOUD-NR, `invalid_grant` from `GoogleProvider.getToken`: 11 / 24h on the same route.

All of them are caller-side conditions (deleted or already-released post, unknown media or channel id, replayed or expired login callback), not server faults. As 500s they count against error budgets and give API consumers nothing actionable; as 4xx they stop reaching Sentry and tell the caller what went wrong.

# Other information:

The register page only reads `token` from the oauth exists response, so a 400 leaves it on its spinner just as the 500 did. Showing that message is a separate frontend change.

# QA

1. [ ] With an org API key, `PUT /public/v1/posts/does-not-exist/release-id` with `{"releaseId":"abc"}` returns 404 "Post not found" (was 500)
2. [ ] Same call on a post that already has a release id returns 400 "Post already has a release id"
3. [ ] `GET /public/v1/analytics/does-not-exist?date=7` returns 404 "Integration not found" (was 500)
4. [ ] Logged in, `POST /media/information` with `{"id":"does-not-exist","alt":"x"}` returns 404 "Media not found"; with a real media id it still returns 201 and updates the alt text
5. [ ] `POST /auth/oauth/GOOGLE/exists` with a JSON body `{"code":"bogus","state":"abc"}` and no `oauth_state` cookie returns 400 "Invalid state"
6. [ ] Same call with `Cookie: oauth_state=abc` returns 400 "Invalid or expired authorization code" (Google rejects the bogus code with invalid_grant)
7. [ ] A real Google login still succeeds

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g3KqiuR5TT68XdqpTRbZh
