### PR TITLE
fix(telegram): stop logging the post text on publish

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts
@@ -180,7 +180,6 @@ export class TelegramProvider extends SocialAbstract implements SocialProvider {
       .replace(/<\/strong>/g, '</b>')
       .replace(/<p>(.*?)<\/p>/g, '$1\n');
 
-    console.log(text);
     const processedMedia = this.processMedia(mediaFiles);
 
     // if there's no media, bot sends a text message only


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Telegram provider, logging). Removes the `console.log(text)` in `TelegramProvider.post` (`libraries/nestjs-libraries/src/integrations/social/telegram.provider.ts`) that printed the full, HTML-stripped text of every Telegram post to the worker's stdout right before sending it. Nothing else in the publish path changed: the text is still built the same way and sent to Telegram exactly as before.

# Why was this change needed?

Two reasons, both visible in the Railway worker logs exported on 2026-09-09:

- Customer data in logs. The line logs the complete post content, so customers' Telegram messages (prices, phone numbers, addresses, hashtags, whatever they publish) land in our log retention and in any log export shared for debugging. That content is not needed for diagnosing publish failures; the provider's error paths already carry Telegram's own response.
- Noise. Every published Telegram post produces a multi-line entry (one log line per line of the message). In the last 7 days that was 556 published Telegram posts across 44 organizations, all logged in full.

# Other information:

No behavior change for users. The only remaining `console.log` calls in this provider are on error paths and on the bot's own status messages, not on customer content. Not exercised locally; the diff is a single deleted statement with no other reference to it.

# QA

1. [ ] Connect a Telegram channel locally and publish a short post with a couple of lines of text.
2. [ ] Expected: the post arrives in Telegram unchanged, and the orchestrator's stdout no longer contains the post text (before this change the text appeared verbatim right before the send).
3. [ ] Publish a post with an attached image: same result, media and caption arrive, nothing about the caption in the logs.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJZGgvB5qop47sQonXiEcj
