### PR TITLE
fix(channels): offer already-connected pages in the continue-integration picker

### DIFF
--- a/apps/frontend/src/components/launches/continue.integration.tsx
+++ b/apps/frontend/src/components/launches/continue.integration.tsx
@@ -361,7 +361,6 @@ export const ContinueIntegration: FC<{
             >
               <Provider
                 onSave={onSave}
-                existingId={[]}
                 initialData={twoStepState.pages}
                 isSaving={isSaving}
               />

--- a/apps/frontend/src/components/layout/continue.provider.tsx
+++ b/apps/frontend/src/components/layout/continue.provider.tsx
@@ -3,35 +3,20 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { TopTitle } from '@gitroom/frontend/components/launches/helpers/top.title.component';
 import { IntegrationContext } from '@gitroom/frontend/components/launches/helpers/use.integration';
 import dayjs from 'dayjs';
-import useSWR, { useSWRConfig } from 'swr';
+import { useSWRConfig } from 'swr';
 import { useFetch } from '@gitroom/helpers/utils/custom.fetch';
 import { continueProviderList } from '@gitroom/frontend/components/new-launch/providers/continue-provider/list';
 import { newDayjs } from '@gitroom/frontend/components/layout/set.timezone';
 import { useModals } from '@gitroom/frontend/components/layout/new-modal';
 export const Null: FC<{
   onSave: (data: any) => Promise<void>;
-  existingId: string[];
 }> = () => null;
 export const ContinueProvider: FC = () => {
   const { mutate } = useSWRConfig();
-  const fetch = useFetch();
   const searchParams = useSearchParams();
   const added = searchParams.get('added');
   const continueId = searchParams.get('continue');
   const router = useRouter();
-  const load = useCallback(async (path: string) => {
-    const list = (await (await fetch(path)).json()).integrations;
-    return list;
-  }, []);
-  const { data: integrations } = useSWR('/integrations/list', load, {
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-    revalidateIfStale: false,
-    revalidateOnMount: true,
-    refreshWhenHidden: false,
-    refreshWhenOffline: false,
-    fallbackData: [],
-  });
   const refreshList = useCallback(() => {
     mutate('/integrations/list');
     const url = new URL(window.location.href);
@@ -48,7 +33,7 @@ export const ContinueProvider: FC = () => {
     );
   }, [added]);
 
-  if (!added || !continueId || !integrations) {
+  if (!added || !continueId) {
     return null;
   }
 
@@ -57,7 +42,6 @@ export const ContinueProvider: FC = () => {
       refreshList={refreshList}
       added={added}
       continueId={continueId}
-      integrations={integrations.map((p: any) => p.internalId)}
       provider={Provider}
     />
   );
@@ -68,8 +52,7 @@ const ModalContent: FC<{
   added: any;
   provider: any;
   closeModal: () => void;
-  integrations: string[];
-}> = ({ continueId, added, provider: Provider, closeModal, integrations }) => {
+}> = ({ continueId, added, provider: Provider, closeModal }) => {
   const fetch = useFetch();
 
   const onSave = useCallback(
@@ -109,7 +92,7 @@ const ModalContent: FC<{
         },
       }}
     >
-      <Provider onSave={onSave} existingId={integrations} />
+      <Provider onSave={onSave} />
     </IntegrationContext.Provider>
   );
 };
@@ -118,7 +101,6 @@ const ContinueModal: FC<{
   continueId: string;
   added: any;
   provider: any;
-  integrations: string[];
   refreshList: () => void;
 }> = (props) => {
   const modals = useModals();

--- a/apps/frontend/src/components/new-launch/providers/continue-provider/with-continue-provider.tsx
+++ b/apps/frontend/src/components/new-launch/providers/continue-provider/with-continue-provider.tsx
@@ -19,7 +19,6 @@ const SWR_OPTIONS = {
 
 export interface ContinueProviderProps {
   onSave: (data: any) => Promise<void>;
-  existingId: string[];
   initialData?: any[];
   isSaving?: boolean;
 }
@@ -59,7 +58,7 @@ export function withContinueProvider<TItem, TSelection>(
   } = config;
 
   return function ContinueProviderComponent(props: ContinueProviderProps) {
-    const { onSave, existingId, initialData, isSaving } = props;
+    const { onSave, initialData, isSaving } = props;
     const call = useCustomProviderFunction();
     const t = useT();
     const [selection, setSelection] = useState<TSelection | null>(null);
@@ -97,13 +96,10 @@ export function withContinueProvider<TItem, TSelection>(
       }
     }, [onSave, selection]);
 
-    const filteredData = useMemo(() => {
-      return (
-        (resolvedData as TItem[])?.filter(
-          (item) => !existingId.includes(getItemId(item))
-        ) || []
-      );
-    }, [resolvedData, existingId]);
+    const items = useMemo(
+      () => (resolvedData as TItem[]) || [],
+      [resolvedData]
+    );
 
     if (!isLoading && !resolvedData?.length) {
       return (
@@ -127,7 +123,7 @@ export function withContinueProvider<TItem, TSelection>(
       <div className="flex flex-col gap-[20px]">
         <div>{t(titleKey, titleDefault)}</div>
         <div className="grid grid-cols-3 justify-items-center select-none cursor-pointer gap-[10px]">
-          {filteredData.map((item) => (
+          {items.map((item) => (
             <div
               key={getItemId(item)}
               className={clsx(


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (frontend, channel connection picker). The shared `withContinueProvider` component no longer filters out pages whose id is already connected, and the `existingId` prop is removed. The legacy "Configure Channel" modal in `layout/continue.provider.tsx`, opened when a user clicks a channel tile that is stuck in the page-selection step, drops the `/integrations/list` fetch that existed only to feed that filter. The OAuth landing page (`continue.integration.tsx`) already passed an empty list, so its behavior is unchanged apart from the removed prop. Selection, saving, and the backend `/integrations/provider/:id/connect` path are untouched.

# Why was this change needed?

A customer with several YouTube channels under one Google account re-authorized with the same account and could not add anything. On the stuck-tile modal the only page returned was the already-connected one, so the filter left a heading with an empty grid and no explanation. Picking an already-connected page is not an error: `updateIntegration` in the integration repository detects the existing row, soft-deletes the in-between row, and refreshes the existing channel in place, which is exactly what the OAuth landing page has always allowed. Filtering those pages out only removed a working reconnect path and produced the empty grid. Both flows now behave the same.

# Other information:

Overlaps with #1719 in `with-continue-provider.tsx`: that PR inserts a `hasDisabled` memo right after the block replaced here and references the old `filteredData` name. Whichever merges second gets a one-hunk conflict; resolution is to keep the `hasDisabled` memo and point it at `items`. Both PRs are independent otherwise.

# QA

1. [ ] Connect a Facebook Page channel (or any two-step provider: Instagram, LinkedIn Page, GMB, YouTube, Tumblr).
2. [ ] Click Add Channel, pick the same provider, approve the dialog with the same account, and on the "Configure Your Channel" page navigate away without selecting. The calendar now shows a channel tile marked as needing setup.
3. [ ] Click that tile. The "Configure Channel" modal opens and lists every page the account offers, including the one already connected. Before this change the connected page was missing, and if it was the only page the grid was empty.
4. [ ] Select the already-connected page and save. The modal closes, the calendar still shows exactly one channel for that page, and the stuck tile is gone.
5. [ ] In the DB, the in-between Integration row is soft-deleted with a `deleted_` internal id and the original row has a fresh `updatedAt`.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gsRv3MWm5YFweP58FM31H
