### PR TITLE
fix(facebook): retry the temporary posting-rate block (368 / 1390008) before failing

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts
@@ -64,7 +64,7 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
     status: number
   ):
     | {
-        type: 'refresh-token' | 'bad-body';
+        type: 'refresh-token' | 'bad-body' | 'retry';
         value: string;
       }
     | undefined {
@@ -90,9 +90,11 @@ export class FacebookProvider extends SocialAbstract implements SocialProvider {
       };
     }
 
+    // code 368 "Temporarily blocked for policies violations" (subcode
+    // 1390008): Meta documents it as temporary, "wait and retry the operation"
     if (body.indexOf('1390008') > -1) {
       return {
-        type: 'bad-body' as const,
+        type: 'retry' as const,
         value: 'You are posting too fast, please slow down',
       };
     }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (Facebook provider, error mapping). In `FacebookProvider.handleErrors` (`libraries/nestjs-libraries/src/integrations/social/facebook.provider.ts`) the branch matching error subcode `1390008` now returns `type: 'retry'` instead of `type: 'bad-body'`; the curated message "You are posting too fast, please slow down" is unchanged. The handler's return type union gained `'retry'`, which the shared `fetch` in `social.abstract.ts` already understands: it waits 5 seconds and retries, up to three attempts, and only then throws a `BadBody` carrying that same message. No other branch, no generic code and no workflow changed.

# Why was this change needed?

The body Meta sends for this case (from stored prod failures) is error code 368, type `OAuthException`, subcode 1390008, message "We limit how often you can post, comment or do other things in a given amount of time in order to help protect the community from spam. You can try again later." Meta's Graph API error-handling reference lists code 368 as "Temporarily blocked for policies violations" with the recommended action "Wait and retry the operation", the same guidance it gives for its throttling codes 4, 17 and 341: https://developers.facebook.com/docs/graph-api/guides/error-handling/

Today the mapping is terminal, so the first such response fails the post outright even though Meta describes the block as temporary. Prod numbers from the `Errors` table: 1230 posts across 10 organizations in the last 30 days, 325 posts across 6 organizations in the 7 days ending 2026-09-09.

The retry window is short (three attempts, 5 seconds apart, the shared behavior for every `retry` mapping), so posts that are still blocked after that fail with exactly the message they get today. Only posts whose block clears within those seconds now go through instead of failing.

# Other information:

Not exercised against a live Facebook block; the change is a one-word type switch on an existing branch plus the return-type widening, and the orchestrator typecheck passes. The `retry` type is already used by other providers' handlers (Pinterest, Instagram, X) through the same shared path.

# QA

1. [ ] Point a local Facebook page publish at a stub that answers status 400 with `{"error":{"message":"We limit how often you can post, comment or do other things in a given amount of time in order to help protect the community from spam. You can try again later.","type":"OAuthException","code":368,"error_subcode":1390008}}` on the first two calls and 200 with a post id on the third.
2. [ ] Publish a post: expected it is published on the third attempt, about 10 seconds after the first, and the calendar shows it as published.
3. [ ] Make the stub answer the 368 body on every call and publish again: expected the post fails after the retries with the message "You are posting too fast, please slow down", the same as before this change.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla) ([ICLA](https://github.com/gitroomhq/postiz-app/blob/main/ICLA.md) for individuals, [CCLA](https://github.com/gitroomhq/postiz-app/blob/main/CCLA.md) for entities).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJZGgvB5qop47sQonXiEcj
