### PR TITLE
fix: guard against duplicate Stripe subscriptions per customer

### DIFF
--- a/apps/frontend/src/components/billing/first.billing.component.tsx
+++ b/apps/frontend/src/components/billing/first.billing.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { useVariables } from '@gitroom/react/helpers/variable.context';
 import { loadStripe, Stripe } from '@stripe/stripe-js';
@@ -54,6 +54,7 @@ export const FirstBillingComponent = () => {
   const [tier, setTier] = useState('STANDARD');
   const [period, setPeriod] = useState('MONTHLY');
   const fetch = useFetch();
+  const { mutate } = useSWRConfig();
   const modals = useModals();
   const t = useT();
   const [datafast_visitor_id] = useCookie('datafast_visitor_id', '');
@@ -105,6 +106,12 @@ export const FirstBillingComponent = () => {
       refreshWhenHidden: false,
     }
   );
+
+  useEffect(() => {
+    if (data?.blocked) {
+      mutate('/user/self');
+    }
+  }, [data?.blocked, mutate]);
 
   const price = useMemo(
     () => Object.entries(pricing).filter(([key, value]) => key !== 'FREE'),

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -162,7 +162,7 @@ export class StripeService extends PaymentProviderAbstract {
     );
     if (isDuplicate) {
       await stripe.subscriptions.cancel(event.data.object.id);
-      logger.info('stripe_duplicate_subscription_cancelled', {
+      console.log('stripe_duplicate_subscription_cancelled', {
         stripe_event_type: event.type,
         stripe_event_id: event.id,
         stripe_subscription_id: event.data.object.id,
@@ -230,7 +230,7 @@ export class StripeService extends PaymentProviderAbstract {
       period: 'MONTHLY' | 'YEARLY';
       uniqueId: string;
     };
-    logger.info('stripe_subscription_deleted_survivor_kept', {
+    console.log('stripe_subscription_deleted_survivor_kept', {
       stripe_event_type: event.type,
       stripe_event_id: event.id,
       stripe_subscription_id: event.data.object.id,

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { Organization, User } from '@prisma/client';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';
@@ -446,6 +446,10 @@ export class StripeService extends PaymentProviderAbstract {
     const subscriptions = await this.getLiveSubscriptions(customer);
 
     const sub = subscriptions[0];
+
+    if (!sub) {
+      throw new BadRequestException('No active subscription found');
+    }
 
     // If the user is toggling back (un-cancelling), just remove the cancel
     if (sub.cancel_at_period_end) {

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -150,6 +150,26 @@ export class StripeService extends PaymentProviderAbstract {
       uniqueId: string;
     };
 
+    const liveSubscriptions = await this.getLiveSubscriptions(
+      event.data.object.customer as string
+    );
+    const isDuplicate = liveSubscriptions.some(
+      (f) =>
+        f.id !== event.data.object.id &&
+        (f.created < event.data.object.created ||
+          (f.created === event.data.object.created &&
+            f.id < event.data.object.id))
+    );
+    if (isDuplicate) {
+      await stripe.subscriptions.cancel(event.data.object.id);
+      logger.info('stripe_duplicate_subscription_cancelled', {
+        stripe_event_type: event.type,
+        stripe_event_id: event.id,
+        stripe_subscription_id: event.data.object.id,
+      });
+      return { ok: true };
+    }
+
     try {
       const check = await this.checkValidCard(event);
       if (!check) {
@@ -195,9 +215,41 @@ export class StripeService extends PaymentProviderAbstract {
   }
 
   async deleteSubscription(event: Stripe.CustomerSubscriptionDeletedEvent) {
-    await this._subscriptionService.deleteSubscription(
-      event.data.object.customer as string,
-      STRIPE_PROVIDER
+    const customer = event.data.object.customer as string;
+    const [survivor] = await this.getLiveSubscriptions(customer);
+    if (!survivor) {
+      await this._subscriptionService.deleteSubscription(
+        customer,
+        STRIPE_PROVIDER
+      );
+      return;
+    }
+
+    const { uniqueId, billing, period } = survivor.metadata as {
+      billing: 'STANDARD' | 'PRO';
+      period: 'MONTHLY' | 'YEARLY';
+      uniqueId: string;
+    };
+    logger.info('stripe_subscription_deleted_survivor_kept', {
+      stripe_event_type: event.type,
+      stripe_event_id: event.id,
+      stripe_subscription_id: event.data.object.id,
+      stripe_survivor_id: survivor.id,
+      outcome: pricing[billing] && period ? 'resynced' : 'metadata_missing',
+    });
+    if (!pricing[billing] || !period) {
+      return;
+    }
+
+    return this._subscriptionService.createOrUpdateSubscription(
+      STRIPE_PROVIDER,
+      survivor.status !== 'active',
+      uniqueId,
+      customer,
+      pricing[billing].channel!,
+      billing,
+      period,
+      survivor.cancel_at
     );
   }
 
@@ -373,28 +425,38 @@ export class StripeService extends PaymentProviderAbstract {
     });
   }
 
+  private async getLiveSubscriptions(customer?: string | null) {
+    if (!customer || !customer.startsWith('cus_')) {
+      return [];
+    }
+
+    return (
+      await stripe.subscriptions.list({
+        customer,
+        status: 'all',
+        expand: ['data.latest_invoice'],
+      })
+    ).data.filter((f) => f.status !== 'canceled');
+  }
+
   async setToCancel(organizationId: string) {
     const id = makeId(10);
     const org = await this._organizationService.getOrgById(organizationId);
     const customer = await this.createOrGetCustomer(org!);
-    const currentUserSubscription = {
-      data: (
-        await stripe.subscriptions.list({
-          customer,
-          status: 'all',
-          expand: ['data.latest_invoice'],
-        })
-      ).data.filter((f) => f.status !== 'canceled'),
-    };
+    const subscriptions = await this.getLiveSubscriptions(customer);
 
-    const sub = currentUserSubscription.data[0];
+    const sub = subscriptions[0];
 
     // If the user is toggling back (un-cancelling), just remove the cancel
     if (sub.cancel_at_period_end) {
-      const { cancel_at } = await stripe.subscriptions.update(sub.id, {
-        cancel_at_period_end: false,
-        metadata: { service: 'gitroom', id },
-      });
+      let cancel_at: number | null = null;
+      for (const s of subscriptions) {
+        const updated = await stripe.subscriptions.update(s.id, {
+          cancel_at_period_end: false,
+          metadata: { service: 'gitroom', id },
+        });
+        cancel_at = cancel_at || updated.cancel_at;
+      }
 
       return {
         id,
@@ -411,7 +473,9 @@ export class StripeService extends PaymentProviderAbstract {
 
     if (hasFailedPayment) {
       // Payment already failed — cancel immediately and delete subscription
-      await stripe.subscriptions.cancel(sub.id);
+      for (const s of subscriptions) {
+        await stripe.subscriptions.cancel(s.id);
+      }
       await this._subscriptionService.deleteSubscription(
         customer,
         STRIPE_PROVIDER
@@ -424,10 +488,16 @@ export class StripeService extends PaymentProviderAbstract {
     }
 
     // Payment succeeded — cancel at end of billing period
-    const { cancel_at } = await stripe.subscriptions.update(sub.id, {
-      cancel_at_period_end: true,
-      metadata: { service: 'gitroom', id },
-    });
+    let cancel_at: number | null = null;
+    for (const s of subscriptions) {
+      const updated = await stripe.subscriptions.update(s.id, {
+        cancel_at_period_end: true,
+        metadata: { service: 'gitroom', id },
+      });
+      if (updated.cancel_at && (!cancel_at || updated.cancel_at < cancel_at)) {
+        cancel_at = updated.cancel_at;
+      }
+    }
 
     return {
       id,
@@ -777,6 +847,9 @@ export class StripeService extends PaymentProviderAbstract {
     const priceData = pricing[body.billing];
     const org = await this._organizationService.getOrgById(organizationId);
     const customer = await this.createOrGetCustomer(org!);
+    if ((await this.getLiveSubscriptions(customer)).length) {
+      return { blocked: true };
+    }
     const allProducts = await stripe.products.list({
       active: true,
       expand: ['data.prices'],
@@ -1042,18 +1115,15 @@ export class StripeService extends PaymentProviderAbstract {
 
     const customer = org.paymentId;
 
-    const subscriptions = (
-      await stripe.subscriptions.list({
-        customer,
-        status: 'all',
-      })
-    ).data.filter((f) => f.status !== 'canceled');
+    const subscriptions = await this.getLiveSubscriptions(customer);
 
     if (!subscriptions.length) {
       throw new Error('No active subscription found');
     }
 
-    await stripe.subscriptions.cancel(subscriptions[0].id);
+    for (const subscription of subscriptions) {
+      await stripe.subscriptions.cancel(subscription.id);
+    }
     await this._subscriptionService.deleteSubscription(
       customer,
       STRIPE_PROVIDER

--- a/libraries/nestjs-libraries/src/services/stripe.service.ts
+++ b/libraries/nestjs-libraries/src/services/stripe.service.ts
@@ -1,5 +1,5 @@
 import Stripe from 'stripe';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import { Organization, User } from '@prisma/client';
 import { SubscriptionService } from '@gitroom/nestjs-libraries/database/prisma/subscriptions/subscription.service';
 import { OrganizationService } from '@gitroom/nestjs-libraries/database/prisma/organizations/organization.service';


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend billing + onboarding pricing page). In `stripe.service.ts` a private `getLiveSubscriptions(customer)` helper lists the customer's non-canceled subscriptions (skipping non-`cus_` ids, i.e. admin-granted rows) and is used in four places: `embedded` returns `{ blocked: true }` instead of creating a checkout session when the org's customer already has a live subscription; `createSubscription` (the `customer.subscription.created` webhook) cancels the incoming subscription in Stripe and skips the DB upsert when an older live subscription exists, before `checkValidCard` runs; `deleteSubscription` (the `deleted` webhook) only downgrades the org when no live subscription remains, otherwise it re-syncs the `Subscription` row from the survivor's metadata; `setToCancel` / `cancelSubscription` act on every live subscription instead of the first one. The onboarding page (`first.billing.component.tsx`) re-fetches the user when it gets a `blocked` response so the pricing page disappears once the row exists. No schema change, no new env var; `checkSubscription`, the `track` cookie, the upsert key, lifetime and store-managed (RevenueCat) paths are untouched.

# Why was this change needed?

A Cloud customer ended up with two active Stripe subscriptions on the same customer: a STANDARD trial confirmed during onboarding on 2026-07-15 and a PRO subscription confirmed 21 minutes later from the same onboarding pricing page (a stale page instance keeps live checkout sessions per tier). Both billed from then on while the app showed a single plan, because the webhook upsert is keyed on the org and the second subscription silently overwrote the first row. On 2026-09-09 the STANDARD subscription was cancelled from the Stripe dashboard to stop the double billing; the `customer.subscription.deleted` handler keyed the deletion on the customer id, hard-deleted the org's only `Subscription` row and disabled all of its channels while the PRO subscription kept billing, leaving the customer paying for PRO and stuck behind the onboarding paywall.

Two fixes: never mint a second subscription for a customer that already has a live one (backend guard on the onboarding checkout, plus the created-webhook safety net for sessions minted before this ships and for races), and make deletion and cancel flows subscription-aware so cancelling one of two subscriptions no longer tears the org down.

# Other information:

- "Live" mirrors the filter the cancel paths already used: `status !== 'canceled'`.
- The created guard decides by `created` timestamp (id tiebreak), so two concurrent `created` webhooks cannot cancel each other.
- A cancelled duplicate is not refunded automatically; refunds stay a support action.
- For existing duplicate customers after deploy, support can cancel the extra subscription from the Stripe dashboard: the deleted-webhook guard keeps the org on the remaining plan and re-syncs the row to it. Before deploy that same action downgrades the org to FREE; the remedy then is to add a harmless metadata key on the surviving subscription so the `updated` webhook recreates the row (channels must be re-enabled from the app afterwards).
- Log lines to confirm behaviour in prod (`console.log`, matching this file's logging on main; the structured `sentry/logger` only exists on staging): `stripe_duplicate_subscription_cancelled` and `stripe_subscription_deleted_survivor_kept`.

# QA

Setup: Stripe test mode with webhooks forwarded to the backend (`stripe listen --forward-to localhost:3000/stripe`, its signing secret in `STRIPE_SIGNING_KEY`). An org whose user has a Stripe customer with one live subscription and at least one enabled channel. To get a second live subscription past the new created guard, create it via the Stripe CLI without `metadata[service]`, then update it to add `metadata[service]=gitroom` (plus `billing`, `period`, `uniqueId`).

1. [ ] With the org's customer holding a live subscription, `POST /billing/embedded` with `{billing:'PRO',period:'MONTHLY'}` returns `{"blocked":true}` and the customer's Checkout sessions count in Stripe does not change.
2. [ ] Open the onboarding pricing page for that org (tier FREE in DB but live subscription in Stripe): the blocked message shows, no embedded checkout form renders.
3. [ ] Create a second subscription on that customer via `stripe subscriptions create` with the full gitroom metadata: within seconds it is `canceled` in Stripe, the org's `Subscription` row is unchanged, and the backend logs `stripe_duplicate_subscription_cancelled`.
4. [ ] Get two live subscriptions on the customer (see setup) and cancel the newer one with `stripe subscriptions cancel <id> --confirm`: the row is not deleted, its tier/period now match the survivor's metadata, channels stay enabled, and the backend logs `stripe_subscription_deleted_survivor_kept`.
5. [ ] Cancel the remaining subscription the same way: the row is hard-deleted and channels are disabled (existing behaviour).
6. [ ] With two live subscriptions again, `POST /billing/cancel`: both subscriptions get `cancel_at_period_end: true` in Stripe and the response `cancel_at` is the earlier of the two dates.
7. [ ] `POST /billing/cancel` again: `cancel_at_period_end` is cleared on both.
8. [ ] As a super admin, `POST /billing/cancel-subscription`: both subscriptions are `canceled`, the row is deleted, channels disabled.
9. [ ] Regression: an org with a single live subscription upgrades via `POST /billing/subscribe` to PRO and back to STANDARD; Stripe still shows one subscription and the row follows the tier.
10. [ ] Regression: `POST /billing/embedded` for an org whose customer has no live subscription still returns a `client_secret`.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

