### PR TITLE
fix: render all mentions in post previews

### DIFF
--- a/apps/frontend/src/components/launches/general.preview.component.tsx
+++ b/apps/frontend/src/components/launches/general.preview.component.tsx
@@ -36,11 +36,11 @@ export const GeneralPreviewComponent: FC<{
     const finalValue =
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;

--- a/apps/frontend/src/components/new-launch/providers/facebook/facebook.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/facebook/facebook.preview.tsx
@@ -109,11 +109,11 @@ export const FacebookPreview: FC<{
     const finalValue =
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;

--- a/apps/frontend/src/components/new-launch/providers/instagram/instagram.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/instagram/instagram.preview.tsx
@@ -36,11 +36,11 @@ export const InstagramPreview: FC<{
       `<strong class="text-[15px] font-[600]">${integration?.name} </strong>` +
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;

--- a/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/linkedin/linkedin.preview.tsx
@@ -272,11 +272,11 @@ export const LinkedinPreview: FC<{
     const finalValue =
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;

--- a/apps/frontend/src/components/new-launch/providers/pinterest/pinterest.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/pinterest/pinterest.preview.tsx
@@ -32,11 +32,11 @@ export const PinterestPreview: FC<{
     const finalValue =
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;

--- a/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/tiktok/tiktok.preview.tsx
@@ -45,11 +45,11 @@ export const TiktokPreview: FC<{
     const finalValue =
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;

--- a/apps/frontend/src/components/new-launch/providers/youtube/youtube.preview.tsx
+++ b/apps/frontend/src/components/new-launch/providers/youtube/youtube.preview.tsx
@@ -34,11 +34,11 @@ export const YoutubePreview: FC<{
     const finalValue =
       newContent
         .slice(start, end)
-        .replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+        .replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
           return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
         }) +
       `<mark class="bg-red-500" data-tooltip-id="tooltip" data-tooltip-content="This text will be cropped">` +
-      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/, (match, match1) => {
+      newContent.slice(end).replace(/\[\[\[([.\s\S]*?)]]]/g, (match, match1) => {
         return `<span class="font-bold font-[arial]" style="color: #ae8afc">${match1}</span>`;
       }) +
       `</mark>`;


### PR DESCRIPTION
When a post contains multiple mentions, the preview styles the first mention but displays subsequent ones as literal `[[[@Name]]]` markers.

Add the global flag to the marker replacement regex in all seven preview components, for both the visible and cropped text portions. This fixes the shared preview used for X and the equivalent Facebook, Instagram, LinkedIn, Pinterest, TikTok, and YouTube previews.

Validation: reproduced the original two-mention failure; ran 56 Node assertions using the replacement expressions extracted from the changed source, covering zero, one, two, and three mentions, multiline text, and an apostrophe in a display name across both replacement paths. `git diff --check` passed. Full frontend build and browser tests were not run.
