### PR TITLE
fix(youtube): stop swallowing channel-list errors in pages()

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/youtube.provider.ts
@@ -341,30 +341,25 @@ export class YoutubeProvider extends SocialAbstract implements SocialProvider {
     client.setCredentials({ access_token: accessToken });
     const youtubeClient = youtube(client);
 
-    try {
-      // Get all channels the user has access to
-      const response = await youtubeClient.channels.list({
-        part: ['snippet', 'contentDetails', 'statistics'],
-        mine: true,
-      });
+    // Get all channels the user has access to
+    const response = await youtubeClient.channels.list({
+      part: ['snippet', 'contentDetails', 'statistics'],
+      mine: true,
+    });
 
-      const channels = response.data.items || [];
+    const channels = response.data.items || [];
 
-      return channels.map((channel) => ({
-        id: channel.id!,
-        name: channel.snippet?.title || 'Unnamed Channel',
-        picture: {
-          data: {
-            url: channel.snippet?.thumbnails?.default?.url || '',
-          },
+    return channels.map((channel) => ({
+      id: channel.id!,
+      name: channel.snippet?.title || 'Unnamed Channel',
+      picture: {
+        data: {
+          url: channel.snippet?.thumbnails?.default?.url || '',
         },
-        username: channel.snippet?.customUrl || '',
-        subscriberCount: channel.statistics?.subscriberCount || '0',
-      }));
-    } catch (error) {
-      console.error('Failed to fetch YouTube channels:', error);
-      return [];
-    }
+      },
+      username: channel.snippet?.customUrl || '',
+      subscriberCount: channel.statistics?.subscriberCount || '0',
+    }));
   }
 
   async fetchPageInformation(accessToken: string, data: { id: string }) {


### PR DESCRIPTION
# What kind of change does this PR introduce?

Observability fix (backend, YouTube provider). `YoutubeProvider.pages()` wrapped `channels.list` in a try/catch that logged to the console and returned an empty list. The try/catch is removed so the error propagates from the `pages` function endpoint and is captured by the Nest Sentry integration, matching `FacebookProvider.pages()`, which has no catch. The channel mapping and the `mine: true` query are unchanged. The frontend continue-integration dialog already catches a failed request in its `loadData` and renders the same "We couldn't find any YouTube channels" empty state, so the customer-facing behavior is identical.

# Why was this change needed?

A customer with several YouTube channels under one Google account connected one channel, then had two more attempts stay stuck at the channel-selection step. The second attempt reused the personal account and only re-offered the already-connected channel. The third attempt was a brand account and never got past selection. Its failure is unexplained: with the catch in place, a failed channel listing leaves nothing in Sentry or the DB, only a console line, so it cannot be distinguished from the user closing the dialog. Letting the throw propagate gives us the actual API error next time.

The alternative, keeping the catch and calling `Sentry.captureException` inside it, was not chosen: no provider calls Sentry directly today (the only direct use is a metrics counter in the posts service), so it would introduce a new pattern for the same result.

# Other information:

The "already connected channel offered again" case shows a heading with an empty grid in the shared continue dialog. That is a separate UX issue that overlaps with PR #1719 and is not addressed here.

# QA

1. [ ] Start adding a YouTube channel and complete the Google consent screen so the "Configure Channel" dialog opens.
2. [ ] With a valid token, the channel tile still appears and can be saved.
3. [ ] Temporarily break the listing (for example revoke the app at myaccount.google.com/permissions before the dialog loads, or point `channels.list` at an invalid part) and reopen the dialog.
4. [ ] The dialog shows "We couldn't find any YouTube channels connected to your account" as before.
5. [ ] The backend log and Sentry now carry the actual Google API error for the `pages` function call instead of only a console line.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gsRv3MWm5YFweP58FM31H
