### PR TITLE
fix(posts): delete published posts from the platform, and report the result

### DIFF
--- a/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
+++ b/libraries/nestjs-libraries/src/database/prisma/posts/posts.service.ts
@@ -649,6 +649,12 @@ export class PostsService {
   }
 
   async deletePost(orgId: string, group: string) {
+    // Take the published copies down on the platform BEFORE the local rows are
+    // soft-deleted, otherwise the integration and release id needed to reach
+    // them are no longer selectable and the post is stranded: gone from the
+    // calendar, still live on the channel.
+    const platform = await this.deleteFromPlatform(orgId, group);
+
     const post = await this._postRepository.deletePost(orgId, group);
 
     if (post?.id) {
@@ -676,7 +682,63 @@ export class PostsService {
       } catch (err) {}
     }
 
-    return { error: true };
+    return { ...platform };
+  }
+
+  /**
+   * Remove already-published posts in this group from their platforms.
+   *
+   * Providers implement `deletePost` only where the platform actually allows
+   * it, so an unsupported channel is reported rather than silently ignored —
+   * the caller can then tell someone the post is still live instead of
+   * showing a delete that only cleared the calendar.
+   */
+  private async deleteFromPlatform(orgId: string, group: string) {
+    const deleted: string[] = [];
+    const stillLive: { integration: string; reason: string }[] = [];
+
+    let posts: any[] = [];
+    try {
+      posts = await this._postRepository.getPostsByGroup(orgId, group);
+    } catch (err) {
+      return { error: false, deleted, stillLive };
+    }
+
+    for (const post of posts) {
+      // Nothing was published yet: cancelling the workflow is the whole job.
+      if (post.state !== 'PUBLISHED' || !post.releaseId || !post.integration) {
+        continue;
+      }
+
+      const provider = this._integrationManager.getSocialIntegration(
+        post.integration.providerIdentifier
+      );
+
+      if (!provider?.deletePost) {
+        stillLive.push({
+          integration: post.integration.providerIdentifier,
+          reason: 'platform does not support deleting a published post',
+        });
+        continue;
+      }
+
+      try {
+        await provider.deletePost(
+          post.integration.internalId,
+          post.releaseId,
+          post.integration.token,
+          post.integration
+        );
+        deleted.push(post.integration.providerIdentifier);
+      } catch (err) {
+        stillLive.push({
+          integration: post.integration.providerIdentifier,
+          reason: err?.message || 'delete rejected by the platform',
+        });
+      }
+    }
+
+    return { error: false, deleted, stillLive };
   }
 
   async countPostsFromDay(orgId: string, date: Date) {

--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -604,6 +604,43 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
     ];
   }
 
+  /**
+   * Delete a published Page post.
+   *
+   * The post id must carry the page id prefix that the Graph API itself
+   * returns. The id embedded in a permalink can use a different page
+   * identifier, and deleting with that one fails with a misleading
+   * "(#200) New Pages experience not supported", which reads as though the
+   * operation were unavailable rather than as a wrong id. Resolve the
+   * canonical id first so the caller is not left guessing.
+   *
+   * A page access token is required; a user or system-user token returns
+   * "(#200) Page token is required to delete posts on page".
+   */
+  async deletePost(id: string, postId: string, accessToken: string) {
+    const canonicalId = await (async () => {
+      try {
+        const { id: resolved } = await (
+          await this.fetch(
+            `https://graph.facebook.com/v20.0/${postId}?fields=id&access_token=${accessToken}`,
+            {},
+            'resolve post id'
+          )
+        ).json();
+
+        return resolved || postId;
+      } catch (err) {
+        return postId;
+      }
+    })();
+
+    await this.fetch(
+      `https://graph.facebook.com/v20.0/${canonicalId}?access_token=${accessToken}`,
+      { method: 'DELETE' },
+      'delete post'
+    );
+  }
+
   async comment(
     id: string,
     postId: string,

--- a/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/instagram.provider.ts
@@ -798,6 +798,25 @@ export class InstagramProvider
     return '';
   }
 
+  /**
+   * Delete published media.
+   *
+   * Supported for images, videos and reels that are not ads. A carousel has
+   * to be deleted whole by passing the album's container id; individual
+   * children cannot be removed.
+   */
+  async deletePost(id: string, postId: string, accessToken: string) {
+    const type = this.identifier === 'instagram-standalone'
+      ? 'graph.instagram.com'
+      : 'graph.facebook.com';
+
+    await this.fetch(
+      `https://${type}/v20.0/${postId}?access_token=${accessToken}`,
+      { method: 'DELETE' },
+      'delete post'
+    );
+  }
+
   async analytics(
     id: string,
     accessToken: string,

--- a/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/social.integrations.interface.ts
@@ -97,6 +97,16 @@ export interface ISocialMediaIntegration {
     postDetails: PostDetails[],
     integration: Integration
   ): Promise<PostResponse[]>; // Schedules a new post
+
+  // Removes an already-published post from the platform. Optional: most
+  // platforms either forbid it or never exposed an endpoint, and the caller
+  // treats a missing implementation as "local delete only".
+  deletePost?(
+    id: string,
+    postId: string,
+    accessToken: string,
+    integration: Integration
+  ): Promise<void>;
 }
 
 export type PostResponse = {


### PR DESCRIPTION
### The problem

`PostsService.deletePost()` ends in a hardcoded `return { error: true }`, returned on success and failure alike, so a caller cannot tell what happened.

Underneath, `PostsRepository.deletePost()` only stamps `deletedAt` and the service terminates the scheduling workflow. No provider implements a platform-side delete. So deleting an **already published** post removes it from the calendar and leaves it live on the channel, with no signal that anything was left behind. Postiz and the actual page then disagree silently.

For an unpublished post this is all correct — cancelling the workflow is the whole job. The gap is only for published ones.

### The change

- Adds an optional `deletePost` to `ISocialMediaIntegration`.
- Implements it for Facebook and Instagram, both of which support deletion.
- `deletePost()` now takes published copies down **before** the local rows are soft-deleted. After the soft delete the integration and `releaseId` are no longer selectable, so the post would be stranded.
- Returns what actually happened: which channels were deleted, and which are still live with a reason. A provider with no `deletePost` is reported rather than silently skipped, so a UI can say the post is still up instead of showing a delete that only cleared a row.

Providers that cannot delete are unaffected, and unpublished posts behave exactly as before.

### The Facebook detail worth knowing

The Facebook implementation resolves the canonical post id before deleting.

The id embedded in a permalink can carry a **different page identifier** from the one the Graph API returns for the same post. Deleting with the permalink's id fails with:

```
(#200) New Pages experience not supported:
This endpoint is not supported in the new Pages experience.
```

which reads as though the endpoint were unavailable, and is widely reported as such. It is not — it is what Meta returns for a wrong page-id prefix. Resolving `?fields=id` first and deleting the canonical id returns `{"success": true}`. Same token, same post, same endpoint.

Verified against a live Page: the permalink id failed with the message above, the canonical id deleted successfully, and a follow-up read confirmed the post was gone.

A **page** token is required. A user or system-user token returns `(#200) Page token is required to delete posts on page`.

### Instagram

A plain `DELETE` on the media id, supported for non-ad images, videos and reels. A carousel must be deleted whole via its container id; individual children cannot be removed. Also verified against live media.

### Notes

- No schema change, no new dependency, no behaviour change for other providers.
- Field names used (`state`, `releaseId`, `integration.internalId/token/providerIdentifier`) match the current Prisma schema.