### PR TITLE
fix(sentry): stop reporting pre-controller body-parser and aborted-request errors

### DIFF
--- a/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
+++ b/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
@@ -68,9 +68,10 @@ export const initializeSentry = (appName: string) => {
         }),
       ],
       tracesSampleRate: 1.0,
-      // body-parser rejects oversized bodies with a 413 before any controller
-      // runs; Nest already answers it, so it is not an application error.
-      ignoreErrors: [/^request entity too large$/],
+      // body-parser / multer errors raised before any controller runs: an
+      // oversized body (Nest already answers 413) and a client that dropped
+      // the connection mid-request. Neither is an application error.
+      ignoreErrors: [/^request entity too large$/, /^request aborted$/i],
       enableLogs: true,
       beforeSendLog: (log: any) => {
         log.attributes = redactLogAttributes({

--- a/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
+++ b/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
@@ -68,6 +68,9 @@ export const initializeSentry = (appName: string) => {
         }),
       ],
       tracesSampleRate: 1.0,
+      // body-parser rejects oversized bodies with a 413 before any controller
+      // runs; Nest already answers it, so it is not an application error.
+      ignoreErrors: [/^request entity too large$/],
       enableLogs: true,
       beforeSendLog: (log: any) => {
         log.attributes = redactLogAttributes({


### PR DESCRIPTION
# What kind of change does this PR introduce?

Observability fix (backend/orchestrator Sentry init). Adds `ignoreErrors: [/^request entity too large$/, /^request aborted$/i]` to the shared `Sentry.init` in `initialize.sentry.ts`, so two Express-level errors raised before any controller runs are no longer reported as exceptions: body-parser's 413 for an oversized body, and the "request aborted" error from raw-body / multer when the client drops the connection mid-request. The HTTP behaviour is unchanged: Nest's base exception handler already answers the 413 with `{"statusCode":413,"message":"request entity too large"}`, and an aborted request has no client left to answer. Both patterns are anchored to the whole message, so any error that merely contains those phrases is still reported.

# Why was this change needed?

Three of the most frequent backend errors in production are these pre-controller Express errors:

- CLOUD-NP, `PayloadTooLargeError: request entity too large`: 61 events in the last 24h, 452 in 7d, of which 441 on `POST /public/v1/upload-from-url`, 9 on `POST /public/v1/upload`, 1 each on `POST /public/v1/media/upload` and `POST /public/v1/posts`.
- CLOUD-14N, `Error: Request aborted` (multer): 271 events in the last 24h, 650 in 7d, all on `POST /public/v1/upload`; the top backend error by volume.
- CLOUD-P0, `BadRequestError: request aborted` (raw-body): 21 in 7d across `POST /public/t`, `POST /public/v1/posts`, `/copilot/*`, `POST /posts` and `GET /auth/oauth/GOOGLE`.

The Sentry Nest filter only treats Nest `HttpException` instances as expected, so these plain Express errors are captured as if they were application crashes. Every other expected client error we map stays out of Sentry because it becomes an `HttpException` in a controller or service; there is no such place for errors thrown before routing, hence the init-level ignore.

# Other information:

An exception filter catching the body-parser error class would express the same thing in code, but needs `http-errors` as a new declared dependency and a global filter for a handful of cases.

# QA

1. [ ] With an org API key, `POST /public/v1/upload-from-url` with a JSON body of about 200 KB (e.g. `{"url":"https://example.com/a.png","pad":"xxxx..."}`) and confirm the response is still `413 {"statusCode":413,"message":"request entity too large"}`
2. [ ] Start a `POST /public/v1/upload` multipart request and kill the client before the body finishes (e.g. `curl --limit-rate 1k` then Ctrl+C); the backend logs nothing beyond the request and stays healthy
3. [ ] Confirm no new events for those requests show up under Sentry issues CLOUD-NP, CLOUD-14N or CLOUD-P0 for the deployed environment
4. [ ] Trigger any other backend error and confirm unrelated errors keep arriving in Sentry

Verified locally: reproduced step 1 against the local backend (413 with that body, before and after the change). Ran a standalone script against the installed `@sentry/nestjs` SDK with the same `ignoreErrors` value and a `beforeSend` spy: errors with the exact messages `request entity too large`, `Request aborted` and `request aborted` never reach `beforeSend`, while `Channel not found`, `Request aborted by user`, `The request aborted early` and `request entity too large (413)` all do. The live capture path (Sentry Nest filter to SDK) was not exercised end to end because the local backend has no way to observe outgoing events.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g3KqiuR5TT68XdqpTRbZh
