### PR TITLE
fix(integrations): keep inBetweenSteps across a token refresh

### DIFF
--- a/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
+++ b/libraries/nestjs-libraries/src/integrations/refresh.integration.service.ts
@@ -39,7 +39,9 @@ export class RefreshIntegrationService {
       integration.providerIdentifier,
       refresh.accessToken,
       refresh.refreshToken,
-      refresh.expiresIn
+      refresh.expiresIn,
+      undefined,
+      integration.inBetweenSteps
     );
 
     return refresh;


### PR DESCRIPTION
# What kind of change does this PR introduce?

Bug fix (backend, token refresh). `RefreshIntegrationService.refresh()` in `refresh.integration.service.ts` now passes the integration's current `inBetweenSteps` value to `createOrUpdateIntegration`. Before, the argument was omitted, so the upsert's update branch wrote its default of `false`, and a channel that had never completed page selection was marked as connected after any token refresh, while its `internalId` still held the account id from the OAuth step instead of the selected page/channel id. Nothing else about the refresh, the token fields, or the completed-channel case changed.

# Why was this change needed?

A customer connecting a second YouTube channel (a brand account) never got past the selection step, so the row stayed with `inBetweenSteps = true` and the Google account id as `internalId`. Two days later they opened Analytics for that channel; the token had expired, `checkAnalytics` refreshed it, and the row flipped to `inBetweenSteps = false` with the account id still in place and a token expiration exactly one hour later. From then on the channel looked connected but pointed at an account id, not a channel id. The same path runs from post creation, the function endpoint, the public API and the refresh workflow, so any stuck channel could be flipped the same way.

For YouTube the damage is limited because uploads and analytics use the token's own channel. For providers whose posting targets the stored id (Google My Business, LinkedIn Page, Facebook, Instagram) a flipped channel fails every post. Rows already flipped are not touched here. #2073, independent of this PR, resurfaces them for re-selection and also refreshes an expired token before the picker's page listing; neither PR depends on the other.

# Other information:

Testing: reproduced with a real Google token refresh through the compiled backend. A local YouTube row cloned from a live channel was set to `inBetweenSteps = true`, `internalId` = the Google account id, expired `tokenExpiration`, then `refresh()` was called on it. Before the fix: refresh succeeded, `inBetweenSteps` became `false`, `internalId` unchanged, expiration one hour ahead, matching the customer's row. After the fix: refresh succeeded, `inBetweenSteps` stayed `true`, `internalId` unchanged.

# QA

1. [ ] Start adding a YouTube (or Facebook Page) channel, approve the provider dialog, and leave the "Configure Your Channel" page without selecting. The calendar shows the new channel tile with the red badge.
2. [ ] In the DB, set that Integration row's `tokenExpiration` to a past time.
3. [ ] Open Analytics and select that channel, which triggers a token refresh.
4. [ ] The row still has `inBetweenSteps = true` and the same `internalId`, and the calendar tile keeps its red badge. Before this change the badge disappeared and the row showed `inBetweenSteps = false`.
5. [ ] Click the badged tile, pick the channel in the picker and save. The channel connects normally with a real channel id.

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitroomhq/postiz-app/blob/main/CONTRIBUTING.md) guide.
- [x] I have signed the [Contributor License Agreement (CLA)](https://contribute.postiz.com/p/postiz/cla).
- [ ] I confirm I have not used AI to submit this PR or generate code for it.
- [x] I checked that there were no similar issues or PRs already open for this.
- [x] This PR fixes just ONE issue
- [x] I have filled in the QA section above with real steps to verify this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gsRv3MWm5YFweP58FM31H

