### PR TITLE
fix(media): reset the uploader with cancelAll instead of clear on error

### DIFF
--- a/apps/frontend/src/components/media/new.uploader.tsx
+++ b/apps/frontend/src/components/media/new.uploader.tsx
@@ -193,7 +193,7 @@ export function useUppyUploader(props: {
       });
     });
     uppy2.on('error', (result) => {
-      uppy2.clear();
+      uppy2.cancelAll();
       setLocked(false);
       props.onEnd();
       fileOrderIndex = 0;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, media uploader). In the Uppy `error` handler in `apps/frontend/src/components/media/new.uploader.tsx`, `uppy.clear()` is replaced with `uppy.cancelAll()`. Uppy's `clear` throws whenever an upload is in progress and the installed uploader plugin does not support per-file cancellation, which is the case with `@uppy/transloadit`; `cancelAll` removes every file, so each in-flight upload is dropped as a whole instead of shrunk and Uppy does not throw. The rest of the handler (unlock, `onEnd`, order counter reset) is unchanged.

# Why was this change needed?

Sentry CLOUD-S1, `Error: The installed uploader plugin does not allow removing files during an upload`, has 58 events from 32 users in the last 30 days: 39 on `/launches` (the post editor's uploader), 18 on `/media`, 1 on an X connect page.

The handler is meant to reset the uploader after an upload error, but the very condition it runs under (an upload in progress) is the one in which `clear` throws. So every Transloadit failure during an upload, for example a failed assembly creation, produced a second exception from our own code on top of the original error, and the uploader was left in its half-finished state.

# Other information:

Same file as #2063 (the missing-results guard), independent lines; either can merge first.

# QA

1. [ ] Run with Transloadit configured, open `/media`, and from the browser console make assembly creation fail, e.g. wrap `window.fetch` to reject any URL containing `transloadit.com`
2. [ ] Add an image through the Upload input
3. [ ] Before this change: besides Uppy's own "Could not create Assembly" log, the console shows `Error: The installed uploader plugin does not allow removing files during an upload` thrown from `new.uploader.tsx`
4. [ ] After this change: only Uppy's own assembly log appears, no exception from our code
5. [ ] Restore `window.fetch` and, without reloading, upload another image: it uploads and appears in the library, showing the uploader recovered

Tested locally exactly as above: step 3 reproduced on the unmodified code earlier in the same session, steps 4 and 5 verified with the change (no exception, the follow-up upload saved and listed).

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g3KqiuR5TT68XdqpTRbZh
