### PR TITLE
fix(instagram): disconnect the channel on Meta checkpoint errors instead of failing every post

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -103,7 +103,7 @@ export class InstagramProvider
     status: number
   ):
     | {
-        type: 'refresh-token' | 'bad-body' | 'retry';
+        type: 'refresh-token' | 'bad-body' | 'retry' | 'disconnect';
         value: string;
       }
     | undefined {
@@ -327,6 +327,20 @@ export class InstagramProvider
       return {
         type: 'bad-body' as const,
         value: 'Aspect ratio not supported, must be between 4:5 to 1.91:1',
+      };
+    }
+
+    // Meta put the account behind a checkpoint: the token is still valid, so a
+    // refresh cannot help and every post fails until the user logs in on
+    // Instagram and re-connects the channel.
+    if (
+      body.indexOf('You cannot access the app till you log in to') > -1 ||
+      body.indexOf('Session key is malformed') > -1
+    ) {
+      return {
+        type: 'disconnect' as const,
+        value:
+          'Instagram requires you to log in at instagram.com and follow its instructions before posting can resume. After that, please reconnect this channel.',
       };
     }
 

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.standalone.provider.ts
@@ -68,7 +68,10 @@ export class InstagramStandaloneProvider
     body: string,
     status: number
   ):
-    | { type: 'refresh-token' | 'bad-body' | 'retry'; value: string }
+    | {
+        type: 'refresh-token' | 'bad-body' | 'retry' | 'disconnect';
+        value: string;
+      }
     | undefined {
     return instagramProvider.handleErrors(body, status);
   }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Instagram and Instagram standalone providers, error mapping). In `InstagramProvider.handleErrors` (`libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts`) a new branch, placed before the generic code-190 branch, matches the two Meta checkpoint bodies `Error validating access token: You cannot access the app till you log in to www.instagram.com and follow the instructions given.` and `Error validating access token: Session key is malformed because of invalid user id.` and returns `type: 'disconnect'` with a message telling the user to log in on Instagram and then reconnect the channel. The `disconnect` type already exists in the shared `fetch` path and in the post activity: it flags the channel for reconnect, sends the one in-app notification, and rethrows a terminal BadBody that every frozen workflow version understands. The standalone provider delegates to the same method, so both get it; only the return type unions of the two `handleErrors` signatures were widened. Every other code-190 body keeps the existing "missing some permissions" bad-body mapping, and no workflow, activity signature or generic code changed.

# Why was this change needed?

Both bodies mean Meta has put the account behind a checkpoint. The access token is still valid, so a token refresh cannot help, and the account stays blocked until the user logs in on Instagram and follows Meta's instructions. Today they fall into the generic code-190 branch as a non-retryable bad-body with the text "The account is missing some permissions to perform this action, please re-add the account and allow all permissions", which is wrong in two ways: the advice does not fix anything, and because it is bad-body rather than disconnect the channel is never flagged, so every subsequent scheduled post on that channel fails the same way.

Prod numbers, Errors table for the 7 days ending 2026-09-09: 598 post failures with the "log in to www.instagram.com" body and 109 with the "Session key is malformed" body, across 26 organizations. 85 of the affected channels carried no reconnect flag at all and kept failing post after post, 525 failed posts between them in that week. In the worker logs of 2026-09-09 07:00-07:10 UTC this was the second largest Instagram failure class after transient container errors. With this change the first failure flags the channel and notifies the user, and later posts fail with the existing "Refresh channel needed" message instead of a misleading permissions error.

`disconnect` was chosen over `refresh-token` deliberately: the refresh-then-retry cycle in the post workflow has no attempt cap, and since the token is usually still valid the refresh tends to succeed, which would loop the same rejection.

# Other information:

Mapping is by substring on the Meta message text, not on the error code, so it is safe regardless of `error_subcode`. Verified locally with the exact response bodies recorded in production (trace ids redacted):

- classification: both bodies -> `disconnect` on both providers; a different code-190 body (`This Page access token belongs to a Page that is not accessible.`) still -> the existing bad-body message
- shared `fetch` against a local HTTP server returning each body with status 400 -> `Disconnect` thrown for the two new cases, `BadBody` for the control case
- `PostActivity.handleDisconnect` with a stubbed integration service -> `disconnectChannel` called once with the mapped message, then a non-retryable `BadBody` rethrown, no refresh and no retry

Orchestrator typecheck passes; the three reported errors are pre-existing implicit-any issues in unrelated files.

# QA

1. [ ] Connect an Instagram (standalone or via Facebook) channel locally and schedule a post on it.
2. [ ] Make the Graph call return the checkpoint body, for example by pointing the provider's media request at a local server that answers status 400 with `{"error":{"message":"Error validating access token: You cannot access the app till you log in to www.instagram.com and follow the instructions given.","type":"OAuthException","code":190,"error_subcode":0,"fbtrace_id":"x"}}`, then let the post publish.
3. [ ] Expected: the post ends in ERROR with the message "Instagram requires you to log in at instagram.com and follow its instructions before posting can resume. After that, please reconnect this channel.", the channel shows the reconnect state in the channel list, and one in-app notification about the channel was created.
4. [ ] Schedule a second post on the same channel: expected it fails with the existing "Refresh channel needed" message rather than hitting Instagram again.
5. [ ] Repeat step 2 with the body message `Error validating access token: Session key is malformed because of invalid user id.`: same outcome as step 3.
6. [ ] Repeat step 2 with a code-190 body whose message is anything else, e.g. `This Page access token belongs to a Page that is not accessible.`: expected the existing "The account is missing some permissions..." error and the channel is not flagged.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJZGgvB5qop47sQonXiEcj
