### PR TITLE
fix(linkedin): request only member scopes for personal profile and use prompt=consent

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.page.provider.ts
@@ -123,7 +123,7 @@ export class LinkedinPageProvider
   override async generateAuthUrl() {
     const state = makeId(6);
     const codeVerifier = makeId(30);
-    const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&prompt=none&client_id=${
+    const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&prompt=consent&client_id=${
       process.env.LINKEDIN_CLIENT_ID
     }&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin-page`

--- a/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/linkedin.provider.ts
@@ -65,10 +65,6 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     'openid',
     'profile',
     'w_member_social',
-    'r_basicprofile',
-    'rw_organization_admin',
-    'w_organization_social',
-    'r_organization_social',
   ];
   override maxConcurrentJob = 2;
   refreshWait = true;
@@ -182,7 +178,7 @@ export class LinkedinProvider extends SocialAbstract implements SocialProvider {
     const codeVerifier = makeId(30);
     const url = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${
       process.env.LINKEDIN_CLIENT_ID
-    }&prompt=none&redirect_uri=${encodeURIComponent(
+    }&prompt=consent&redirect_uri=${encodeURIComponent(
       `${process.env.FRONTEND_URL}/integrations/social/linkedin`
     )}&state=${state}&scope=${encodeURIComponent(this.scopes.join(' '))}`;
     return {


### PR DESCRIPTION
<h1 dir="ltr" style="">What kind of change does this PR introduce?</h1>

<p dir="ltr" style="">Bug fix</p>

<h1 dir="ltr" style="">Why was this change needed?</h1>

<p dir="ltr" style="">Self-hosted instances cannot connect a personal LinkedIn profile. Two separate
issues combine to make the OAuth flow fail, and fixing only one of them is not
enough.</p>

<p dir="ltr" style=""><strong>1. Organization scopes on the personal provider</strong></p>

<p dir="ltr" style=""><code>LinkedinProvider</code> requests seven scopes, four of which (<code>r_basicprofile</code>,
<code>rw_organization_admin</code>, <code>w_organization_social</code>, <code>r_organization_social</code>)
require the Community Management API.</p>

<p dir="ltr" style="">LinkedIn's policy is that Community Management API must be the <strong>only</strong> product
on an application. It cannot coexist with "Share on LinkedIn" or "Sign In with
LinkedIn using OpenID Connect". The developer portal blocks the request with:</p>

<blockquote style="">
<p dir="ltr">This API product requires that it be the only product on the application for
legal and security reasons.</p>

</blockquote>

<p dir="ltr" style="">Since LinkedIn rejects the entire authorization request if a single scope is
unauthorized, no self-hosted setup can satisfy the current scope list. An app
with the two standard products lacks the org scopes; an app with Community
Management API lacks <code>w_member_social</code> and cannot have it added.</p>

<p dir="ltr" style=""><strong>2. <code>prompt=none</code> prevents first-time consent</strong></p>

<p dir="ltr" style="">Both providers build the authorization URL with <code>prompt=none</code>, which requests
silent authorization. LinkedIn only returns scopes the user has already
consented to. On a first connection there is no prior consent, so the request
fails regardless of scope correctness.</p>

<p dir="ltr" style="">This is why reducing the scopes alone does not fix the flow.</p>

<h1 dir="ltr" style="">Changes</h1>

<div dir="ltr" style="">
File | Change
-- | --
linkedin.provider.ts | Scopes reduced to openid, profile, w_member_social
linkedin.provider.ts | prompt=none -> prompt=consent
linkedin.page.provider.ts | prompt=none -> prompt=consent (scopes unchanged)

</div>

<p dir="ltr" style=""><code>LinkedinPageProvider</code> extends <code>LinkedinProvider</code> and overrides <code>scopes</code>, so
reducing the parent's scopes does not affect organization page functionality.</p>

<h1 dir="ltr" style="">Testing</h1>

<p dir="ltr" style="">Verified on a self-hosted instance (Docker Compose, current <code>latest</code> image) by
applying the equivalent change to the compiled output and restarting the
container.</p>

<p dir="ltr" style="">Result: the LinkedIn authorization screen renders correctly and the personal
profile channel connects successfully. Before the change, the flow returned
LinkedIn's generic error page.</p>

<p dir="ltr" style="">The LinkedIn Page provider still requests the full scope set as expected. It
could not be tested end to end because Community Management API access is
pending LinkedIn review, which is precisely the situation this PR addresses for
the personal provider.</p>

<h1 dir="ltr" style="">Related issues</h1>

<ul dir="ltr" style="">
<li>Fixes #1582</li>
<li>Fixes #1580</li>
<li>Relates to #844, #1197, #1243</li>
</ul>

<p dir="ltr" style="">Previous attempts (#1134, #1658) were closed. #1134 addressed only the scopes
and additionally bundled an unrelated Ghost CMS provider, which drew review
comments and sank the whole PR. This one is limited to the LinkedIn OAuth fix
and addresses both root causes.</p>