### PR TITLE
fix(sentry): load the Sentry modules behind the DSN guard

### DIFF
--- a/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
+++ b/libraries/nestjs-libraries/src/sentry/initialize.sentry.ts
@@ -1,6 +1,28 @@
-import * as Sentry from '@sentry/nestjs';
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { capitalize } from 'lodash';
+
+type SentryModule = typeof import('@sentry/nestjs');
+
+let cachedSentry: SentryModule | null = null;
+
+// Loading @sentry/nestjs and @sentry/profiling-node together deadlocks the module
+// loader on roughly 2% of process starts: the instrumentation hook @sentry/nestjs
+// installs on require races the dlopen @sentry/profiling-node performs for its
+// native addon. The process keeps a live Node runtime but never reaches Nest, so
+// there is no crash, no log line, and — in the orchestrator — no Temporal worker.
+//
+// Because these were top-level imports, that risk was paid on every start, even
+// with Sentry entirely unconfigured. Loading them behind the DSN check removes it
+// for every deployment that does not use Sentry.
+const loadSentry = (): SentryModule | null => {
+  if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
+    return null;
+  }
+  if (!cachedSentry) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    cachedSentry = require('@sentry/nestjs');
+  }
+  return cachedSentry;
+};
 
 export const setSentryUserContext = (params: {
   userId?: string;
@@ -9,6 +31,10 @@ export const setSentryUserContext = (params: {
   paymentId?: string | null;
 }) => {
   try {
+    const Sentry = loadSentry();
+    if (!Sentry) {
+      return;
+    }
     Sentry.setUser(
       params.userId
         ? { id: params.userId, ...(params.email ? { email: params.email } : {}) }
@@ -26,11 +52,15 @@ export const setSentryUserContext = (params: {
 };
 
 export const initializeSentry = (appName: string, allowLogs = false) => {
-  if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  const Sentry = loadSentry();
+  if (!Sentry) {
     return null;
   }
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { nodeProfilingIntegration } = require('@sentry/profiling-node');
+
     Sentry.init({
       initialScope: {
         tags: {


### PR DESCRIPTION
## What

`initialize.sentry.ts` imports `@sentry/nestjs` and `@sentry/profiling-node` at the top level. This moves both behind a shared lazy loader gated on `NEXT_PUBLIC_SENTRY_DSN`, so they are only loaded when Sentry is actually configured.

## Why

Loaded together, those two modules deadlock the module loader on roughly **2% of process starts**: the instrumentation hook `@sentry/nestjs` installs on `require` races the `dlopen` that `@sentry/profiling-node` performs for its native addon.

When it happens, the process keeps a live Node runtime but **never reaches Nest** — so there is no crash, no `Starting Nest application` line, and, in the orchestrator, no Temporal worker. For a scheduler this is the worst shape a failure can take: `pm2` reports `online` with 0 restarts, the calendar looks full, and posts sit in `QUEUE` past their time with no error attached. The instance where this was diagnosed lost **97 posts over nine days** before anyone noticed, across four separate episodes in twelve months.

Because these are top-level imports, the risk is paid on **every** start — including by the majority of self-hosters who never set a DSN, and for whom `initializeSentry` returns `null` immediately anyway.

## Measurements

Ephemeral `node -e` processes inside a running container, 10s timeout, nothing touching the publishing queue:

| what was loaded | blocked |
|---|---|
| `@sentry/profiling-node` alone | 0 / 25 |
| `@sentry/nestjs` alone | 0 / 60 |
| both, as imported today | **2 / 105** (~1.9%) |
| both, behind the DSN guard (this PR) | **0 / 105** |

Neither module blocks on its own — it is the combination.

The detector was validated in both directions before those numbers were trusted: a process that never exits gives `exit 124`, one that exits cleanly gives `exit 0`.

**Behaviour with this change, verified:**

| scenario | result |
|---|---|
| no DSN, 105 starts | 0 blocked |
| no DSN | nothing under `@sentry` in `require.cache`; `initializeSentry` returns `null` |
| **DSN set** | `initializeSentry` returns `true`, 604 `@sentry` modules loaded, no exception |

So Sentry users are unaffected.

## Signature, for anyone triaging this

A stuck process:

```
wchan:   futex_wait_queue     ← all 11 threads, the 4 libuv workers included
Threads: 11                   ← a healthy worker has ~135; 11 is an empty Node runtime
utime/stime unchanged across two reads 5s apart   ← 0% CPU, so not slow startup
```

Counting threads separates this from a slow or failed start in two seconds, and `pm2` will not: the process is `online` either way.

Ruled out with evidence: OOM (`OOMKilled=false`, no `oom-kill` in dmesg, 56 GB free), slow startup (0% CPU over five minutes), and the Temporal addon itself (`@temporalio/core-bridge` loaded 30/30 without blocking).

## Notes

`setSentryUserContext` also uses `Sentry`, which is why this uses a shared lazy loader rather than moving the imports into `initializeSentry`.

Related: #1748 and #2035 report this symptom with the cause attributed to the Temporal connection, and #2027 addressed a cold-boot hang by waiting for Temporal in compose. This is a different path to the same symptom — the one that leaves no log line at all, and that waiting for Temporal cannot fix.

Running in production on a self-hosted instance since today.
